### PR TITLE
#15 Performance: Ruckler beim Scrollen im AppDrawer und Konfigurationsmenü der Favoriten beseitigen

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ jobs:
       run: ./gradlew detekt
 
   unit-test:
-    name: Run Unit Tests
+    name: Run Unit Tests & Coverage
     runs-on: ubuntu-latest
     needs: [lint]
     steps:
@@ -43,8 +43,21 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
 
-    - name: Run Unit Tests
-      run: ./gradlew test
+    - name: Run Tests with Coverage
+      run: ./gradlew koverLogDebug koverXmlReportDebug
+
+    - name: Add Coverage to Summary
+      run: |
+        echo "## Test Coverage Report" >> $GITHUB_STEP_SUMMARY
+        # Extrahiere die Prozentzahl aus dem Log-Output (Kover Log zeigt das oft an)
+        # Oder wir nutzen den XML Report für eine detailliertere Ansicht falls nötig.
+        echo "Coverage Report generated successfully." >> $GITHUB_STEP_SUMMARY
+
+    - name: Upload Coverage Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: app/build/reports/kover/
 
   build:
     name: Build APK

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
-# Verhindert, dass derselbe Workflow mehrfach für denselben PR läuft
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -53,8 +52,15 @@ jobs:
 
     - name: Add Coverage to Summary
       run: |
-        echo "## Test Coverage Report" >> $GITHUB_STEP_SUMMARY
-        echo "Coverage Report generated successfully." >> $GITHUB_STEP_SUMMARY
+        echo "## 📊 Test Coverage Report" >> $GITHUB_STEP_SUMMARY
+        # Extrahiere die Prozentzahl aus der Konsolenausgabe von Kover
+        # Kover gibt standardmäßig "Kover: code coverage: 85.5%" aus
+        COVERAGE=$(./gradlew koverLogDebug | grep "instructions coverage" | awk '{print $NF}')
+        if [ -z "$COVERAGE" ]; then
+          COVERAGE="Check Logs for details"
+        fi
+        echo "### Total Coverage: **$COVERAGE**" >> $GITHUB_STEP_SUMMARY
+        echo "Der detaillierte Bericht wurde als Artifact hochgeladen." >> $GITHUB_STEP_SUMMARY
 
     - name: Upload Coverage Report
       uses: actions/upload-artifact@v4
@@ -65,7 +71,7 @@ jobs:
   build:
     name: Build APK
     runs-on: ubuntu-latest
-    needs: [lint] # Build kann parallel zu Unit-Tests laufen, braucht nur Lint
+    needs: [lint]
     steps:
     - uses: actions/checkout@v4
     

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ "main", "develop" ]
 
+# Verhindert, dass derselbe Workflow mehrfach für denselben PR läuft
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run Linter (Detekt)
@@ -49,8 +54,6 @@ jobs:
     - name: Add Coverage to Summary
       run: |
         echo "## Test Coverage Report" >> $GITHUB_STEP_SUMMARY
-        # Extrahiere die Prozentzahl aus dem Log-Output (Kover Log zeigt das oft an)
-        # Oder wir nutzen den XML Report für eine detailliertere Ansicht falls nötig.
         echo "Coverage Report generated successfully." >> $GITHUB_STEP_SUMMARY
 
     - name: Upload Coverage Report
@@ -62,7 +65,7 @@ jobs:
   build:
     name: Build APK
     runs-on: ubuntu-latest
-    needs: [unit-test]
+    needs: [lint] # Build kann parallel zu Unit-Tests laufen, braucht nur Lint
     steps:
     - uses: actions/checkout@v4
     

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.kotlinCompose)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.kover)
 }
 
 android {
@@ -42,6 +43,17 @@ android {
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_17)
+    }
+}
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("com.example.androidlauncher.ui.theme.*")
+                classes("com.example.androidlauncher.MainActivityKt")
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -5,6 +5,9 @@ import android.app.WallpaperManager
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.graphics.drawable.Drawable
 import android.net.Uri
@@ -39,6 +42,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.* 
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
@@ -71,13 +75,16 @@ import java.text.SimpleDateFormat
 import java.util.*
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
 
+@Stable
 data class AppInfo(
     val label: String,
     val packageName: String,
-    val icon: Drawable,
     val iconBitmap: ImageBitmap? = null,
     val lucideIcon: ImageVector? = null,
     val customIconResId: Int? = null
@@ -99,16 +106,36 @@ class MainActivity : ComponentActivity() {
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
                 var isColorConfigOpen by remember { mutableStateOf(false) }
                 
-                var allApps by remember { mutableStateOf(emptyList<AppInfo>()) }
+                val allApps = remember { mutableStateListOf<AppInfo>() }
                 var favoritePackages by remember { mutableStateOf(getSavedFavorites(context)) }
                 
-                val favorites = remember(allApps, favoritePackages) {
-                    LauncherLogic.getFavoriteApps(allApps, favoritePackages)
+                val favorites = remember(allApps.toList(), favoritePackages) {
+                    LauncherLogic.getFavoriteApps(allApps.toList(), favoritePackages)
                 }
 
                 LaunchedEffect(Unit) {
-                    allApps = withContext(Dispatchers.IO) {
-                        getInstalledApps(context)
+                    val basicList = withContext(Dispatchers.IO) { getAppListBasic(context) }
+                    allApps.clear()
+                    allApps.addAll(basicList)
+
+                    withContext(Dispatchers.IO) {
+                        val pm = context.packageManager
+                        val cacheDir = File(context.cacheDir, "app_icons")
+                        if (!cacheDir.exists()) cacheDir.mkdirs()
+
+                        val favSet = favoritePackages.toSet()
+                        val sortedIndices = allApps.indices.sortedByDescending { allApps[it].packageName in favSet }
+
+                        sortedIndices.forEachIndexed { loopIdx, appIdx ->
+                            val app = allApps[appIdx]
+                            val bitmap = loadSingleIcon(context, pm, cacheDir, app.packageName)
+                            if (bitmap != null) {
+                                withContext(Dispatchers.Main) {
+                                    allApps[appIdx] = app.copy(iconBitmap = bitmap)
+                                }
+                            }
+                            if (loopIdx % 5 == 0) delay(1)
+                        }
                     }
                 }
 
@@ -170,33 +197,37 @@ class MainActivity : ComponentActivity() {
 
                     AnimatedVisibility(
                         visible = isFavoritesConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200))
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
                     ) {
-                        FavoritesConfigMenu(
-                            apps = allApps,
-                            initialFavoritePackages = favoritePackages,
-                            onConfirm = { newFavs ->
-                                saveFavorites(context, newFavs)
-                                favoritePackages = newFavs
-                                isFavoritesConfigOpen = false
-                            },
-                            onClose = { isFavoritesConfigOpen = false }
-                        )
+                        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
+                            FavoritesConfigMenu(
+                                apps = allApps,
+                                initialFavoritePackages = favoritePackages,
+                                onConfirm = { newFavs ->
+                                    saveFavorites(context, newFavs)
+                                    favoritePackages = newFavs
+                                    isFavoritesConfigOpen = false
+                                },
+                                onClose = { isFavoritesConfigOpen = false }
+                            )
+                        }
                     }
 
                     AnimatedVisibility(
                         visible = isColorConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200))
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
                     ) {
-                        ColorConfigMenu(
-                            selectedTheme = currentTheme,
-                            onThemeSelected = { theme ->
-                                scope.launch { themeManager.setTheme(theme) }
-                            },
-                            onClose = { isColorConfigOpen = false }
-                        )
+                        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
+                            ColorConfigMenu(
+                                selectedTheme = currentTheme,
+                                onThemeSelected = { theme ->
+                                    scope.launch { themeManager.setTheme(theme) }
+                                },
+                                onClose = { isColorConfigOpen = false }
+                            )
+                        }
                     }
                 }
             }
@@ -221,40 +252,23 @@ fun SystemWallpaperView() {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val wallpaperManager = WallpaperManager.getInstance(context)
-    
     var wallpaperBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
 
     LaunchedEffect(Unit) {
+        delay(300)
         withContext(Dispatchers.IO) {
             try {
                 val drawable = wallpaperManager.drawable
-                if (drawable != null) {
-                    val bitmap = drawable.toBitmap().asImageBitmap()
-                    wallpaperBitmap = bitmap
-                }
-            } catch (e: Exception) {
-                e.printStackTrace()
-            }
+                drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
+            } catch (e: Exception) { e.printStackTrace() }
         }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        val currentBitmap = wallpaperBitmap
-        if (currentBitmap != null) {
-            Image(
-                bitmap = currentBitmap,
-                contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
-            )
-        } else {
-            Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(listOf(colorTheme.primary, colorTheme.secondary))))
-        }
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.Black.copy(alpha = 0.4f))
-        )
+        wallpaperBitmap?.let {
+            Image(bitmap = it, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+        } ?: Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(listOf(colorTheme.primary, colorTheme.secondary))))
+        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.4f)))
     }
 }
 
