### PR TITLE
#13 Größen- und Skalierungsmenü mit Live-Vorschau implementieren

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -73,6 +73,7 @@ import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.ui.ColorConfigMenu
 import com.example.androidlauncher.ui.SettingsPaletteMenu
+import com.example.androidlauncher.ui.SizeConfigMenu
 import com.composables.icons.lucide.*
 import java.text.SimpleDateFormat
 import java.util.*
@@ -122,6 +123,7 @@ class MainActivity : ComponentActivity() {
                 var isSettingsOpen by remember { mutableStateOf(false) }
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
                 var isColorConfigOpen by remember { mutableStateOf(false) }
+                var isSizeConfigOpen by remember { mutableStateOf(false) }
                 
                 val allApps = remember { mutableStateListOf<AppInfo>() }
                 var favoritePackages by remember { mutableStateOf(getSavedFavorites(context)) }
@@ -161,13 +163,15 @@ class MainActivity : ComponentActivity() {
                         isSettingsOpen = false
                         isFavoritesConfigOpen = false
                         isColorConfigOpen = false
+                        isSizeConfigOpen = false
                     }
                 }
 
-                BackHandler(enabled = isDrawerOpen || isSettingsOpen || isFavoritesConfigOpen || isColorConfigOpen) {
+                BackHandler(enabled = isDrawerOpen || isSettingsOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen) {
                     if (isDrawerOpen) isDrawerOpen = false
                     else if (isFavoritesConfigOpen) isFavoritesConfigOpen = false
                     else if (isColorConfigOpen) isColorConfigOpen = false
+                    else if (isSizeConfigOpen) isSizeConfigOpen = false
                     else if (isSettingsOpen) isSettingsOpen = false
                 }
 
@@ -208,7 +212,8 @@ class MainActivity : ComponentActivity() {
                                 onOpenDrawer = { isDrawerOpen = true },
                                 onToggleSettings = { isSettingsOpen = !isSettingsOpen },
                                 onOpenFavoritesConfig = { isFavoritesConfigOpen = true },
-                                onOpenColorConfig = { isColorConfigOpen = true }
+                                onOpenColorConfig = { isColorConfigOpen = true },
+                                onOpenSizeConfig = { isSizeConfigOpen = true }
                             )
                         }
                     }
@@ -245,6 +250,18 @@ class MainActivity : ComponentActivity() {
                                     scope.launch { themeManager.setTheme(theme) }
                                 },
                                 onClose = { isColorConfigOpen = false }
+                            )
+                        }
+                    }
+
+                    AnimatedVisibility(
+                        visible = isSizeConfigOpen,
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                    ) {
+                        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
+                            SizeConfigMenu(
+                                onClose = { isSizeConfigOpen = false }
                             )
                         }
                     }