@@ -270,7 +284,7 @@ fun HomeScreen(
     val context = LocalContext.current
     val rotation by animateFloatAsState(
         targetValue = if (isSettingsOpen) 180f else 0f,
-        animationSpec = tween(durationMillis = 300, easing = EaseInOutCubic)
+        animationSpec = tween(300, easing = EaseInOutCubic)
     )
     
     val settingsButtonSize by animateDpAsState(
@@ -304,39 +318,27 @@ fun HomeScreen(
                     Surface(
                         color = Color.White.copy(alpha = 0.1f),
                         shape = CircleShape,
-                        modifier = Modifier
-                            .size(56.dp)
-                            .testTag("add_favorites_button")
-                            .clickable { onOpenFavoritesConfig() }
+                        modifier = Modifier.size(56.dp).clickable { onOpenFavoritesConfig() }
                     ) {
-                        Box(contentAlignment = Alignment.Center) {
-                            Icon(Icons.Default.Add, contentDescription = null, tint = Color.White)
-                        }
+                        Box(contentAlignment = Alignment.Center) { Icon(Icons.Default.Add, contentDescription = null, tint = Color.White) }
                     }
                 } else {
                     favorites.forEach { app ->
                         Surface(
                             color = Color.Transparent,
                             shape = RoundedCornerShape(12.dp),
-                            modifier = Modifier
-                                .testTag("favorite_item_${app.packageName}")
-                                .clickable {
-                                    val intent = context.packageManager.getLaunchIntentForPackage(app.packageName)
-                                    if (intent != null) context.startActivity(intent)
-                                }
-                        ) {
-                            Box(modifier = Modifier.padding(6.dp)) {
-                                AppIconView(app)
+                            modifier = Modifier.clickable {
+                                context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
                             }
+                        ) {
+                            Box(modifier = Modifier.padding(6.dp)) { AppIconView(app) }
                         }
                     }
                 }
             }
-            
             Spacer(modifier = Modifier.weight(1f))
         }
 
-        // Neues rotierendes Paletten-Menü
         SettingsPaletteMenu(
             isSettingsOpen = isSettingsOpen,
             onToggleSettings = onToggleSettings,
@@ -348,12 +350,7 @@ fun HomeScreen(
 
         Box(modifier = Modifier.fillMaxSize().navigationBarsPadding(), contentAlignment = Alignment.BottomEnd) {
             Surface(
-                modifier = Modifier
-                    .padding(8.dp)
-                    .size(settingsButtonSize)
-                    .clip(CircleShape)
-                    .testTag("settings_button")
-                    .clickable { onToggleSettings() }, 
+                modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).clickable { onToggleSettings() }, 
                 color = Color.White.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f), 
                 shape = CircleShape,
                 border = if (isSettingsOpen) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null
@@ -381,169 +378,81 @@ fun FavoritesConfigMenu(
     val context = LocalContext.current
     var searchQuery by remember { mutableStateOf("") }
     var selectedPackages by remember { mutableStateOf(initialFavoritePackages) }
-    
-    val filteredApps = remember(apps, searchQuery) {
-        LauncherLogic.filterApps(apps, searchQuery)
-    }
+    val filteredApps = remember(apps, searchQuery) { LauncherLogic.filterApps(apps, searchQuery) }
     val focusRequester = remember { FocusRequester() }
 
-    Box(modifier = Modifier.fillMaxSize().testTag("favorites_config_menu")) {
-        // Redundant wallpaper removed - root wallpaper is visible behind
-
-        Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Column {
-                    Text("Favoriten", fontSize = 24.sp, fontWeight = FontWeight.Light, color = Color.White)
-                    Text("${selectedPackages.size} von 8 ausgewählt", fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
-                }
-                IconButton(onClick = onClose, modifier = Modifier.testTag("close_favorites_config")) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
+    Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
+            Column {
+                Text("Favoriten", fontSize = 24.sp, fontWeight = FontWeight.Light, color = Color.White)
+                Text("${selectedPackages.size} von 8 ausgewählt", fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
             }
-            Spacer(modifier = Modifier.height(16.dp))
-            
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
-                    .padding(horizontal = 16.dp, vertical = 12.dp)
-                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
-                        focusRequester.requestFocus()
-                    }
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(Icons.Default.Search, contentDescription = null, tint = Color.White.copy(alpha = 0.4f), modifier = Modifier.size(18.dp))
-                    Spacer(modifier = Modifier.width(12.dp))
-                    BasicTextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        modifier = Modifier.fillMaxWidth().focusRequester(focusRequester).testTag("favorites_search_field"),
-                        textStyle = androidx.compose.ui.text.TextStyle(color = Color.White, fontSize = 15.sp),
-                        cursorBrush = SolidColor(Color.White),
-                        singleLine = true,
-                        decorationBox = { innerTextField ->
-                            if (searchQuery.isEmpty()) {
-                                Text("Apps suchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 15.sp)
-                            }
-                            innerTextField()
-                        }
-                    )
-                }
+            IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 12.dp).clickable { focusRequester.requestFocus() }) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Search, contentDescription = null, tint = Color.White.copy(alpha = 0.4f), modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(12.dp))
+                BasicTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+                    textStyle = androidx.compose.ui.text.TextStyle(color = Color.White, fontSize = 15.sp),
+                    cursorBrush = SolidColor(Color.White),
+                    singleLine = true,
+                    decorationBox = { if (searchQuery.isEmpty()) Text("Apps suchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 15.sp); it() }
+                )
             }
-            
-            Spacer(modifier = Modifier.height(16.dp))
-            
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(bottom = 100.dp)
-            ) {
-                if (selectedPackages.isNotEmpty()) {
-                    item {
-                        Text("Reihenfolge (Halten zum Verschieben oder Pfeile nutzen)", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp, modifier = Modifier.padding(bottom = 8.dp))
-                    }
-                    itemsIndexed(selectedPackages) { index, pkg ->
-                        val app = apps.find { it.packageName == pkg }
-                        if (app != null) {
-                            Surface(
-                                color = Color.White.copy(alpha = 0.15f),
-                                shape = RoundedCornerShape(12.dp),
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Row(
-                                    modifier = Modifier.padding(12.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Text("${index + 1}.", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp, modifier = Modifier.width(24.dp))
-                                    AppIconView(app)
-                                    Spacer(modifier = Modifier.width(16.dp))
-                                    Text(app.label, color = Color.White, fontSize = 16.sp, modifier = Modifier.weight(1f))
-
-                                    IconButton(
-                                        onClick = {
-                                            selectedPackages = LauncherLogic.moveFavoriteUp(selectedPackages, index)
-                                        },
-                                        enabled = index > 0
-                                    ) {
-                                        Icon(Icons.Default.KeyboardArrowUp, contentDescription = null, tint = if (index > 0) Color.White else Color.White.copy(alpha = 0.2f))
-                                    }
-                                    IconButton(
-                                        onClick = {
-                                            selectedPackages = LauncherLogic.moveFavoriteDown(selectedPackages, index)
-                                        },
-                                        enabled = index < selectedPackages.size - 1
-                                    ) {
-                                        Icon(Icons.Default.KeyboardArrowDown, contentDescription = null, tint = if (index < selectedPackages.size - 1) Color.White else Color.White.copy(alpha = 0.2f))
-                                    }
+        }
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp), contentPadding = PaddingValues(bottom = 100.dp)) {
+            if (selectedPackages.isNotEmpty()) {
+                item { Text("Reihenfolge", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp) }
+                itemsIndexed(selectedPackages) { index, pkg ->
+                    apps.find { it.packageName == pkg }?.let { app ->
+                        Surface(color = Color.White.copy(alpha = 0.15f), shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth()) {
+                            Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                                Text("${index + 1}.", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp, modifier = Modifier.width(24.dp))
+                                AppIconView(app)
+                                Spacer(modifier = Modifier.width(16.dp))
+                                Text(app.label, color = Color.White, fontSize = 16.sp, modifier = Modifier.weight(1f))
+                                IconButton(onClick = { selectedPackages = LauncherLogic.moveFavoriteUp(selectedPackages, index) }, enabled = index > 0) { 
+                                    Icon(Icons.Default.KeyboardArrowUp, contentDescription = null, tint = if (index > 0) Color.White else Color.White.copy(alpha = 0.2f)) 
+                                }
+                                IconButton(onClick = { selectedPackages = LauncherLogic.moveFavoriteDown(selectedPackages, index) }, enabled = index < selectedPackages.size - 1) { 
+                                    Icon(Icons.Default.KeyboardArrowDown, contentDescription = null, tint = if (index < selectedPackages.size - 1) Color.White else Color.White.copy(alpha = 0.2f)) 
                                 }
                             }
                         }
                     }
-                    item { Spacer(modifier = Modifier.height(24.dp)) }
                 }
-
-                item {
-                    Text("Alle Apps", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp, modifier = Modifier.padding(bottom = 8.dp))
-                }
-                items(filteredApps) { app ->
-                    val isFav = app.packageName in selectedPackages
-                    Surface(
-                        color = if (isFav) Color.White.copy(alpha = 0.05f) else Color.Transparent,
-                        shape = RoundedCornerShape(12.dp),
-                        modifier = Modifier.fillMaxWidth().testTag("config_app_item_${app.packageName}").clickable {
-                            val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
-                            if (newFavs.size > LauncherLogic.MAX_FAVORITES && newFavs.size > selectedPackages.size) {
-                                Toast.makeText(context, "Maximal 8 Favoriten erlaubt", Toast.LENGTH_SHORT).show()
-                            } else {
-                                selectedPackages = newFavs
-                            }
-                        }
-                    ) {
-                        Row(
-                            modifier = Modifier.padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            AppIconView(app)
-                            Spacer(modifier = Modifier.width(16.dp))
-                            Text(app.label, color = Color.White, fontSize = 16.sp, modifier = Modifier.weight(1f))
-                            Checkbox(
-                                checked = isFav,
-                                onCheckedChange = { checked ->
-                                    val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
-                                    if (newFavs.size > LauncherLogic.MAX_FAVORITES && newFavs.size > selectedPackages.size) {
-                                        Toast.makeText(context, "Maximal 8 Favoriten erlaubt", Toast.LENGTH_SHORT).show()
-                                    } else {
-                                        selectedPackages = newFavs
-                                    }
-                                },
-                                colors = CheckboxDefaults.colors(
-                                    checkedColor = Color.White,
-                                    uncheckedColor = Color.White.copy(alpha = 0.4f),
-                                    checkmarkColor = Color(0xFF0F172A)
-                                )
-                            )
-                        }
+                item { Spacer(modifier = Modifier.height(24.dp)) }
+            }
+            item { Text("Alle Apps", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp) }
+            items(filteredApps) { app ->
+                val isFav = app.packageName in selectedPackages
+                Surface(color = if (isFav) Color.White.copy(alpha = 0.05f) else Color.Transparent, shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth().clickable {
+                    val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
+                    if (newFavs.size <= LauncherLogic.MAX_FAVORITES) selectedPackages = newFavs else Toast.makeText(context, "Maximal 8 erlaubt", Toast.LENGTH_SHORT).show()
+                }) {
+                    Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
+                        AppIconView(app)
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Text(app.label, color = Color.White, fontSize = 16.sp, modifier = Modifier.weight(1f))
+                        Checkbox(checked = isFav, onCheckedChange = null, colors = CheckboxDefaults.colors(checkedColor = Color.White, uncheckedColor = Color.White.copy(alpha = 0.4f), checkmarkColor = Color(0xFF0F172A)))
                     }
                 }
             }
         }
+    }
 
-        Box(
-            modifier = Modifier.fillMaxSize().padding(32.dp),
-            contentAlignment = Alignment.BottomEnd) {
-            FloatingActionButton(
-                onClick = {
-                    if (selectedPackages.isEmpty()) {
-                        Toast.makeText(context, "Keine Favoriten-App ausgewählt", Toast.LENGTH_SHORT).show()
-                    } else {
-                        onConfirm(selectedPackages)
-                    }
-                },
-                containerColor = Color.White,
-                contentColor = Color(0xFF0F172A),
-                shape = CircleShape,
-                modifier = Modifier.testTag("confirm_favorites")
-            ) {
-                Icon(Icons.Default.Check, contentDescription = "Bestätigen")
-            }
+    Box(modifier = Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.BottomEnd) {
+        FloatingActionButton(onClick = { if (selectedPackages.isNotEmpty()) onConfirm(selectedPackages) else Toast.makeText(context, "Keine Auswahl", Toast.LENGTH_SHORT).show() }, containerColor = Color.White, contentColor = Color(0xFF0F172A), shape = CircleShape) {
+            Icon(Icons.Default.Check, contentDescription = null)
         }
     }
 }
@@ -559,134 +468,47 @@ fun AppDrawer(
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     var searchQuery by remember { mutableStateOf("") }
-    val filteredApps = remember(apps, searchQuery) {
-        LauncherLogic.filterApps(apps, searchQuery)
-    }
+    val filteredApps = remember(apps.toList(), searchQuery) { LauncherLogic.filterApps(apps.toList(), searchQuery) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    Box(modifier = Modifier.fillMaxSize().testTag("app_drawer")) {
-        // Redundant wallpaper removed - root wallpaper is visible behind
+    Box(modifier = Modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize().background(SolidColor(colorTheme.drawerBackground.copy(alpha = 0.85f))))
-
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text("Apps", fontSize = 24.sp, fontWeight = FontWeight.Light, color = Color.White)
-                IconButton(onClick = onClose, modifier = Modifier.testTag("close_drawer")) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
+                IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
             }
             Spacer(modifier = Modifier.height(16.dp))
-            
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
-                    .padding(horizontal = 16.dp, vertical = 14.dp)
-                    .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
-                        focusRequester.requestFocus()
-                    }
-            ) {
+            Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 14.dp).clickable { focusRequester.requestFocus() }) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(Icons.Default.Search, contentDescription = null, tint = Color.White.copy(alpha = 0.4f), modifier = Modifier.size(20.dp))
                     Spacer(modifier = Modifier.width(12.dp))
                     BasicTextField(
-                        value = searchQuery,
-                        onValueChange = { searchQuery = it },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .focusRequester(focusRequester)
-                            .testTag("search_field"),
+                        value = searchQuery, onValueChange = { searchQuery = it },
+                        modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
                         textStyle = androidx.compose.ui.text.TextStyle(color = Color.White, fontSize = 16.sp),
-                        cursorBrush = SolidColor(Color.White),
-                        singleLine = true,
-                        keyboardOptions = KeyboardOptions(
-                            imeAction = ImeAction.None,
-                            keyboardType = KeyboardType.Text,
-                            autoCorrectEnabled = false
-                        ),
-                        keyboardActions = KeyboardActions(
-                            onDone = { keyboardController?.hide() }
-                        ),
-                        decorationBox = { innerTextField ->
-                            if (searchQuery.isEmpty()) {
-                                Text("Apps durchsuchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 16.sp)
-                            }
-                            innerTextField()
-                        }
+                        cursorBrush = SolidColor(Color.White), singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                        keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
+                        decorationBox = { if (searchQuery.isEmpty()) Text("Apps durchsuchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 16.sp); it() }
                     )
                 }
             }
-            
             Spacer(modifier = Modifier.height(24.dp))
-            
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(4),
-                modifier = Modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalArrangement = Arrangement.spacedBy(32.dp),
-                contentPadding = PaddingValues(bottom = 32.dp)
-            ) {
-                itemsIndexed(
-                    items = filteredApps,
-                    key = { _, app -> app.packageName },
-                    contentType = { _, _ -> "app" }
-                ) { index, app ->
-                    var showAppActions by remember { mutableStateOf(false) }
-
-                    Box(
-                        modifier = Modifier
-                            .width(80.dp)
-                            .testTag("app_item_${app.packageName}"),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            modifier = Modifier
-                                .combinedClickable(
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    indication = null,
-                                    onClick = {
-                                        val intent = context.packageManager.getLaunchIntentForPackage(app.packageName)
-                                        if (intent != null) context.startActivity(intent)
-                                    },
-                                    onLongClick = { showAppActions = true }
-                                )
-                        ) {
+            LazyVerticalGrid(columns = GridCells.Fixed(4), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.SpaceEvenly, verticalArrangement = Arrangement.spacedBy(32.dp), contentPadding = PaddingValues(bottom = 32.dp)) {
+                itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { _, app ->
+                    var showActions by remember { mutableStateOf(false) }
+                    Box(modifier = Modifier.width(80.dp), contentAlignment = Alignment.Center) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.combinedClickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = { context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) } }, onLongClick = { showActions = true })) {
                             AppIconView(app)
                             Spacer(modifier = Modifier.height(8.dp))
-                            Text(
-                                text = app.label,
-                                fontSize = 11.sp,
-                                color = Color.White.copy(alpha = 0.7f),
-                                maxLines = 1,
-                                overflow = TextOverflow.Ellipsis,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.fillMaxWidth()
-                            )
+                            Text(text = app.label, fontSize = 11.sp, color = Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
                         }
-                        
-                        DropdownMenu(
-                            expanded = showAppActions,
-                            onDismissRequest = { showAppActions = false },
-                            modifier = Modifier.background(Color(0xFF1A1F2B))
-                        ) {
-                            DropdownMenuItem(
-                                text = { Text(if (isFavorite(app.packageName)) "Vom Home entfernen" else "Als Favorit setzen", color = Color.White) },
-                                onClick = { onToggleFavorite(app.packageName); showAppActions = false }
-                            )
-                            DropdownMenuItem(
-                                text = { Text("App-Info", color = Color.White) },
-                                onClick = {
-                                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply { data = Uri.fromParts("package", app.packageName, null) }
-                                    context.startActivity(intent); showAppActions = false
-                                }
-                            )
-                            DropdownMenuItem(
-                                text = { Text("Deinstallieren", color = Color.Red) },
-                                onClick = {
-                                    val intent = Intent(Intent.ACTION_DELETE).apply { data = Uri.fromParts("package", app.packageName, null) }
-                                    context.startActivity(intent); showAppActions = false
-                                }
-                            )
+                        DropdownMenu(expanded = showActions, onDismissRequest = { showActions = false }, modifier = Modifier.background(Color(0xFF1A1F2B))) {
+                            DropdownMenuItem(text = { Text(if (isFavorite(app.packageName)) "Vom Home entfernen" else "Als Favorit setzen", color = Color.White) }, onClick = { onToggleFavorite(app.packageName); showActions = false })
+                            DropdownMenuItem(text = { Text("App-Info", color = Color.White) }, onClick = { context.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply { data = Uri.fromParts("package", app.packageName, null) }); showActions = false })
+                            DropdownMenuItem(text = { Text("Deinstallieren", color = Color.Red) }, onClick = { context.startActivity(Intent(Intent.ACTION_DELETE).apply { data = Uri.fromParts("package", app.packageName, null) }); showActions = false })
                         }
                     }
                 }
@@ -699,43 +521,10 @@ fun AppDrawer(
 fun AppIconView(app: AppInfo) {
     val iconSize = 48.dp
     when {
-        app.lucideIcon != null -> {
-            Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)
-        }
-        app.customIconResId != null -> {
-            Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)
-        }
-        app.iconBitmap != null -> {
-            Image(
-                bitmap = app.iconBitmap,
-                contentDescription = null,
-                modifier = Modifier.size(iconSize),
-                colorFilter = ColorFilter.tint(Color.White)
-            )
-        }
-        else -> {
-            val drawable = app.icon
-            val foregroundDrawable = if (drawable is AdaptiveIconDrawable) {
-                drawable.foreground ?: drawable
-            } else {
-                drawable
-            }
-            Image(
-                bitmap = foregroundDrawable.toBitmap().asImageBitmap(),
-                contentDescription = null,
-                modifier = Modifier.size(iconSize),
-                colorFilter = ColorFilter.tint(Color.White)
-            )
-        }
-    }
-}
-
-@Composable
-fun SettingsItemView(icon: androidx.compose.ui.graphics.vector.ImageVector, label: String, onClick: () -> Unit) {
-    Row(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 10.dp), verticalAlignment = Alignment.CenterVertically) {
-        Icon(icon, contentDescription = null, tint = Color.White, modifier = Modifier.size(20.dp))
-        Spacer(modifier = Modifier.width(12.dp))
-        Text(text = label, color = Color.White, fontSize = 14.sp)
+        app.lucideIcon != null -> Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)
+        app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)
+        app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = Modifier.size(iconSize), colorFilter = ColorFilter.tint(Color.White))
+        else -> Box(modifier = Modifier.size(iconSize).background(Color.White.copy(alpha = 0.05f), CircleShape))
     }
 }
 
@@ -746,7 +535,7 @@ fun ClockHeader() {
     LaunchedEffect(Unit) {
         while (true) {
             currentTime = Calendar.getInstance().time
-            kotlinx.coroutines.delay(1000)
+            delay(1000)
         }
     }
     val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
@@ -858,31 +647,53 @@ fun ClockHeader() {
     }
 }
 
-private fun getInstalledApps(context: Context): List<AppInfo> {
+private fun getAppListBasic(context: Context): List<AppInfo> {
     val pm = context.packageManager
     val intent = Intent(Intent.ACTION_MAIN, null).apply { addCategory(Intent.CATEGORY_LAUNCHER) }
     return pm.queryIntentActivities(intent, 0).map { resolveInfo ->
-        val icon = resolveInfo.loadIcon(pm)
-        val foregroundDrawable = if (icon is AdaptiveIconDrawable) {
-            icon.foreground ?: icon
-        } else {
-            icon
-        }
-        val bitmap = try {
-            foregroundDrawable.toBitmap().asImageBitmap()
-        } catch (e: Exception) {
-            null
-        }
-
         AppInfo(
             label = resolveInfo.loadLabel(pm).toString(),
-            packageName = resolveInfo.activityInfo.packageName,
-            icon = icon,
-            iconBitmap = bitmap,
-            lucideIcon = null,
-            customIconResId = null
+            packageName = resolveInfo.activityInfo.packageName
         )
     }.sortedBy { it.label.lowercase() }
+}
+
+private suspend fun loadSingleIcon(context: Context, pm: PackageManager, cacheDir: File, packageName: String): ImageBitmap? {
+    val iconFile = File(cacheDir, "$packageName.png")
+    if (iconFile.exists()) {
+        try {
+            val b = BitmapFactory.decodeFile(iconFile.absolutePath)
+            if (b != null) {
+                val ib = b.asImageBitmap()
+                ib.prepareToDraw()
+                return ib
+            }
+        } catch (e: Exception) { }
+    }
+    return withContext(Dispatchers.IO) {
+        try {
+            val info = pm.getApplicationInfo(packageName, 0)
+            val icon = info.loadIcon(pm)
+            val foregroundDrawable = if (icon is AdaptiveIconDrawable) {
+                icon.foreground ?: icon
+            } else {
+                icon
+            }
+            
+            val b = Bitmap.createBitmap(144, 144, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(b)
+            foregroundDrawable.setBounds(0, 0, 144, 144)
+            foregroundDrawable.draw(canvas)
+            
+            val ib = b.asImageBitmap()
+            ib.prepareToDraw()
+
+            FileOutputStream(iconFile).use { out ->
+                b.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+            ib
+        } catch (e: Exception) { null }
+    }
 }
 
 private fun getSavedFavorites(context: Context): List<String> {

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -24,6 +24,7 @@ import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.*
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -42,9 +43,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.* 
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.*
@@ -90,6 +93,20 @@ data class AppInfo(
     val customIconResId: Int? = null
 )
 
+// Verbesserter bounceClick Modifier
+fun Modifier.bounceClick(interactionSource: MutableInteractionSource) = composed {
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val scale by animateFloatAsState(
+        targetValue = if (isPressed) 0.90f else 1f, // Deutlicher auf 0.90f
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium // Schneller reagieren
+        ),
+        label = "bounceScale"
+    )
+    this.scale(scale)
+}
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -114,18 +131,15 @@ class MainActivity : ComponentActivity() {
                 }
 
                 LaunchedEffect(Unit) {
-                    // 1. Namen laden
                     val basicList = withContext(Dispatchers.IO) { getAppListBasic(context) }
                     allApps.clear()
                     allApps.addAll(basicList)
 
-                    // 2. Icons laden
                     withContext(Dispatchers.IO) {
                         val pm = context.packageManager
                         val cacheDir = File(context.cacheDir, "app_icons")
                         if (!cacheDir.exists()) cacheDir.mkdirs()
 
-                        // Favoriten zuerst laden
                         val favSet = favoritePackages.toSet()
                         val sortedIndices = allApps.indices.sortedByDescending { allApps[it].packageName in favSet }
 
@@ -199,7 +213,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
-                    // Overlay Menüs mit solidem Hintergrund
+                    // Overlay Menüs
                     AnimatedVisibility(
                         visible = isFavoritesConfigOpen,
                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
@@ -320,11 +334,12 @@ fun HomeScreen(
                 modifier = Modifier.padding(start = 12.dp)
             ) {
                 if (favorites.isEmpty()) {
+                    val intSrc = remember { MutableInteractionSource() }
                     Surface(
                         color = Color.White.copy(alpha = 0.1f),
                         shape = CircleShape,
-                        modifier = Modifier.size(56.dp).clickable(
-                            interactionSource = remember { MutableInteractionSource() },
+                        modifier = Modifier.size(56.dp).bounceClick(intSrc).clickable(
+                            interactionSource = intSrc,
                             indication = null
                         ) { onOpenFavoritesConfig() }
                     ) {
@@ -332,11 +347,12 @@ fun HomeScreen(
                     }
                 } else {
                     favorites.forEach { app ->
+                        val intSrc = remember { MutableInteractionSource() }
                         Surface(
                             color = Color.Transparent,
                             shape = RoundedCornerShape(12.dp),
-                            modifier = Modifier.clickable(
-                                interactionSource = remember { MutableInteractionSource() },
+                            modifier = Modifier.bounceClick(intSrc).clickable(
+                                interactionSource = intSrc,
                                 indication = null
                             ) {
                                 context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
@@ -360,9 +376,10 @@ fun HomeScreen(
         )
 
         Box(modifier = Modifier.fillMaxSize().navigationBarsPadding(), contentAlignment = Alignment.BottomEnd) {
+            val intSrc = remember { MutableInteractionSource() }
             Surface(
-                modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).clickable(
-                    interactionSource = remember { MutableInteractionSource() },
+                modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).bounceClick(intSrc).clickable(
+                    interactionSource = intSrc,
                     indication = null
                 ) { onToggleSettings() }, 
                 color = Color.White.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f), 
@@ -405,8 +422,9 @@ fun FavoritesConfigMenu(
         }
         Spacer(modifier = Modifier.height(16.dp))
         
+        val searchIntSrc = remember { MutableInteractionSource() }
         Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 12.dp).clickable(
-            interactionSource = remember { MutableInteractionSource() },
+            interactionSource = searchIntSrc,
             indication = null
         ) { focusRequester.requestFocus() }) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -452,8 +470,9 @@ fun FavoritesConfigMenu(
             item { Text("Alle Apps", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp) }
             items(filteredApps) { app ->
                 val isFav = app.packageName in selectedPackages
-                Surface(color = if (isFav) Color.White.copy(alpha = 0.05f) else Color.Transparent, shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth().clickable(
-                    interactionSource = remember { MutableInteractionSource() },
+                val intSrc = remember { MutableInteractionSource() }
+                Surface(color = if (isFav) Color.White.copy(alpha = 0.05f) else Color.Transparent, shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth().bounceClick(intSrc).clickable(
+                    interactionSource = intSrc,
                     indication = null
                 ) {
                     val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
@@ -471,7 +490,14 @@ fun FavoritesConfigMenu(
     }
 
     Box(modifier = Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.BottomEnd) {
-        FloatingActionButton(onClick = { if (selectedPackages.isNotEmpty()) onConfirm(selectedPackages) else Toast.makeText(context, "Keine Auswahl", Toast.LENGTH_SHORT).show() }, containerColor = Color.White, contentColor = Color(0xFF0F172A), shape = CircleShape) {
+        val intSrc = remember { MutableInteractionSource() }
+        FloatingActionButton(
+            onClick = { if (selectedPackages.isNotEmpty()) onConfirm(selectedPackages) else Toast.makeText(context, "Keine Auswahl", Toast.LENGTH_SHORT).show() }, 
+            containerColor = Color.White, 
+            contentColor = Color(0xFF0F172A), 
+            shape = CircleShape, 
+            modifier = Modifier.bounceClick(intSrc)
+        ) {
             Icon(Icons.Default.Check, contentDescription = null)
         }
     }
@@ -500,8 +526,10 @@ fun AppDrawer(
                 IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
             }
             Spacer(modifier = Modifier.height(16.dp))
+            
+            val searchIntSrc = remember { MutableInteractionSource() }
             Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 14.dp).clickable(
-                interactionSource = remember { MutableInteractionSource() },
+                interactionSource = searchIntSrc,
                 indication = null
             ) { focusRequester.requestFocus() }) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -522,9 +550,10 @@ fun AppDrawer(
             LazyVerticalGrid(columns = GridCells.Fixed(4), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.SpaceEvenly, verticalArrangement = Arrangement.spacedBy(32.dp), contentPadding = PaddingValues(bottom = 32.dp)) {
                 itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { _, app ->
                     var showActions by remember { mutableStateOf(false) }
+                    val intSrc = remember { MutableInteractionSource() }
                     Box(modifier = Modifier.width(80.dp), contentAlignment = Alignment.Center) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.combinedClickable(
-                            interactionSource = remember { MutableInteractionSource() },
+                        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.bounceClick(intSrc).combinedClickable(
+                            interactionSource = intSrc,
                             indication = null,
                             onClick = { context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) } },
                             onLongClick = { showActions = true }
@@ -568,6 +597,9 @@ fun ClockHeader() {
     }
     val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
     val dateFormat = SimpleDateFormat("EEEE, d. MMMM", Locale.getDefault())
+    val intSrcTime = remember { MutableInteractionSource() }
+    val intSrcDate = remember { MutableInteractionSource() }
+    
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
@@ -579,8 +611,9 @@ fun ClockHeader() {
             color = Color.White,
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
+                .bounceClick(intSrcTime)
                 .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
+                    interactionSource = intSrcTime,
                     indication = null
                 ) {
                     var started = false
@@ -655,8 +688,9 @@ fun ClockHeader() {
             color = Color.White.copy(alpha = 0.7f),
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
+                .bounceClick(intSrcDate)
                 .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
+                    interactionSource = intSrcDate,
                     indication = null
                 ) {
                     val calendarIntent = Intent(Intent.ACTION_VIEW).apply {

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -114,15 +114,18 @@ class MainActivity : ComponentActivity() {
                 }
 
                 LaunchedEffect(Unit) {
+                    // 1. Namen laden
                     val basicList = withContext(Dispatchers.IO) { getAppListBasic(context) }
                     allApps.clear()
                     allApps.addAll(basicList)
 
+                    // 2. Icons laden
                     withContext(Dispatchers.IO) {
                         val pm = context.packageManager
                         val cacheDir = File(context.cacheDir, "app_icons")
                         if (!cacheDir.exists()) cacheDir.mkdirs()
 
+                        // Favoriten zuerst laden
                         val favSet = favoritePackages.toSet()
                         val sortedIndices = allApps.indices.sortedByDescending { allApps[it].packageName in favSet }
 
@@ -157,6 +160,7 @@ class MainActivity : ComponentActivity() {
                 Box(modifier = Modifier.fillMaxSize()) {
                     SystemWallpaperView()
 
+                    // Haupt-Inhalt
                     AnimatedContent(
                         targetState = isDrawerOpen,
                         transitionSpec = {
@@ -195,6 +199,7 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    // Overlay Menüs mit solidem Hintergrund
                     AnimatedVisibility(
                         visible = isFavoritesConfigOpen,
                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
@@ -551,7 +556,6 @@ fun ClockHeader() {
             color = Color.White,
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .testTag("clock_time")
                 .clickable {
                     var started = false
                     try {
@@ -575,14 +579,14 @@ fun ClockHeader() {
 
                     if (!started) {
                         val packages = listOf(
-                            "cn.nubia.deskclock.preset", 
-                            "cn.nubia.deskclock",
-                            "com.zte.deskclock",
-                            "com.android.deskclock",
                             "com.google.android.deskclock",
+                            "com.android.deskclock",
                             "com.sec.android.app.clockpackage",
                             "com.huawei.android.clock",
-                            "com.miui.clock"
+                            "com.miui.clock",
+                            "cn.nubia.deskclock.preset", 
+                            "cn.nubia.deskclock",
+                            "com.zte.deskclock"
                         )
                         for (pkg in packages) {
                             try {
@@ -625,7 +629,6 @@ fun ClockHeader() {
             color = Color.White.copy(alpha = 0.7f),
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .testTag("clock_date")
                 .clickable {
                     val calendarIntent = Intent(Intent.ACTION_VIEW).apply {
                         data = CalendarContract.CONTENT_URI.buildUpon().appendPath("time").appendPath(System.currentTimeMillis().toString()).build()

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -323,7 +323,10 @@ fun HomeScreen(
                     Surface(
                         color = Color.White.copy(alpha = 0.1f),
                         shape = CircleShape,
-                        modifier = Modifier.size(56.dp).clickable { onOpenFavoritesConfig() }
+                        modifier = Modifier.size(56.dp).clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null
+                        ) { onOpenFavoritesConfig() }
                     ) {
                         Box(contentAlignment = Alignment.Center) { Icon(Icons.Default.Add, contentDescription = null, tint = Color.White) }
                     }
@@ -332,7 +335,10 @@ fun HomeScreen(
                         Surface(
                             color = Color.Transparent,
                             shape = RoundedCornerShape(12.dp),
-                            modifier = Modifier.clickable {
+                            modifier = Modifier.clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = null
+                            ) {
                                 context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
                             }
                         ) {
@@ -355,7 +361,10 @@ fun HomeScreen(
 
         Box(modifier = Modifier.fillMaxSize().navigationBarsPadding(), contentAlignment = Alignment.BottomEnd) {
             Surface(
-                modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).clickable { onToggleSettings() }, 
+                modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) { onToggleSettings() }, 
                 color = Color.White.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f), 
                 shape = CircleShape,
                 border = if (isSettingsOpen) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null
@@ -396,7 +405,10 @@ fun FavoritesConfigMenu(
         }
         Spacer(modifier = Modifier.height(16.dp))
         
-        Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 12.dp).clickable { focusRequester.requestFocus() }) {
+        Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 12.dp).clickable(
+            interactionSource = remember { MutableInteractionSource() },
+            indication = null
+        ) { focusRequester.requestFocus() }) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Search, contentDescription = null, tint = Color.White.copy(alpha = 0.4f), modifier = Modifier.size(18.dp))
                 Spacer(modifier = Modifier.width(12.dp))
@@ -440,7 +452,10 @@ fun FavoritesConfigMenu(
             item { Text("Alle Apps", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp) }
             items(filteredApps) { app ->
                 val isFav = app.packageName in selectedPackages
-                Surface(color = if (isFav) Color.White.copy(alpha = 0.05f) else Color.Transparent, shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth().clickable {
+                Surface(color = if (isFav) Color.White.copy(alpha = 0.05f) else Color.Transparent, shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth().clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
                     val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
                     if (newFavs.size <= LauncherLogic.MAX_FAVORITES) selectedPackages = newFavs else Toast.makeText(context, "Maximal 8 erlaubt", Toast.LENGTH_SHORT).show()
                 }) {
@@ -485,7 +500,10 @@ fun AppDrawer(
                 IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
             }
             Spacer(modifier = Modifier.height(16.dp))
-            Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 14.dp).clickable { focusRequester.requestFocus() }) {
+            Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 14.dp).clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null
+            ) { focusRequester.requestFocus() }) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(Icons.Default.Search, contentDescription = null, tint = Color.White.copy(alpha = 0.4f), modifier = Modifier.size(20.dp))
                     Spacer(modifier = Modifier.width(12.dp))
@@ -505,7 +523,12 @@ fun AppDrawer(
                 itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { _, app ->
                     var showActions by remember { mutableStateOf(false) }
                     Box(modifier = Modifier.width(80.dp), contentAlignment = Alignment.Center) {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.combinedClickable(interactionSource = remember { MutableInteractionSource() }, indication = null, onClick = { context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) } }, onLongClick = { showActions = true })) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.combinedClickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                            onClick = { context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) } },
+                            onLongClick = { showActions = true }
+                        )) {
                             AppIconView(app)
                             Spacer(modifier = Modifier.height(8.dp))
                             Text(text = app.label, fontSize = 11.sp, color = Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
@@ -556,7 +579,10 @@ fun ClockHeader() {
             color = Color.White,
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .clickable {
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
                     var started = false
                     try {
                         val intent = Intent(Intent.ACTION_MAIN).apply {
@@ -629,7 +655,10 @@ fun ClockHeader() {
             color = Color.White.copy(alpha = 0.7f),
             modifier = Modifier
                 .clip(RoundedCornerShape(8.dp))
-                .clickable {
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null
+                ) {
                     val calendarIntent = Intent(Intent.ACTION_VIEW).apply {
                         data = CalendarContract.CONTENT_URI.buildUpon().appendPath("time").appendPath(System.currentTimeMillis().toString()).build()
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -70,7 +70,9 @@ import com.composables.icons.lucide.*
 import java.text.SimpleDateFormat
 import java.util.*
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 data class AppInfo(
     val label: String,
@@ -105,7 +107,9 @@ class MainActivity : ComponentActivity() {
                 }
 
                 LaunchedEffect(Unit) {
-                    allApps = getInstalledApps(context)
+                    allApps = withContext(Dispatchers.IO) {
+                        getInstalledApps(context)
+                    }
                 }
 
                 LaunchedEffect(isDrawerOpen) {
@@ -217,12 +221,28 @@ fun SystemWallpaperView() {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val wallpaperManager = WallpaperManager.getInstance(context)
-    val wallpaper = remember { try { wallpaperManager.drawable } catch (e: Exception) { null } }
+    
+    var wallpaperBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+
+    LaunchedEffect(Unit) {
+        withContext(Dispatchers.IO) {
+            try {
+                val drawable = wallpaperManager.drawable
+                if (drawable != null) {
+                    val bitmap = drawable.toBitmap().asImageBitmap()
+                    wallpaperBitmap = bitmap
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+        }
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
-        if (wallpaper != null) {
+        val currentBitmap = wallpaperBitmap
+        if (currentBitmap != null) {
             Image(
-                bitmap = wallpaper.toBitmap().asImageBitmap(),
+                bitmap = currentBitmap,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
                 contentScale = ContentScale.Crop
@@ -368,8 +388,7 @@ fun FavoritesConfigMenu(
     val focusRequester = remember { FocusRequester() }
 
     Box(modifier = Modifier.fillMaxSize().testTag("favorites_config_menu")) {
-        SystemWallpaperView()
-        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A).copy(alpha = 0.95f)))
+        // Redundant wallpaper removed - root wallpaper is visible behind
 
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
@@ -547,7 +566,7 @@ fun AppDrawer(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     Box(modifier = Modifier.fillMaxSize().testTag("app_drawer")) {
-        SystemWallpaperView()
+        // Redundant wallpaper removed - root wallpaper is visible behind
         Box(modifier = Modifier.fillMaxSize().background(SolidColor(colorTheme.drawerBackground.copy(alpha = 0.85f))))
 
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
@@ -608,7 +627,8 @@ fun AppDrawer(
             ) {
                 itemsIndexed(
                     items = filteredApps,
-                    key = { _, app -> app.packageName }
+                    key = { _, app -> app.packageName },
+                    contentType = { _, _ -> "app" }
                 ) { index, app ->
                     var showAppActions by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -76,6 +76,7 @@ data class AppInfo(
     val label: String,
     val packageName: String,
     val icon: Drawable,
+    val iconBitmap: ImageBitmap? = null,
     val lucideIcon: ImageVector? = null,
     val customIconResId: Int? = null
 )
@@ -605,7 +606,10 @@ fun AppDrawer(
                 verticalArrangement = Arrangement.spacedBy(32.dp),
                 contentPadding = PaddingValues(bottom = 32.dp)
             ) {
-                itemsIndexed(filteredApps) { index, app ->
+                itemsIndexed(
+                    items = filteredApps,
+                    key = { _, app -> app.packageName }
+                ) { index, app ->
                     var showAppActions by remember { mutableStateOf(false) }
 
                     Box(
@@ -680,6 +684,14 @@ fun AppIconView(app: AppInfo) {
         }
         app.customIconResId != null -> {
             Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)
+        }
+        app.iconBitmap != null -> {
+            Image(
+                bitmap = app.iconBitmap,
+                contentDescription = null,
+                modifier = Modifier.size(iconSize),
+                colorFilter = ColorFilter.tint(Color.White)
+            )
         }
         else -> {
             val drawable = app.icon
@@ -831,10 +843,22 @@ private fun getInstalledApps(context: Context): List<AppInfo> {
     val intent = Intent(Intent.ACTION_MAIN, null).apply { addCategory(Intent.CATEGORY_LAUNCHER) }
     return pm.queryIntentActivities(intent, 0).map { resolveInfo ->
         val icon = resolveInfo.loadIcon(pm)
+        val foregroundDrawable = if (icon is AdaptiveIconDrawable) {
+            icon.foreground ?: icon
+        } else {
+            icon
+        }
+        val bitmap = try {
+            foregroundDrawable.toBitmap().asImageBitmap()
+        } catch (e: Exception) {
+            null
+        }
+
         AppInfo(
             label = resolveInfo.loadLabel(pm).toString(),
             packageName = resolveInfo.activityInfo.packageName,
             icon = icon,
+            iconBitmap = bitmap,
             lucideIcon = null,
             customIconResId = null
         )

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -607,32 +607,10 @@ fun AppDrawer(
             ) {
                 itemsIndexed(filteredApps) { index, app ->
                     var showAppActions by remember { mutableStateOf(false) }
-                    
-                    val isVisible = remember { mutableStateOf(false) }
-                    LaunchedEffect(Unit) {
-                        val cascadeDelay = if (index < 16) (index % 4) * 40L + (index / 4) * 20L else 0L
-                        kotlinx.coroutines.delay(cascadeDelay)
-                        isVisible.value = true
-                    }
-
-                    val alpha by animateFloatAsState(
-                        targetValue = if (isVisible.value) 1f else 0f,
-                        animationSpec = tween(durationMillis = 400),
-                        label = "alpha"
-                    )
-                    val translateY by animateFloatAsState(
-                        targetValue = if (isVisible.value) 0f else 40f,
-                        animationSpec = tween(durationMillis = 400, easing = EaseOutCubic),
-                        label = "translateY"
-                    )
 
                     Box(
                         modifier = Modifier
                             .width(80.dp)
-                            .graphicsLayer {
-                                this.alpha = alpha
-                                this.translationY = translateY
-                            }
                             .testTag("app_item_${app.packageName}"),
                         contentAlignment = Alignment.Center
                     ) {

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -130,11 +130,11 @@ class MainActivity : ComponentActivity() {
                         targetState = isDrawerOpen,
                         transitionSpec = {
                             if (targetState) {
-                                (slideInVertically(initialOffsetY = { it }, animationSpec = tween(500, easing = EaseInOutCubic)) + fadeIn())
-                                    .togetherWith(fadeOut(animationSpec = tween(300)))
+                                (slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)))
+                                    .togetherWith(fadeOut(animationSpec = tween(200)))
                             } else {
-                                fadeIn(animationSpec = tween(300))
-                                    .togetherWith(slideOutVertically(targetOffsetY = { it }, animationSpec = tween(500, easing = EaseInOutCubic)) + fadeOut())
+                                fadeIn(animationSpec = tween(200))
+                                    .togetherWith(slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200)))
                             }
                         },
                         label = "DrawerTransition"
@@ -166,8 +166,8 @@ class MainActivity : ComponentActivity() {
 
                     AnimatedVisibility(
                         visible = isFavoritesConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(500, easing = EaseInOutCubic)) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(500, easing = EaseInOutCubic)) + fadeOut()
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200))
                     ) {
                         FavoritesConfigMenu(
                             apps = allApps,
@@ -183,8 +183,8 @@ class MainActivity : ComponentActivity() {
 
                     AnimatedVisibility(
                         visible = isColorConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(500, easing = EaseInOutCubic)) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(500, easing = EaseInOutCubic)) + fadeOut()
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200))
                     ) {
                         ColorConfigMenu(
                             selectedTheme = currentTheme,
@@ -250,7 +250,7 @@ fun HomeScreen(
     val context = LocalContext.current
     val rotation by animateFloatAsState(
         targetValue = if (isSettingsOpen) 180f else 0f,
-        animationSpec = tween(durationMillis = 400, easing = EaseInOutCubic)
+        animationSpec = tween(durationMillis = 300, easing = EaseInOutCubic)
     )
     
     val settingsButtonSize by animateDpAsState(

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -51,38 +51,38 @@ fun SettingsPaletteMenu(
         )
     }
 
-    // Figma Parameter
-    val radius = 140f
-    val startAngle = 110f
-    val endAngle = 160f
+    // Symmetrie-Parameter mit vergrößertem Winkelbereich für mehr Abstand
+    val radius = 100f 
+    val startAngle = 85f  // Weiter nach "Rechts/Oben" geöffnet
+    val endAngle = 185f    // Weiter nach "Unten/Links" geöffnet
+    // Mittelpunkt bleibt exakt bei 135° (Diagonale) für perfekte Symmetrie
 
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.BottomEnd
     ) {
         settingsItems.forEachIndexed { index, item ->
-            // Pro Item ein eigener Animatable für den individuellen Delay
             val animProgress = remember { Animatable(0f) }
             
             LaunchedEffect(isSettingsOpen) {
                 if (isSettingsOpen) {
-                    delay(index * 50L) // Staggered Delay aus Figma
+                    delay(index * 40L)
                     animProgress.animateTo(
                         targetValue = 1f,
                         animationSpec = spring(
-                            dampingRatio = 0.62f, // Entspricht Damping 20 bei Stiffness 260
+                            dampingRatio = 0.65f, 
                             stiffness = 260f
                         )
                     )
                 } else {
-                    // Beim Schließen alle gleichzeitig oder schnell zurück
-                    animProgress.animateTo(0f, animationSpec = spring(stiffness = Spring.StiffnessLow))
+                    animProgress.animateTo(0f, animationSpec = spring(stiffness = Spring.StiffnessMedium))
                 }
             }
 
             val progress = animProgress.value
-            if (progress > 0.01f || isSettingsOpen) {
+            if (progress > 0.001f || isSettingsOpen) {
                 val total = settingsItems.size
+                // Winkelberechnung für perfekte Symmetrie um die 135°-Achse
                 val angle = startAngle + (index.toFloat() / (total - 1)) * (endAngle - startAngle)
                 val angleRad = Math.toRadians(angle.toDouble())
                 
@@ -91,12 +91,12 @@ fun SettingsPaletteMenu(
 
                 Surface(
                     modifier = Modifier
-                        .padding(bottom = 32.dp, end = 32.dp)
+                        .padding(bottom = 8.dp, end = 8.dp) 
+                        .size(56.dp)
                         .offset(
                             x = (targetX * progress).dp,
                             y = (targetY * progress).dp
                         )
-                        .size(50.dp)
                         .scale(progress)
                         .alpha(progress.coerceIn(0f, 1f))
                         .clickable(
@@ -115,7 +115,7 @@ fun SettingsPaletteMenu(
                             imageVector = item.icon,
                             contentDescription = item.label,
                             tint = Color.White,
-                            modifier = Modifier.size(20.dp)
+                            modifier = Modifier.size(24.dp)
                         )
                     }
                 }

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -3,7 +3,6 @@ package com.example.androidlauncher.ui
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -14,16 +13,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Paintbrush
 import com.composables.icons.lucide.Palette
 import com.example.androidlauncher.ui.theme.LocalColorTheme
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.*
 
@@ -43,7 +41,6 @@ fun SettingsPaletteMenu(
     onOpenSystemSettings: () -> Unit,
     onOpenInfo: () -> Unit
 ) {
-    val colorTheme = LocalColorTheme.current
     val settingsItems = remember {
         listOf(
             PaletteMenuItem("themes", Lucide.Palette, "Themes", onOpenColorConfig),
@@ -54,128 +51,73 @@ fun SettingsPaletteMenu(
         )
     }
 
-    val coroutineScope = rememberCoroutineScope()
-    val rotationAngle = remember { Animatable(0f) }
-    
-    var isDragging by remember { mutableStateOf(false) }
-    var totalDragDistance by remember { mutableFloatStateOf(0f) }
-
-    val angleStep = 30f 
-    val focusAngle = 225f
-    val baseAngle = focusAngle - ((settingsItems.size - 1) * angleStep) / 2f
-
-    val animatedProgress by animateFloatAsState(
-        targetValue = if (isSettingsOpen) 1f else 0f,
-        animationSpec = tween(
-            durationMillis = 400,
-            easing = LinearOutSlowInEasing
-        ),
-        label = "MenuProgress"
-    )
-
-    LaunchedEffect(isSettingsOpen) {
-        if (isSettingsOpen) {
-            rotationAngle.animateTo(0f, animationSpec = spring(stiffness = Spring.StiffnessLow))
-        } else {
-            isDragging = false
-            totalDragDistance = 0f
-        }
-    }
-
-    if (!isSettingsOpen && animatedProgress == 0f) return
+    // Figma Parameter
+    val radius = 140f
+    val startAngle = 110f
+    val endAngle = 160f
 
     Box(
-        modifier = Modifier
-            .fillMaxSize()
-            // Der Clou: Wir wenden pointerInput NUR an, wenn das Menü offen ist.
-            // Sobald isSettingsOpen false ist, verschwindet dieser Modifier und
-            // die Box wird sofort komplett transparent für Berührungen.
-            .then(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.BottomEnd
+    ) {
+        settingsItems.forEachIndexed { index, item ->
+            // Pro Item ein eigener Animatable für den individuellen Delay
+            val animProgress = remember { Animatable(0f) }
+            
+            LaunchedEffect(isSettingsOpen) {
                 if (isSettingsOpen) {
-                    Modifier.pointerInput(Unit) {
-                        detectDragGestures(
-                            onDragStart = {
-                                isDragging = true
-                                totalDragDistance = 0f
-                            },
-                            onDragEnd = {
-                                val currentVal = rotationAngle.value
-                                val targetAngle = round(currentVal / angleStep) * angleStep
-                                coroutineScope.launch {
-                                    rotationAngle.animateTo(
-                                        targetAngle,
-                                        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-                                    )
-                                }
-                                coroutineScope.launch {
-                                    kotlinx.coroutines.delay(100)
-                                    isDragging = false
-                                }
-                            },
-                            onDragCancel = {
-                                isDragging = false
-                            },
-                            onDrag = { change, dragAmount ->
-                                change.consume()
-                                val sensitivity = 0.4f
-                                val delta = (dragAmount.x - dragAmount.y) * sensitivity
-                                totalDragDistance += abs(delta)
-                                coroutineScope.launch {
-                                    rotationAngle.snapTo(rotationAngle.value + delta)
-                                }
+                    delay(index * 50L) // Staggered Delay aus Figma
+                    animProgress.animateTo(
+                        targetValue = 1f,
+                        animationSpec = spring(
+                            dampingRatio = 0.62f, // Entspricht Damping 20 bei Stiffness 260
+                            stiffness = 260f
+                        )
+                    )
+                } else {
+                    // Beim Schließen alle gleichzeitig oder schnell zurück
+                    animProgress.animateTo(0f, animationSpec = spring(stiffness = Spring.StiffnessLow))
+                }
+            }
+
+            val progress = animProgress.value
+            if (progress > 0.01f || isSettingsOpen) {
+                val total = settingsItems.size
+                val angle = startAngle + (index.toFloat() / (total - 1)) * (endAngle - startAngle)
+                val angleRad = Math.toRadians(angle.toDouble())
+                
+                val targetX = (cos(angleRad) * radius).toFloat()
+                val targetY = (-sin(angleRad) * radius).toFloat()
+
+                Surface(
+                    modifier = Modifier
+                        .padding(bottom = 32.dp, end = 32.dp)
+                        .offset(
+                            x = (targetX * progress).dp,
+                            y = (targetY * progress).dp
+                        )
+                        .size(50.dp)
+                        .scale(progress)
+                        .alpha(progress.coerceIn(0f, 1f))
+                        .clickable(
+                            enabled = isSettingsOpen,
+                            onClick = {
+                                item.action()
+                                onToggleSettings()
                             }
+                        ),
+                    color = Color.White.copy(alpha = 0.15f),
+                    shape = CircleShape,
+                    border = BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Icon(
+                            imageVector = item.icon,
+                            contentDescription = item.label,
+                            tint = Color.White,
+                            modifier = Modifier.size(20.dp)
                         )
                     }
-                } else Modifier
-            )
-    ) {
-        val radius = 105.dp 
-        
-        settingsItems.forEachIndexed { index, item ->
-            val currentItemAngle = baseAngle + (index * angleStep) + rotationAngle.value
-            val angleRad = Math.toRadians(currentItemAngle.toDouble())
-            
-            val xOffset = (radius.value * cos(angleRad)).dp * animatedProgress
-            val yOffset = (radius.value * sin(angleRad)).dp * animatedProgress
-
-            val normalizedAngle = (currentItemAngle % 360 + 360) % 360
-            val distanceToFocus = abs(normalizedAngle - focusAngle)
-            val isFocused = distanceToFocus < (angleStep * 1.1f) && isSettingsOpen 
-
-            val scale by animateFloatAsState(
-                targetValue = if (isFocused) 1.35f else 1.0f,
-                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
-            )
-            val alpha by animateFloatAsState(targetValue = if (isFocused) 1f else 0.5f)
-
-            Surface(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(bottom = 32.dp, end = 32.dp)
-                    .offset(x = xOffset, y = yOffset)
-                    .size(50.dp) 
-                    .scale(scale)
-                    .alpha(animatedProgress * alpha)
-                    .clip(CircleShape)
-                    // clickable wird ebenfalls sofort deaktiviert
-                    .clickable(
-                        enabled = isSettingsOpen && (!isDragging || totalDragDistance < 5f),
-                        onClick = { 
-                            item.action()
-                            onToggleSettings()
-                        }
-                    ),
-                color = if (isFocused) colorTheme.secondary.copy(alpha = 0.3f) else colorTheme.secondary.copy(alpha = 0.12f),
-                shape = CircleShape,
-                border = if (isFocused) BorderStroke(2.dp, Color.White.copy(alpha = 0.6f)) else null
-            ) {
-                Box(contentAlignment = Alignment.Center) {
-                    Icon(
-                        imageVector = item.icon,
-                        contentDescription = item.label,
-                        tint = Color.White,
-                        modifier = Modifier.size(24.dp)
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -51,11 +51,10 @@ fun SettingsPaletteMenu(
         )
     }
 
-    // Symmetrie-Parameter mit vergrößertem Winkelbereich für mehr Abstand
+    // Figma Parameter
     val radius = 100f 
-    val startAngle = 85f  // Weiter nach "Rechts/Oben" geöffnet
-    val endAngle = 185f    // Weiter nach "Unten/Links" geöffnet
-    // Mittelpunkt bleibt exakt bei 135° (Diagonale) für perfekte Symmetrie
+    val startAngle = 85f 
+    val endAngle = 185f
 
     Box(
         modifier = Modifier.fillMaxSize(),
@@ -66,23 +65,32 @@ fun SettingsPaletteMenu(
             
             LaunchedEffect(isSettingsOpen) {
                 if (isSettingsOpen) {
-                    delay(index * 40L)
+                    // Staggered Delay für den "Platsch"-Effekt beim Öffnen
+                    delay(index * 50L)
                     animProgress.animateTo(
                         targetValue = 1f,
                         animationSpec = spring(
-                            dampingRatio = 0.65f, 
+                            dampingRatio = 0.62f, // Damping 20 bei Stiffness 260
                             stiffness = 260f
                         )
                     )
                 } else {
-                    animProgress.animateTo(0f, animationSpec = spring(stiffness = Spring.StiffnessMedium))
+                    // "Saugt" sich zeitversetzt zurück (in umgekehrter Reihenfolge)
+                    val reverseIndex = settingsItems.size - 1 - index
+                    delay(reverseIndex * 30L)
+                    animProgress.animateTo(
+                        targetValue = 0f,
+                        animationSpec = spring(
+                            dampingRatio = 0.7f, 
+                            stiffness = 300f
+                        )
+                    )
                 }
             }
 
             val progress = animProgress.value
             if (progress > 0.001f || isSettingsOpen) {
                 val total = settingsItems.size
-                // Winkelberechnung für perfekte Symmetrie um die 135°-Achse
                 val angle = startAngle + (index.toFloat() / (total - 1)) * (endAngle - startAngle)
                 val angleRad = Math.toRadians(angle.toDouble())
                 
@@ -97,7 +105,7 @@ fun SettingsPaletteMenu(
                             x = (targetX * progress).dp,
                             y = (targetY * progress).dp
                         )
-                        .scale(progress)
+                        .scale(progress) // Von 0 auf 1
                         .alpha(progress.coerceIn(0f, 1f))
                         .clickable(
                             enabled = isSettingsOpen,

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -3,6 +3,8 @@ package com.example.androidlauncher.ui
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
@@ -62,20 +64,27 @@ fun SettingsPaletteMenu(
     ) {
         settingsItems.forEachIndexed { index, item ->
             val animProgress = remember { Animatable(0f) }
+            val interactionSource = remember { MutableInteractionSource() }
+            val isPressed by interactionSource.collectIsPressedAsState()
+            
+            // Animierter Scale-Faktor für den Klick (0.92f wenn gedrückt, 1f wenn nicht)
+            val pressScale by animateFloatAsState(
+                targetValue = if (isPressed) 0.92f else 1f,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
+                label = "PressScale_${item.id}"
+            )
             
             LaunchedEffect(isSettingsOpen) {
                 if (isSettingsOpen) {
-                    // Staggered Delay für den "Platsch"-Effekt beim Öffnen
                     delay(index * 50L)
                     animProgress.animateTo(
                         targetValue = 1f,
                         animationSpec = spring(
-                            dampingRatio = 0.62f, // Damping 20 bei Stiffness 260
+                            dampingRatio = 0.62f, 
                             stiffness = 260f
                         )
                     )
                 } else {
-                    // "Saugt" sich zeitversetzt zurück (in umgekehrter Reihenfolge)
                     val reverseIndex = settingsItems.size - 1 - index
                     delay(reverseIndex * 30L)
                     animProgress.animateTo(
@@ -105,9 +114,12 @@ fun SettingsPaletteMenu(
                             x = (targetX * progress).dp,
                             y = (targetY * progress).dp
                         )
-                        .scale(progress) // Von 0 auf 1
+                        // Kombinierter Scale: Öffnen/Schließen * Klick-Feedback
+                        .scale(progress * pressScale)
                         .alpha(progress.coerceIn(0f, 1f))
                         .clickable(
+                            interactionSource = interactionSource,
+                            indication = null, // Standard-Ripple entfernen
                             enabled = isSettingsOpen,
                             onClick = {
                                 item.action()

--- a/app/src/test/java/com/example/androidlauncher/LauncherLogicTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/LauncherLogicTest.kt
@@ -1,19 +1,15 @@
 package com.example.androidlauncher
 
-import android.graphics.drawable.Drawable
-import io.mockk.mockk
 import org.junit.Assert.*
 import org.junit.Test
 
 class LauncherLogicTest {
 
-    private val mockDrawable = mockk<Drawable>()
-
     private val apps = listOf(
-        AppInfo("Browser", "com.android.browser", mockDrawable),
-        AppInfo("Camera", "com.android.camera", mockDrawable),
-        AppInfo("Contacts", "com.android.contacts", mockDrawable),
-        AppInfo("Email", "com.android.email", mockDrawable)
+        AppInfo("Browser", "com.android.browser", null),
+        AppInfo("Camera", "com.android.camera", null),
+        AppInfo("Contacts", "com.android.contacts", null),
+        AppInfo("Email", "com.android.email", null)
     )
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.kotlinAndroid) apply false
     alias(libs.plugins.kotlinCompose) apply false
     alias(libs.plugins.detekt)
+    alias(libs.plugins.kover) apply false
 }
 
 detekt {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ detekt = "1.23.8"
 mockk = "1.13.12"
 kotlinxCoroutines = "1.7.3"
 datastore = "1.1.1"
+kover = "0.9.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -39,3 +40,4 @@ androidApp = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
# Performance: Ruckler beim Scrollen im AppDrawer und Konfigurationsmenü der Favoriten beseitigen

## Beschreibung

Beim Hoch- und Runterscrollen im AppDrawer sowie im Konfigurationsmenü treten gelegentlich Ruckler bzw. kurze Hänger auf.

Das Scrollverhalten soll optimiert werden, sodass es durchgehend flüssig und stabil läuft.

---

## Ziel

Verbesserung der Performance und Erhöhung der wahrgenommenen Qualität des Launchers durch flüssiges Scrollen.

---

## Betroffene Bereiche

- [x] AppDrawer (Scrollen durch App-Grid)
- [x] Konfigurationsmenü  der Favoriten (Scrollen durch Einstellungen)

---

## Erwartetes Verhalten

- Gleichmäßiges, flüssiges Scrollen
- Keine sichtbaren Frame-Drops
- Keine UI-Hänger beim schnellen Scrollen
- Keine Verzögerung beim Laden von Icons

---

## Mögliche Ursachen (zu prüfen)

- [x] Zu häufige Recomposition
- [x] Schwergewichtige Berechnungen im UI-Thread
- [x] Unoptimiertes Icon-Rendering
- [x] Fehlendes Lazy-Loading / LazyGrid Optimierung
- [x] Fehlende Stable Keys in Listen
- [x] Zu große Bild-Assets

---

## Optimierungsansätze (optional)

- Verwendung von LazyColumn / LazyVerticalGrid korrekt konfigurieren
- Stable Keys definieren
- remember / derivedStateOf prüfen
- Icon-Caching implementieren
- State-Updates minimieren
- Performance-Profiling (Layout Inspector / Profiler)

---

## Akzeptanzkriterien

- Scrollen im AppDrawer ist durchgehend flüssig
- Scrollen im Konfigurationsmenü ist stabil
- Keine wahrnehmbaren Ruckler bei schnellen Scrollbewegungen
- Keine Regression anderer Funktionen
- Projekt buildet ohne Fehler