@@ -298,7 +315,8 @@ fun HomeScreen(
     onOpenDrawer: () -> Unit, 
     onToggleSettings: () -> Unit,
     onOpenFavoritesConfig: () -> Unit,
-    onOpenColorConfig: () -> Unit
+    onOpenColorConfig: () -> Unit,
+    onOpenSizeConfig: () -> Unit
 ) {
     val context = LocalContext.current
     val rotation by animateFloatAsState(
@@ -371,6 +389,7 @@ fun HomeScreen(
             onToggleSettings = onToggleSettings,
             onOpenFavoritesConfig = onOpenFavoritesConfig,
             onOpenColorConfig = onOpenColorConfig,
+            onOpenSizeConfig = onOpenSizeConfig,
             onOpenSystemSettings = { context.startActivity(Intent(Settings.ACTION_SETTINGS)) },
             onOpenInfo = { /* Action */ }
         )

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -70,7 +70,9 @@ import androidx.core.graphics.drawable.toBitmap
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalFontSize
 import com.example.androidlauncher.data.ThemeManager
+import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.ui.ColorConfigMenu
 import com.example.androidlauncher.ui.SettingsPaletteMenu
 import com.example.androidlauncher.ui.SizeConfigMenu
@@ -116,9 +118,10 @@ class MainActivity : ComponentActivity() {
             val context = LocalContext.current
             val themeManager = remember { ThemeManager(context) }
             val currentTheme by themeManager.selectedTheme.collectAsState(initial = ColorTheme.LAUNCHER)
+            val currentFontSize by themeManager.selectedFontSize.collectAsState(initial = FontSize.STANDARD)
             val scope = rememberCoroutineScope()
 
-            AndroidLauncherTheme(colorTheme = currentTheme) {
+            AndroidLauncherTheme(colorTheme = currentTheme, fontSize = currentFontSize) {
                 var isDrawerOpen by remember { mutableStateOf(false) }
                 var isSettingsOpen by remember { mutableStateOf(false) }
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
@@ -261,6 +264,10 @@ class MainActivity : ComponentActivity() {
                     ) {
                         Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
                             SizeConfigMenu(
+                                currentFontSize = currentFontSize,
+                                onFontSizeSelected = { size ->
+                                    scope.launch { themeManager.setFontSize(size) }
+                                },
                                 onClose = { isSizeConfigOpen = false }
                             )
                         }
@@ -532,6 +539,7 @@ fun AppDrawer(
 ) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
+    val fontSize = LocalFontSize.current
     var searchQuery by remember { mutableStateOf("") }
     val filteredApps = remember(apps.toList(), searchQuery) { LauncherLogic.filterApps(apps.toList(), searchQuery) }
     val focusRequester = remember { FocusRequester() }
@@ -541,7 +549,7 @@ fun AppDrawer(
         Box(modifier = Modifier.fillMaxSize().background(SolidColor(colorTheme.drawerBackground.copy(alpha = 0.85f))))
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Text("Apps", fontSize = 24.sp, fontWeight = FontWeight.Light, color = Color.White)
+                Text("Apps", fontSize = 24.sp * fontSize.scale, fontWeight = FontWeight.Light, color = Color.White)
                 IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = Color.White) }
             }
             Spacer(modifier = Modifier.height(16.dp))
@@ -557,11 +565,11 @@ fun AppDrawer(
                     BasicTextField(
                         value = searchQuery, onValueChange = { searchQuery = it },
                         modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
-                        textStyle = androidx.compose.ui.text.TextStyle(color = Color.White, fontSize = 16.sp),
+                        textStyle = androidx.compose.ui.text.TextStyle(color = Color.White, fontSize = 16.sp * fontSize.scale),
                         cursorBrush = SolidColor(Color.White), singleLine = true,
                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
                         keyboardActions = KeyboardActions(onSearch = { keyboardController?.hide() }),
-                        decorationBox = { if (searchQuery.isEmpty()) Text("Apps durchsuchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 16.sp); it() }
+                        decorationBox = { if (searchQuery.isEmpty()) Text("Apps durchsuchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 16.sp * fontSize.scale); it() }
                     )
                 }
             }
@@ -579,12 +587,12 @@ fun AppDrawer(
                         )) {
                             AppIconView(app)
                             Spacer(modifier = Modifier.height(8.dp))
-                            Text(text = app.label, fontSize = 11.sp, color = Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
+                            Text(text = app.label, fontSize = 11.sp * fontSize.scale, color = Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
                         }
                         DropdownMenu(expanded = showActions, onDismissRequest = { showActions = false }, modifier = Modifier.background(Color(0xFF1A1F2B))) {
-                            DropdownMenuItem(text = { Text(if (isFavorite(app.packageName)) "Vom Home entfernen" else "Als Favorit setzen", color = Color.White) }, onClick = { onToggleFavorite(app.packageName); showActions = false })
-                            DropdownMenuItem(text = { Text("App-Info", color = Color.White) }, onClick = { context.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply { data = Uri.fromParts("package", app.packageName, null) }); showActions = false })
-                            DropdownMenuItem(text = { Text("Deinstallieren", color = Color.Red) }, onClick = { context.startActivity(Intent(Intent.ACTION_DELETE).apply { data = Uri.fromParts("package", app.packageName, null) }); showActions = false })
+                            DropdownMenuItem(text = { Text(if (isFavorite(app.packageName)) "Vom Home entfernen" else "Als Favorit setzen", color = Color.White, fontSize = 14.sp * fontSize.scale) }, onClick = { onToggleFavorite(app.packageName); showActions = false })
+                            DropdownMenuItem(text = { Text("App-Info", color = Color.White, fontSize = 14.sp * fontSize.scale) }, onClick = { context.startActivity(Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply { data = Uri.fromParts("package", app.packageName, null) }); showActions = false })
+                            DropdownMenuItem(text = { Text("Deinstallieren", color = Color.Red, fontSize = 14.sp * fontSize.scale) }, onClick = { context.startActivity(Intent(Intent.ACTION_DELETE).apply { data = Uri.fromParts("package", app.packageName, null) }); showActions = false })
                         }
                     }
                 }
@@ -607,6 +615,7 @@ fun AppIconView(app: AppInfo) {
 @Composable
 fun ClockHeader() {
     val context = LocalContext.current
+    val fontSize = LocalFontSize.current
     var currentTime by remember { mutableStateOf(Calendar.getInstance().time) }
     LaunchedEffect(Unit) {
         while (true) {
@@ -624,7 +633,7 @@ fun ClockHeader() {
     ) {
         Text(
             text = timeFormat.format(currentTime),
-            fontSize = 72.sp,
+            fontSize = 72.sp * fontSize.scale,
             fontWeight = FontWeight.Normal,
             letterSpacing = (-2).sp,
             color = Color.White,
@@ -702,7 +711,7 @@ fun ClockHeader() {
         )
         Text(
             text = dateFormat.format(currentTime),
-            fontSize = 18.sp,
+            fontSize = 18.sp * fontSize.scale,
             fontWeight = FontWeight.Normal,
             color = Color.White.copy(alpha = 0.7f),
             modifier = Modifier

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -71,8 +71,10 @@ import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalFontSize
+import com.example.androidlauncher.ui.theme.LocalIconSize
 import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.data.FontSize
+import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.ColorConfigMenu
 import com.example.androidlauncher.ui.SettingsPaletteMenu
 import com.example.androidlauncher.ui.SizeConfigMenu
@@ -119,9 +121,14 @@ class MainActivity : ComponentActivity() {
             val themeManager = remember { ThemeManager(context) }
             val currentTheme by themeManager.selectedTheme.collectAsState(initial = ColorTheme.LAUNCHER)
             val currentFontSize by themeManager.selectedFontSize.collectAsState(initial = FontSize.STANDARD)
+            val currentIconSize by themeManager.selectedIconSize.collectAsState(initial = IconSize.STANDARD)
             val scope = rememberCoroutineScope()
 
-            AndroidLauncherTheme(colorTheme = currentTheme, fontSize = currentFontSize) {
+            AndroidLauncherTheme(
+                colorTheme = currentTheme, 
+                fontSize = currentFontSize,
+                iconSize = currentIconSize
+            ) {
                 var isDrawerOpen by remember { mutableStateOf(false) }
                 var isSettingsOpen by remember { mutableStateOf(false) }
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
@@ -267,6 +274,10 @@ class MainActivity : ComponentActivity() {
                                 currentFontSize = currentFontSize,
                                 onFontSizeSelected = { size ->
                                     scope.launch { themeManager.setFontSize(size) }
+                                },
+                                currentIconSize = currentIconSize,
+                                onIconSizeSelected = { size ->
+                                    scope.launch { themeManager.setIconSize(size) }
                                 },
                                 onClose = { isSizeConfigOpen = false }
                             )
@@ -540,6 +551,7 @@ fun AppDrawer(
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val fontSize = LocalFontSize.current
+    val iconSize = LocalIconSize.current
     var searchQuery by remember { mutableStateOf("") }
     val filteredApps = remember(apps.toList(), searchQuery) { LauncherLogic.filterApps(apps.toList(), searchQuery) }
     val focusRequester = remember { FocusRequester() }
@@ -574,11 +586,24 @@ fun AppDrawer(
                 }
             }
             Spacer(modifier = Modifier.height(24.dp))
-            LazyVerticalGrid(columns = GridCells.Fixed(4), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.SpaceEvenly, verticalArrangement = Arrangement.spacedBy(32.dp), contentPadding = PaddingValues(bottom = 32.dp)) {
+            
+            val adaptiveColumns = when (iconSize) {
+                IconSize.SMALL -> 5
+                IconSize.STANDARD -> 4
+                IconSize.LARGE -> 3
+            }
+
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(adaptiveColumns), 
+                modifier = Modifier.fillMaxSize(), 
+                horizontalArrangement = Arrangement.SpaceEvenly, 
+                verticalArrangement = Arrangement.spacedBy(32.dp), 
+                contentPadding = PaddingValues(bottom = 32.dp)
+            ) {
                 itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { _, app ->
                     var showActions by remember { mutableStateOf(false) }
                     val intSrc = remember { MutableInteractionSource() }
-                    Box(modifier = Modifier.width(80.dp), contentAlignment = Alignment.Center) {
+                    Box(modifier = Modifier.width(if (adaptiveColumns == 5) 64.dp else 80.dp), contentAlignment = Alignment.Center) {
                         Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.bounceClick(intSrc).combinedClickable(
                             interactionSource = intSrc,
                             indication = null,
@@ -603,7 +628,7 @@ fun AppDrawer(
 
 @Composable
 fun AppIconView(app: AppInfo) {
-    val iconSize = 48.dp
+    val iconSize = LocalIconSize.current.size
     when {
         app.lucideIcon != null -> Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)
         app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = Modifier.size(iconSize), tint = Color.White)

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -234,7 +234,7 @@ class MainActivity : ComponentActivity() {
                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
                     ) {
-                        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
+                        Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
                             FavoritesConfigMenu(
                                 apps = allApps,
                                 initialFavoritePackages = favoritePackages,
@@ -253,7 +253,7 @@ class MainActivity : ComponentActivity() {
                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
                     ) {
-                        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
+                        Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
                             ColorConfigMenu(
                                 selectedTheme = currentTheme,
                                 onThemeSelected = { theme ->
@@ -269,7 +269,7 @@ class MainActivity : ComponentActivity() {
                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
                     ) {
-                        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A))) {
+                        Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
                             SizeConfigMenu(
                                 currentFontSize = currentFontSize,
                                 onFontSizeSelected = { size ->

--- a/app/src/main/java/com/example/androidlauncher/data/FontSize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/FontSize.kt
@@ -1,0 +1,7 @@
+package com.example.androidlauncher.data
+
+enum class FontSize(val label: String, val scale: Float) {
+    SMALL("Klein", 0.85f),
+    STANDARD("Standard", 1.0f),
+    LARGE("Groß", 1.2f)
+}

--- a/app/src/main/java/com/example/androidlauncher/data/IconSize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IconSize.kt
@@ -1,0 +1,10 @@
+package com.example.androidlauncher.data
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+enum class IconSize(val label: String, val size: Dp) {
+    SMALL("Klein", 40.dp),
+    STANDARD("Standard", 48.dp),
+    LARGE("Groß", 56.dp)
+}

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -13,6 +13,7 @@ private val Context.dataStore by preferencesDataStore(name = "settings")
 class ThemeManager(private val context: Context) {
     companion object {
         private val THEME_KEY = stringPreferencesKey("selected_theme")
+        private val FONT_SIZE_KEY = stringPreferencesKey("font_size")
     }
 
     val selectedTheme: Flow<ColorTheme> = context.dataStore.data
@@ -25,9 +26,25 @@ class ThemeManager(private val context: Context) {
             }
         }
 
+    val selectedFontSize: Flow<FontSize> = context.dataStore.data
+        .map { preferences ->
+            val fontSizeName = preferences[FONT_SIZE_KEY] ?: FontSize.STANDARD.name
+            try {
+                FontSize.valueOf(fontSizeName)
+            } catch (e: IllegalArgumentException) {
+                FontSize.STANDARD
+            }
+        }
+
     suspend fun setTheme(theme: ColorTheme) {
         context.dataStore.edit { preferences ->
             preferences[THEME_KEY] = theme.name
+        }
+    }
+
+    suspend fun setFontSize(fontSize: FontSize) {
+        context.dataStore.edit { preferences ->
+            preferences[FONT_SIZE_KEY] = fontSize.name
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -14,6 +14,7 @@ class ThemeManager(private val context: Context) {
     companion object {
         private val THEME_KEY = stringPreferencesKey("selected_theme")
         private val FONT_SIZE_KEY = stringPreferencesKey("font_size")
+        private val ICON_SIZE_KEY = stringPreferencesKey("icon_size")
     }
 
     val selectedTheme: Flow<ColorTheme> = context.dataStore.data
@@ -36,6 +37,16 @@ class ThemeManager(private val context: Context) {
             }
         }
 
+    val selectedIconSize: Flow<IconSize> = context.dataStore.data
+        .map { preferences ->
+            val iconSizeName = preferences[ICON_SIZE_KEY] ?: IconSize.STANDARD.name
+            try {
+                IconSize.valueOf(iconSizeName)
+            } catch (e: IllegalArgumentException) {
+                IconSize.STANDARD
+            }
+        }
+
     suspend fun setTheme(theme: ColorTheme) {
         context.dataStore.edit { preferences ->
             preferences[THEME_KEY] = theme.name
@@ -45,6 +56,12 @@ class ThemeManager(private val context: Context) {
     suspend fun setFontSize(fontSize: FontSize) {
         context.dataStore.edit { preferences ->
             preferences[FONT_SIZE_KEY] = fontSize.name
+        }
+    }
+
+    suspend fun setIconSize(iconSize: IconSize) {
+        context.dataStore.edit { preferences ->
+            preferences[ICON_SIZE_KEY] = iconSize.name
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -32,7 +32,8 @@ fun ColorConfigMenu(
 ) {
     Box(modifier = Modifier.fillMaxSize().testTag("color_config_menu")) {
         SystemWallpaperView()
-        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A).copy(alpha = 0.95f)))
+        // Nutzt nun die Farbe des aktuell ausgewählten Themes statt des statischen Blaus
+        Box(modifier = Modifier.fillMaxSize().background(selectedTheme.drawerBackground.copy(alpha = 0.95f)))
 
         Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -19,8 +19,8 @@ import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
+import com.composables.icons.lucide.ALargeSmall
 import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Paintbrush
 import com.composables.icons.lucide.Palette
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import kotlinx.coroutines.delay
@@ -40,13 +40,14 @@ fun SettingsPaletteMenu(
     onToggleSettings: () -> Unit,
     onOpenFavoritesConfig: () -> Unit,
     onOpenColorConfig: () -> Unit,
+    onOpenSizeConfig: () -> Unit,
     onOpenSystemSettings: () -> Unit,
     onOpenInfo: () -> Unit
 ) {
     val settingsItems = remember {
         listOf(
             PaletteMenuItem("themes", Lucide.Palette, "Themes", onOpenColorConfig),
-            PaletteMenuItem("colors", Lucide.Paintbrush, "Colors", onOpenColorConfig),
+            PaletteMenuItem("size", Lucide.ALargeSmall, "Größe", onOpenSizeConfig),
             PaletteMenuItem("favorites", Icons.Default.Star, "Favorites", onOpenFavoritesConfig),
             PaletteMenuItem("system", Icons.Default.Settings, "System", onOpenSystemSettings),
             PaletteMenuItem("info", Icons.Default.Info, "Info", onOpenInfo),
@@ -54,7 +55,7 @@ fun SettingsPaletteMenu(
     }
 
     // Figma Parameter
-    val radius = 100f 
+    val radius = 110f // Leicht vergrößert für 5 Items
     val startAngle = 85f 
     val endAngle = 185f
 
@@ -67,7 +68,6 @@ fun SettingsPaletteMenu(
             val interactionSource = remember { MutableInteractionSource() }
             val isPressed by interactionSource.collectIsPressedAsState()
             
-            // Animierter Scale-Faktor für den Klick (0.92f wenn gedrückt, 1f wenn nicht)
             val pressScale by animateFloatAsState(
                 targetValue = if (isPressed) 0.92f else 1f,
                 animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow),
@@ -114,12 +114,11 @@ fun SettingsPaletteMenu(
                             x = (targetX * progress).dp,
                             y = (targetY * progress).dp
                         )
-                        // Kombinierter Scale: Öffnen/Schließen * Klick-Feedback
                         .scale(progress * pressScale)
                         .alpha(progress.coerceIn(0f, 1f))
                         .clickable(
                             interactionSource = interactionSource,
-                            indication = null, // Standard-Ripple entfernen
+                            indication = null,
                             enabled = isSettingsOpen,
                             onClick = {
                                 item.action()

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -17,11 +17,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.androidlauncher.data.FontSize
+import com.example.androidlauncher.data.IconSize
 
 @Composable
 fun SizeConfigMenu(
     currentFontSize: FontSize,
     onFontSizeSelected: (FontSize) -> Unit,
+    currentIconSize: IconSize,
+    onIconSizeSelected: (IconSize) -> Unit,
     onClose: () -> Unit
 ) {
     Column(
@@ -69,6 +72,42 @@ fun SizeConfigMenu(
                 val isSelected = size == currentFontSize
                 Surface(
                     onClick = { onFontSizeSelected(size) },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    color = if (isSelected) Color.White else Color.White.copy(alpha = 0.1f),
+                    contentColor = if (isSelected) Color(0xFF0F172A) else Color.White,
+                    border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = size.label,
+                            fontSize = 14.sp,
+                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            text = "Icon-Größe",
+            color = Color.White.copy(alpha = 0.5f),
+            fontSize = 12.sp,
+            modifier = Modifier.padding(bottom = 16.dp)
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            IconSize.entries.forEach { size ->
+                val isSelected = size == currentIconSize
+                Surface(
+                    onClick = { onIconSizeSelected(size) },
                     modifier = Modifier
                         .weight(1f)
                         .height(48.dp),

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -1,7 +1,11 @@
 package com.example.androidlauncher.ui
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
@@ -12,9 +16,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.data.FontSize
 
 @Composable
 fun SizeConfigMenu(
+    currentFontSize: FontSize,
+    onFontSizeSelected: (FontSize) -> Unit,
     onClose: () -> Unit
 ) {
     Column(
@@ -47,11 +54,38 @@ fun SizeConfigMenu(
         
         Spacer(modifier = Modifier.height(32.dp))
         
-        // Placeholder für die kommenden Kriterien
         Text(
-            text = "Inhalt für Größenanpassung folgt...",
-            color = Color.White.copy(alpha = 0.6f),
-            fontSize = 16.sp
+            text = "Schriftgröße",
+            color = Color.White.copy(alpha = 0.5f),
+            fontSize = 12.sp,
+            modifier = Modifier.padding(bottom = 16.dp)
         )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            FontSize.entries.forEach { size ->
+                val isSelected = size == currentFontSize
+                Surface(
+                    onClick = { onFontSizeSelected(size) },
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(48.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    color = if (isSelected) Color.White else Color.White.copy(alpha = 0.1f),
+                    contentColor = if (isSelected) Color(0xFF0F172A) else Color.White,
+                    border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                ) {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = size.label,
+                            fontSize = 14.sp,
+                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
+                        )
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -1,0 +1,57 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun SizeConfigMenu(
+    onClose: () -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column {
+                Text(
+                    text = "Größe & Skalierung",
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Light,
+                    color = Color.White
+                )
+            }
+            IconButton(onClick = onClose) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = "Schließen",
+                    tint = Color.White
+                )
+            }
+        }
+        
+        Spacer(modifier = Modifier.height(32.dp))
+        
+        // Placeholder für die kommenden Kriterien
+        Text(
+            text = "Inhalt für Größenanpassung folgt...",
+            color = Color.White.copy(alpha = 0.6f),
+            fontSize = 16.sp
+        )
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -34,9 +34,10 @@ fun SizeConfigMenu(
     onIconSizeSelected: (IconSize) -> Unit,
     onClose: () -> Unit
 ) {
+    val colorTheme = LocalColorTheme.current
     Box(modifier = Modifier.fillMaxSize()) {
         SystemWallpaperView()
-        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A).copy(alpha = 0.95f)))
+        Box(modifier = Modifier.fillMaxSize().background(colorTheme.drawerBackground.copy(alpha = 0.95f)))
 
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -2,22 +2,29 @@ package com.example.androidlauncher.ui
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.SystemWallpaperView
 import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.IconSize
+import com.example.androidlauncher.ui.theme.LocalColorTheme
 
 @Composable
 fun SizeConfigMenu(
@@ -27,101 +34,224 @@ fun SizeConfigMenu(
     onIconSizeSelected: (IconSize) -> Unit,
     onClose: () -> Unit
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .statusBarsPadding()
-            .padding(horizontal = 24.dp, vertical = 16.dp)
-    ) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column {
-                Text(
-                    text = "Größe & Skalierung",
-                    fontSize = 24.sp,
-                    fontWeight = FontWeight.Light,
-                    color = Color.White
-                )
-            }
-            IconButton(onClick = onClose) {
-                Icon(
-                    imageVector = Icons.Default.Close,
-                    contentDescription = "Schließen",
-                    tint = Color.White
-                )
-            }
-        }
-        
-        Spacer(modifier = Modifier.height(32.dp))
-        
-        Text(
-            text = "Schriftgröße",
-            color = Color.White.copy(alpha = 0.5f),
-            fontSize = 12.sp,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
+    Box(modifier = Modifier.fillMaxSize()) {
+        SystemWallpaperView()
+        Box(modifier = Modifier.fillMaxSize().background(Color(0xFF0F172A).copy(alpha = 0.95f)))
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
         ) {
-            FontSize.entries.forEach { size ->
-                val isSelected = size == currentFontSize
-                Surface(
-                    onClick = { onFontSizeSelected(size) },
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(48.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    color = if (isSelected) Color.White else Color.White.copy(alpha = 0.1f),
-                    contentColor = if (isSelected) Color(0xFF0F172A) else Color.White,
-                    border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Text(
-                            text = size.label,
-                            fontSize = 14.sp,
-                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
-                        )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
+                    Text(
+                        text = "Größe & Skalierung",
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Light,
+                        color = Color.White
+                    )
+                }
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Schließen",
+                        tint = Color.White
+                    )
+                }
+            }
+            
+            Spacer(modifier = Modifier.height(24.dp))
+            
+            Text("Vorschau", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp)
+            Spacer(modifier = Modifier.height(12.dp))
+            
+            // Preview Area
+            Row(modifier = Modifier.fillMaxWidth().height(150.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                SizePreviewCard(
+                    title = "Startseite", 
+                    fontSize = currentFontSize, 
+                    iconSize = currentIconSize,
+                    isHome = true, 
+                    modifier = Modifier.weight(1f)
+                )
+                SizePreviewCard(
+                    title = "App Drawer", 
+                    fontSize = currentFontSize, 
+                    iconSize = currentIconSize,
+                    isHome = false, 
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+            
+            Text(
+                text = "Schriftgröße",
+                color = Color.White.copy(alpha = 0.5f),
+                fontSize = 12.sp,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                FontSize.entries.forEach { size ->
+                    val isSelected = size == currentFontSize
+                    Surface(
+                        onClick = { onFontSizeSelected(size) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        color = if (isSelected) Color.White else Color.White.copy(alpha = 0.1f),
+                        contentColor = if (isSelected) Color(0xFF0F172A) else Color.White,
+                        border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text(
+                                text = size.label,
+                                fontSize = 14.sp,
+                                fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Text(
+                text = "Icon-Größe",
+                color = Color.White.copy(alpha = 0.5f),
+                fontSize = 12.sp,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                IconSize.entries.forEach { size ->
+                    val isSelected = size == currentIconSize
+                    Surface(
+                        onClick = { onIconSizeSelected(size) },
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        color = if (isSelected) Color.White else Color.White.copy(alpha = 0.1f),
+                        contentColor = if (isSelected) Color(0xFF0F172A) else Color.White,
+                        border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Text(
+                                text = size.label,
+                                fontSize = 14.sp,
+                                fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
+                            )
+                        }
                     }
                 }
             }
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
-
-        Text(
-            text = "Icon-Größe",
-            color = Color.White.copy(alpha = 0.5f),
-            fontSize = 12.sp,
-            modifier = Modifier.padding(bottom = 16.dp)
-        )
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        // Zurücksetzen Button am unteren Rand
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = 32.dp, end = 24.dp, start = 24.dp),
+            contentAlignment = Alignment.BottomCenter
         ) {
-            IconSize.entries.forEach { size ->
-                val isSelected = size == currentIconSize
-                Surface(
-                    onClick = { onIconSizeSelected(size) },
-                    modifier = Modifier
-                        .weight(1f)
-                        .height(48.dp),
-                    shape = RoundedCornerShape(12.dp),
-                    color = if (isSelected) Color.White else Color.White.copy(alpha = 0.1f),
-                    contentColor = if (isSelected) Color(0xFF0F172A) else Color.White,
-                    border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
-                ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Text(
-                            text = size.label,
-                            fontSize = 14.sp,
-                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal
-                        )
+            TextButton(
+                onClick = {
+                    onFontSizeSelected(FontSize.STANDARD)
+                    onIconSizeSelected(IconSize.STANDARD)
+                },
+                colors = ButtonDefaults.textButtonColors(contentColor = Color.White.copy(alpha = 0.6f))
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Auf Standardwerte zurücksetzen", fontSize = 14.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, isHome: Boolean, modifier: Modifier = Modifier) {
+    val colorTheme = LocalColorTheme.current
+    Surface(
+        color = Color.White.copy(alpha = 0.05f),
+        shape = RoundedCornerShape(16.dp),
+        modifier = modifier
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(title, color = Color.White.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+            Spacer(modifier = Modifier.height(8.dp))
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(
+                        if (isHome) {
+                            Brush.verticalGradient(listOf(colorTheme.primary.copy(alpha = 0.6f), colorTheme.secondary.copy(alpha = 0.6f)))
+                        } else {
+                            SolidColor(colorTheme.drawerBackground)
+                        }
+                    )
+            ) {
+                if (isHome) {
+                    // Simpler Home Screen content with size scaling
+                    Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                        Box(modifier = Modifier.width(40.dp * fontSize.scale).height(8.dp * fontSize.scale).background(Color.White.copy(alpha = 0.8f), CircleShape))
+                        Box(modifier = Modifier.width(30.dp * fontSize.scale).height(4.dp * fontSize.scale).background(Color.White.copy(alpha = 0.4f), CircleShape))
+                        Spacer(modifier = Modifier.height(12.dp))
+                        repeat(3) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                // Scale preview dot based on icon size
+                                val dotSize = 12.dp * (iconSize.size / 48.dp)
+                                Box(modifier = Modifier.size(dotSize).border(1.dp, Color.White.copy(alpha = 0.5f), CircleShape))
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Box(modifier = Modifier.width(40.dp * fontSize.scale).height(4.dp * fontSize.scale).background(Color.White.copy(alpha = 0.2f), CircleShape))
+                            }
+                        }
+                    }
+                } else {
+                    // Simpler App Drawer content with size scaling
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        Column(modifier = Modifier.padding(8.dp)) {
+                            Box(modifier = Modifier.fillMaxWidth().height(16.dp * fontSize.scale).background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(4.dp)))
+                            Spacer(modifier = Modifier.height(12.dp))
+                            
+                            val columns = when (iconSize) {
+                                IconSize.SMALL -> 5
+                                IconSize.STANDARD -> 4
+                                IconSize.LARGE -> 3
+                            }
+                            val dotSize = 10.dp * (iconSize.size / 48.dp)
+                            
+                            repeat(3) {
+                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+                                    repeat(columns) {
+                                        Box(modifier = Modifier.size(dotSize).border(1.dp, Color.White.copy(alpha = 0.7f), CircleShape))
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                            }
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -14,14 +14,17 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import com.example.androidlauncher.data.FontSize
+import com.example.androidlauncher.data.IconSize
 
 val LocalColorTheme = staticCompositionLocalOf { ColorTheme.LAUNCHER }
 val LocalFontSize = staticCompositionLocalOf { FontSize.STANDARD }
+val LocalIconSize = staticCompositionLocalOf { IconSize.STANDARD }
 
 @Composable
 fun AndroidLauncherTheme(
     colorTheme: ColorTheme = ColorTheme.LAUNCHER,
     fontSize: FontSize = FontSize.STANDARD,
+    iconSize: IconSize = IconSize.STANDARD,
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
@@ -44,7 +47,8 @@ fun AndroidLauncherTheme(
 
     CompositionLocalProvider(
         LocalColorTheme provides colorTheme,
-        LocalFontSize provides fontSize
+        LocalFontSize provides fontSize,
+        LocalIconSize provides iconSize
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -13,15 +13,17 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.example.androidlauncher.data.FontSize
 
 val LocalColorTheme = staticCompositionLocalOf { ColorTheme.LAUNCHER }
+val LocalFontSize = staticCompositionLocalOf { FontSize.STANDARD }
 
 @Composable
 fun AndroidLauncherTheme(
     colorTheme: ColorTheme = ColorTheme.LAUNCHER,
+    fontSize: FontSize = FontSize.STANDARD,
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = false, // Default to false to use our custom themes
+    dynamicColor: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val colorScheme = when {
@@ -40,7 +42,10 @@ fun AndroidLauncherTheme(
         }
     }
 
-    CompositionLocalProvider(LocalColorTheme provides colorTheme) {
+    CompositionLocalProvider(
+        LocalColorTheme provides colorTheme,
+        LocalFontSize provides fontSize
+    ) {
         MaterialTheme(
             colorScheme = colorScheme,
             typography = Typography,


### PR DESCRIPTION
# Größen- und Skalierungsmenü mit Live-Vorschau implementieren

## Beschreibung

Es soll ein eigenständiges Menü für die Anpassung von Schrift- und Icon-Größen implementiert werden.

Dieses Menü ist unabhängig vom Farbkonfigurations-Menü und soll über das Einstellungsmenü erreichbar sein.

Alle Änderungen sollen eine **Live-Vorschau** enthalten und direkt sichtbar sein, ohne dass eine Bestätigung erforderlich ist.

---

## Ziel

Nutzer sollen die allgemeine Darstellung des Launchers (Schrift- und Icon-Größe) unabhängig von der Farbwahl personalisieren können.

---

## Integration ins Einstellungsmenü

- [x] Neuer Menüpunkt „Größe & Skalierung“
- [x] Öffnet eine separate Konfigurationsseite
- [x] Keine Vermischung mit Farbkonfiguration

---

## Schriftgrößen-Presets

- [x] Vordefinierte Presets (z.B. Klein, Standard, Groß)
- [x] Beeinflusst:
  - [x] App-Namen
  - [x] Uhrzeit
  - [x] Datum
  - [x] Menütexte
- [x] Aktive Auswahl klar markiert
- [x] Live-Vorschau ohne Bestätigung

---

## Icon-Größen-Presets

- [x] Vordefinierte Presets (z.B. Klein, Standard, Groß)
- [x] Beeinflusst:
  - [x] Icons auf der Startseite
  - [x] Icons im AppDrawer
- [x] Grid passt sich automatisch an
- [x] Keine Überlappungen oder Layout-Breaks
- [x] Live-Vorschau ohne Bestätigung

---

## Live-Vorschau

- [x] Änderungen wirken sich sofort auf:
  - [x] Startseite
  - [x] AppDrawer
- [x] Kein zusätzlicher „Speichern“-Button notwendig
- [x] Optional: „Zurücksetzen auf Standardwerte“

---

## Technische Anforderungen

- [x] Zentrales UI-Scaling-Management
- [x] Skalierungsfaktoren als definierte Presets (z.B. multiplier)
- [x] Reaktive UI-Aktualisierung bei Änderung
- [x] Persistente Speicherung (z.B. DataStore)
- [x] Konsistente Skalierung für:
  - [x] Original-Icons
  - [x] Custom-Icons
  - [x] Lucide-Ersatz-Icons

---

## Akzeptanzkriterien

- Schriftgröße kann unabhängig von Farben angepasst werden
- Icon-Größe kann unabhängig von Farben angepasst werden
- Änderungen werden sofort sichtbar
- Einstellungen bleiben nach Neustart erhalten
- Layout bleibt stabil bei allen Presets
- Projekt buildet ohne Fehler

+ Farben der Themes werden auch von den Konfigurationsmenüs übernommen
