### PR TITLE
#17 🎬 Issue: Systemnahe Öffnungs- & Schließanimationen + AppDrawer Swipe-Verhalten

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,11 +5,19 @@
     <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
     <uses-permission android:name="android.permission.SET_WALLPAPER" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
 
     <queries>
         <intent>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+            <category android:name="android.intent.category.APP_CLOCK" />
+        </intent>
+        <intent>
+            <action android:name="android.provider.AlarmClock.ACTION_SHOW_ALARMS" />
         </intent>
     </queries>
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -165,7 +165,7 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(returnIconPackage) {
                     if (returnIconPackage != null) {
-                        delay(240)
+                        delay(160)
                         returnIconPackage = null
                     }
                 }
@@ -597,7 +597,7 @@ fun HomeScreen(
 
         val launchTransition = updateTransition(targetState = launchRequest != null, label = "HomeLaunchTransition")
         val launchProgress by launchTransition.animateFloat(
-            transitionSpec = { spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow) },
+            transitionSpec = { spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessMedium) },
             label = "HomeLaunchProgress"
         ) { isVisible ->
             if (isVisible) 1f else 0f

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -497,7 +497,7 @@ fun HomeScreen(
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
                 Spacer(modifier = Modifier.height(64.dp))
-                ClockHeader(onAppLaunchForReturn = onAppLaunchForReturn, onLaunchRequest = { launchRequest = it })
+                ClockHeader(onAppLaunchForReturn = onAppLaunchForReturn, onLaunchRequest = { launchRequest = it }, returnIconPackage = returnIconPackage)
 
                 Spacer(modifier = Modifier.weight(1f))
 
@@ -802,7 +802,8 @@ fun FavoritesConfigMenu(
 @Composable
 fun ClockHeader(
     onAppLaunchForReturn: (String, Rect?) -> Unit,
-    onLaunchRequest: (HomeLaunchRequest) -> Unit
+    onLaunchRequest: (HomeLaunchRequest) -> Unit,
+    returnIconPackage: String?
 ) {
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
@@ -822,6 +823,21 @@ fun ClockHeader(
     val intSrcDate = remember { MutableInteractionSource() }
     val clockBounds = remember { mutableStateOf<Rect?>(null) }
     val calendarBounds = remember { mutableStateOf<Rect?>(null) }
+
+    // Identifizieren der Pakete für die Return-Animation
+    var clockPackage by remember { mutableStateOf<String?>(null) }
+    var calendarPackage by remember { mutableStateOf<String?>(null) }
+
+    val bounceScaleTime by animateFloatAsState(
+        targetValue = if (returnIconPackage != null && returnIconPackage == clockPackage) 1.08f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "ClockReturnBounce"
+    )
+    val bounceScaleDate by animateFloatAsState(
+        targetValue = if (returnIconPackage != null && returnIconPackage == calendarPackage) 1.08f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "CalendarReturnBounce"
+    )
     
     Column(
         modifier = Modifier.fillMaxWidth()
@@ -834,6 +850,10 @@ fun ClockHeader(
             color = mainTextColor,
             modifier = Modifier
                 .onGloballyPositioned { clockBounds.value = it.boundsInRoot() }
+                .graphicsLayer {
+                    scaleX = bounceScaleTime
+                    scaleY = bounceScaleTime
+                }
                 .clip(RoundedCornerShape(8.dp))
                 .bounceClick(intSrcTime)
                 .clickable(
@@ -888,7 +908,7 @@ fun ClockHeader(
                         } catch (e: Exception) {}
                     }
 
-                    // 4. Weg: Aggressiver Scan aller installierten Apps
+                    // 4. Weg: Scan
                     if (foundPkg == null) {
                         try {
                             val apps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
@@ -902,13 +922,12 @@ fun ClockHeader(
                     }
 
                     if (foundPkg != null) {
+                        clockPackage = foundPkg
                         val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
                         if (launchIntent != null) {
                             launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
                             onAppLaunchForReturn(foundPkg, clockBounds.value)
                             onLaunchRequest(HomeLaunchRequest(foundPkg, clockBounds.value, launchIntent))
-                        } else {
-                            Toast.makeText(context, "App-Start fehlgeschlagen", Toast.LENGTH_SHORT).show()
                         }
                     } else {
                         Toast.makeText(context, "Uhr-App nicht gefunden", Toast.LENGTH_SHORT).show()
@@ -922,6 +941,10 @@ fun ClockHeader(
             color = mainTextColor.copy(alpha = 0.7f),
             modifier = Modifier
                 .onGloballyPositioned { calendarBounds.value = it.boundsInRoot() }
+                .graphicsLayer {
+                    scaleX = bounceScaleDate
+                    scaleY = bounceScaleDate
+                }
                 .clip(RoundedCornerShape(8.dp))
                 .bounceClick(intSrcDate)
                 .clickable(
@@ -940,13 +963,14 @@ fun ClockHeader(
                     
                     val foundPkg = pm.resolveActivity(calendarIntent, 0)?.activityInfo?.packageName
                     if (foundPkg != null) {
+                        calendarPackage = foundPkg
                         val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
                         if (launchIntent != null) {
                             launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
                             onAppLaunchForReturn(foundPkg, calendarBounds.value)
                             onLaunchRequest(HomeLaunchRequest(foundPkg, calendarBounds.value, launchIntent))
                         } else {
-                            calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
                             onAppLaunchForReturn(foundPkg, calendarBounds.value)
                             onLaunchRequest(HomeLaunchRequest(foundPkg, calendarBounds.value, calendarIntent))
                         }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -165,7 +165,7 @@ class MainActivity : ComponentActivity() {
 
                 LaunchedEffect(returnIconPackage) {
                     if (returnIconPackage != null) {
-                        delay(160)
+                        delay(300)
                         returnIconPackage = null
                     }
                 }
@@ -472,7 +472,7 @@ fun HomeScreen(
     LaunchedEffect(launchRequest) {
         val request = launchRequest ?: return@LaunchedEffect
         delay(280)
-        context.packageManager.getLaunchIntentForPackage(request.app.packageName)?.let {
+        request.intent?.let {
             launchAppNoTransition(context, it)
         }
         launchRequest = null
@@ -497,7 +497,7 @@ fun HomeScreen(
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
                 Spacer(modifier = Modifier.height(64.dp))
-                ClockHeader()
+                ClockHeader(onAppLaunchForReturn = onAppLaunchForReturn, onLaunchRequest = { launchRequest = it })
 
                 Spacer(modifier = Modifier.weight(1f))
 
@@ -545,7 +545,8 @@ fun HomeScreen(
                                     ) {
                                         if (launchRequest == null) {
                                             onAppLaunchForReturn(app.packageName, itemBounds.value)
-                                            launchRequest = HomeLaunchRequest(app, itemBounds.value)
+                                            val intent = context.packageManager.getLaunchIntentForPackage(app.packageName)
+                                            launchRequest = HomeLaunchRequest(app.packageName, itemBounds.value, intent)
                                         }
                                     }
                             ) {
@@ -660,9 +661,10 @@ fun HomeScreen(
     }
 }
 
-private data class HomeLaunchRequest(
-    val app: AppInfo,
-    val bounds: Rect?
+data class HomeLaunchRequest(
+    val packageName: String,
+    val bounds: Rect?,
+    val intent: Intent?
 )
 
 @Composable
@@ -798,7 +800,10 @@ fun FavoritesConfigMenu(
 }
 
 @Composable
-fun ClockHeader() {
+fun ClockHeader(
+    onAppLaunchForReturn: (String, Rect?) -> Unit,
+    onLaunchRequest: (HomeLaunchRequest) -> Unit
+) {
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
@@ -815,6 +820,8 @@ fun ClockHeader() {
     val dateFormat = SimpleDateFormat("EEEE, d. MMMM", Locale.getDefault())
     val intSrcTime = remember { MutableInteractionSource() }
     val intSrcDate = remember { MutableInteractionSource() }
+    val clockBounds = remember { mutableStateOf<Rect?>(null) }
+    val calendarBounds = remember { mutableStateOf<Rect?>(null) }
     
     Column(
         modifier = Modifier.fillMaxWidth()
@@ -826,56 +833,57 @@ fun ClockHeader() {
             letterSpacing = (-2).sp,
             color = mainTextColor,
             modifier = Modifier
+                .onGloballyPositioned { clockBounds.value = it.boundsInRoot() }
                 .clip(RoundedCornerShape(8.dp))
                 .bounceClick(intSrcTime)
                 .clickable(
                     interactionSource = intSrcTime,
                     indication = null
                 ) {
-                    var started = false
-                    try {
-                        val intent = Intent(Intent.ACTION_MAIN).apply {
-                            addCategory("android.intent.category.APP_CLOCK")
-                            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                        }
-                        context.startActivity(intent)
-                        started = true
-                    } catch (e: Exception) {}
-
-                    if (!started) {
+                    var clockIntent: Intent? = null
+                    
+                    // nubia spezifische App-Suche zuerst
+                    val packages = listOf(
+                        "cn.nubia.deskclock.preset", 
+                        "cn.nubia.deskclock",
+                        "com.android.deskclock",
+                        "com.google.android.deskclock",
+                        "com.sec.android.app.clockpackage",
+                        "com.huawei.android.clock",
+                        "com.miui.clock",
+                        "com.zte.deskclock"
+                    )
+                    
+                    for (pkg in packages) {
                         try {
-                            val intent = Intent(AlarmClock.ACTION_SHOW_ALARMS).apply {
-                                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            val launchIntent = context.packageManager.getLaunchIntentForPackage(pkg)
+                            if (launchIntent != null) {
+                                clockIntent = launchIntent
+                                break
                             }
-                            context.startActivity(intent)
-                            started = true
                         } catch (e: Exception) {}
                     }
 
-                    if (!started) {
-                        val packages = listOf(
-                            "com.google.android.deskclock",
-                            "com.android.deskclock",
-                            "com.sec.android.app.clockpackage",
-                            "com.huawei.android.clock",
-                            "com.miui.clock",
-                            "cn.nubia.deskclock.preset", 
-                            "cn.nubia.deskclock",
-                            "com.zte.deskclock"
-                        )
-                        for (pkg in packages) {
-                            try {
-                                val launchIntent = context.packageManager.getLaunchIntentForPackage(pkg)
-                                if (launchIntent != null) {
-                                    context.startActivity(launchIntent)
-                                    started = true
-                                    break
-                                }
-                            } catch (e: Exception) {}
-                        }
+                    if (clockIntent == null) {
+                        try {
+                            clockIntent = Intent(Intent.ACTION_MAIN).apply {
+                                addCategory("android.intent.category.APP_CLOCK")
+                                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            }
+                            if (context.packageManager.resolveActivity(clockIntent, 0) == null) { clockIntent = null }
+                        } catch (e: Exception) { clockIntent = null }
                     }
 
-                    if (!started) {
+                    if (clockIntent == null) {
+                        try {
+                            clockIntent = Intent(AlarmClock.ACTION_SHOW_ALARMS).apply {
+                                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            }
+                            if (context.packageManager.resolveActivity(clockIntent, 0) == null) { clockIntent = null }
+                        } catch (e: Exception) { clockIntent = null }
+                    }
+
+                    if (clockIntent == null) {
                         try {
                             val pm = context.packageManager
                             val apps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
@@ -886,13 +894,16 @@ fun ClockHeader() {
                                 pm.getLaunchIntentForPackage(it.packageName) != null
                             }
                             clockApp?.let {
-                                context.startActivity(pm.getLaunchIntentForPackage(it.packageName))
-                                started = true
+                                clockIntent = pm.getLaunchIntentForPackage(it.packageName)
                             }
                         } catch (e: Exception) {}
                     }
 
-                    if (!started) {
+                    if (clockIntent != null) {
+                        val pkg = clockIntent?.`package` ?: clockIntent?.component?.packageName ?: "clock"
+                        onAppLaunchForReturn(pkg, clockBounds.value)
+                        onLaunchRequest(HomeLaunchRequest(pkg, clockBounds.value, clockIntent))
+                    } else {
                         Toast.makeText(context, "Uhr-App nicht gefunden", Toast.LENGTH_SHORT).show()
                     }
                 }
@@ -903,26 +914,26 @@ fun ClockHeader() {
             fontWeight = FontWeight.Normal,
             color = mainTextColor.copy(alpha = 0.7f),
             modifier = Modifier
+                .onGloballyPositioned { calendarBounds.value = it.boundsInRoot() }
                 .clip(RoundedCornerShape(8.dp))
                 .bounceClick(intSrcDate)
                 .clickable(
                     interactionSource = intSrcDate,
                     indication = null
                 ) {
-                    val calendarIntent = Intent(Intent.ACTION_VIEW).apply {
+                    var calendarIntent = Intent(Intent.ACTION_VIEW).apply {
                         data = CalendarContract.CONTENT_URI.buildUpon().appendPath("time").appendPath(System.currentTimeMillis().toString()).build()
                         flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     }
-                    try {
-                        context.startActivity(calendarIntent)
-                    } catch (e: Exception) {
-                        val selectorIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
+                    if (context.packageManager.resolveActivity(calendarIntent, 0) == null) {
+                        calendarIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
                             flags = Intent.FLAG_ACTIVITY_NEW_TASK
                         }
-                        try {
-                            context.startActivity(selectorIntent)
-                        } catch (e2: Exception) {}
                     }
+                    
+                    val pkg = calendarIntent.`package` ?: calendarIntent.component?.packageName ?: "calendar"
+                    onAppLaunchForReturn(pkg, calendarBounds.value)
+                    onLaunchRequest(HomeLaunchRequest(pkg, calendarBounds.value, calendarIntent))
                 }
                 .padding(horizontal = 4.dp, vertical = 2.dp)
         )

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -841,7 +841,7 @@ fun ClockHeader(
                     indication = null
                 ) {
                     val pm = context.packageManager
-                    var clockIntent: Intent? = null
+                    var foundPkg: String? = null
                     
                     // 1. nubia & bekannte Pakete direkt probieren
                     val packages = listOf(
@@ -859,56 +859,57 @@ fun ClockHeader(
                     
                     for (pkg in packages) {
                         try {
-                            val li = pm.getLaunchIntentForPackage(pkg)
-                            if (li != null) {
-                                clockIntent = li
+                            if (pm.getLaunchIntentForPackage(pkg) != null) {
+                                foundPkg = pkg
                                 break
                             }
                         } catch (e: Exception) {}
                     }
 
-                    if (clockIntent == null) {
+                    // 2. Weg: Suche über Standard-Clock-Kategorie
+                    if (foundPkg == null) {
                         try {
                             val stdIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.APP_CLOCK")
                             val res = pm.resolveActivity(stdIntent, 0)
                             if (res != null) {
-                                clockIntent = pm.getLaunchIntentForPackage(res.activityInfo.packageName)
+                                foundPkg = res.activityInfo.packageName
                             }
                         } catch (e: Exception) {}
                     }
 
-                    if (clockIntent == null) {
+                    // 3. Weg: Suche über Alarm-Aktion
+                    if (foundPkg == null) {
                         try {
                             val alarmIntent = Intent(AlarmClock.ACTION_SHOW_ALARMS)
                             val res = pm.resolveActivity(alarmIntent, 0)
                             if (res != null) {
-                                clockIntent = pm.getLaunchIntentForPackage(res.activityInfo.packageName)
+                                foundPkg = res.activityInfo.packageName
                             }
                         } catch (e: Exception) {}
                     }
 
-                    if (clockIntent == null) {
+                    // 4. Weg: Aggressiver Scan aller installierten Apps
+                    if (foundPkg == null) {
                         try {
                             val apps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
                             val foundApp = apps.find { 
                                 val pkg = it.packageName.lowercase()
-                                val label = it.loadLabel(pm).toString().lowercase()
-                                (pkg.contains("deskclock") || pkg.contains("uhr") || pkg.contains("clock")) && 
+                                (pkg.contains("deskclock") || pkg.contains("uhr") || (pkg.contains("clock") && !pkg.contains("widget"))) && 
                                 pm.getLaunchIntentForPackage(it.packageName) != null
                             }
-                            foundApp?.let {
-                                clockIntent = pm.getLaunchIntentForPackage(it.packageName)
-                            }
+                            foundPkg = foundApp?.packageName
                         } catch (e: Exception) {}
                     }
 
-                    if (clockIntent != null) {
-                        // Wichtige Flags für Launcher-Starts
-                        clockIntent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-                        
-                        val pkg = clockIntent?.`package` ?: clockIntent?.component?.packageName ?: "clock"
-                        onAppLaunchForReturn(pkg, clockBounds.value)
-                        onLaunchRequest(HomeLaunchRequest(pkg, clockBounds.value, clockIntent))
+                    if (foundPkg != null) {
+                        val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
+                        if (launchIntent != null) {
+                            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                            onAppLaunchForReturn(foundPkg, clockBounds.value)
+                            onLaunchRequest(HomeLaunchRequest(foundPkg, clockBounds.value, launchIntent))
+                        } else {
+                            Toast.makeText(context, "App-Start fehlgeschlagen", Toast.LENGTH_SHORT).show()
+                        }
                     } else {
                         Toast.makeText(context, "Uhr-App nicht gefunden", Toast.LENGTH_SHORT).show()
                     }
@@ -927,19 +928,29 @@ fun ClockHeader(
                     interactionSource = intSrcDate,
                     indication = null
                 ) {
+                    val pm = context.packageManager
                     var calendarIntent = Intent(Intent.ACTION_VIEW).apply {
                         data = CalendarContract.CONTENT_URI.buildUpon().appendPath("time").appendPath(System.currentTimeMillis().toString()).build()
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-                    }
-                    if (context.packageManager.resolveActivity(calendarIntent, 0) == null) {
-                        calendarIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
-                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
-                        }
                     }
                     
-                    val pkg = calendarIntent.`package` ?: calendarIntent.component?.packageName ?: "calendar"
-                    onAppLaunchForReturn(pkg, calendarBounds.value)
-                    onLaunchRequest(HomeLaunchRequest(pkg, calendarBounds.value, calendarIntent))
+                    val res = pm.resolveActivity(calendarIntent, 0)
+                    if (res == null) {
+                        calendarIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR)
+                    }
+                    
+                    val foundPkg = pm.resolveActivity(calendarIntent, 0)?.activityInfo?.packageName
+                    if (foundPkg != null) {
+                        val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
+                        if (launchIntent != null) {
+                            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                            onAppLaunchForReturn(foundPkg, calendarBounds.value)
+                            onLaunchRequest(HomeLaunchRequest(foundPkg, calendarBounds.value, launchIntent))
+                        } else {
+                            calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            onAppLaunchForReturn(foundPkg, calendarBounds.value)
+                            onLaunchRequest(HomeLaunchRequest(foundPkg, calendarBounds.value, calendarIntent))
+                        }
+                    }
                 }
                 .padding(horizontal = 4.dp, vertical = 2.dp)
         )

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -51,13 +51,13 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
-import androidx.core.graphics.drawable.toBitmap
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
@@ -77,9 +77,15 @@ import com.example.androidlauncher.ui.AppIconView
 import com.example.androidlauncher.ui.bounceClick
 import com.example.androidlauncher.ui.FolderConfigMenu
 import com.example.androidlauncher.ui.launchAppNoTransition
+import com.example.androidlauncher.ui.ReturnAnimationOverlay
+import com.example.androidlauncher.LaunchSource
+import com.example.androidlauncher.ReturnAnimation
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import java.text.SimpleDateFormat
 import java.util.*
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.core.graphics.drawable.toBitmap
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -123,16 +129,50 @@ class MainActivity : ComponentActivity() {
                 iconSize = currentIconSize,
                 darkTextEnabled = isDarkTextEnabled
             ) {
+                val lifecycleOwner = LocalLifecycleOwner.current
+                var rootSize by remember { mutableStateOf(IntSize.Zero) }
+                var pendingReturnAnimation by remember { mutableStateOf<ReturnAnimation?>(null) }
+                var activeReturnAnimation by remember { mutableStateOf<ReturnAnimation?>(null) }
+                var returnIconPackage by remember { mutableStateOf<String?>(null) }
                 var isDrawerOpen by remember { mutableStateOf(false) }
                 var isSettingsOpen by remember { mutableStateOf(false) }
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
                 var isColorConfigOpen by remember { mutableStateOf(false) }
                 var isSizeConfigOpen by remember { mutableStateOf(false) }
                 var selectedFolderForConfig by remember { mutableStateOf<FolderInfo?>(null) }
-                
+
+                DisposableEffect(lifecycleOwner) {
+                    val observer = LifecycleEventObserver { _, event ->
+                        if (event == Lifecycle.Event.ON_RESUME) {
+                            pendingReturnAnimation?.let {
+                                isDrawerOpen = it.source == LaunchSource.DRAWER
+                                if (!isDrawerOpen) {
+                                    isSettingsOpen = false
+                                    isFavoritesConfigOpen = false
+                                    isColorConfigOpen = false
+                                    isSizeConfigOpen = false
+                                    selectedFolderForConfig = null
+                                }
+                                activeReturnAnimation = it
+                                returnIconPackage = it.packageName
+                                pendingReturnAnimation = null
+                            }
+                        }
+                    }
+                    lifecycleOwner.lifecycle.addObserver(observer)
+                    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+                }
+
+                LaunchedEffect(returnIconPackage) {
+                    if (returnIconPackage != null) {
+                        delay(240)
+                        returnIconPackage = null
+                    }
+                }
+
                 val allApps = remember { mutableStateListOf<AppInfo>() }
                 var favoritePackages by remember { mutableStateOf(getSavedFavorites(context)) }
-                
+
                 val favorites = remember(allApps.toList(), favoritePackages) {
                     LauncherLogic.getFavoriteApps(allApps.toList(), favoritePackages)
                 }
@@ -186,41 +226,48 @@ class MainActivity : ComponentActivity() {
                     else if (isSizeConfigOpen) isSizeConfigOpen = false
                 }
 
-                Box(modifier = Modifier.fillMaxSize()) {
+                Box(
+                    modifier = Modifier.fillMaxSize()
+                        .onGloballyPositioned { rootSize = it.size }
+                ) {
                     SystemWallpaperView()
 
                     AnimatedContent(
-                        targetState = isDrawerOpen,
-                        transitionSpec = {
-                            if (targetState) {
-                                (slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)))
-                                    .togetherWith(fadeOut(animationSpec = tween(200)))
-                            } else {
-                                fadeIn(animationSpec = tween(200))
-                                    .togetherWith(slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200)))
-                            }
-                        },
-                        label = "DrawerTransition"
-                    ) { targetIsDrawerOpen ->
-                        if (targetIsDrawerOpen) {
-                            AppDrawer(
-                                apps = allApps,
-                                folders = folders,
-                                onToggleFavorite = { pkg ->
-                                    val newFavs = LauncherLogic.toggleFavorite(favoritePackages, pkg)
-                                    if (newFavs != favoritePackages) {
-                                        saveFavorites(context, newFavs)
-                                        favoritePackages = newFavs
-                                    }
-                                },
-                                isFavorite = { pkg -> pkg in favoritePackages },
-                                onUpdateFolders = { newFolders ->
-                                    scope.launch { folderManager.saveFolders(newFolders) }
-                                },
-                                onOpenFolderConfig = { folder ->
-                                    selectedFolderForConfig = folder
-                                },
-                                onClose = { isDrawerOpen = false }
+                         targetState = isDrawerOpen,
+                         transitionSpec = {
+                             if (targetState) {
+                                 (slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(animationSpec = tween(200)))
+                                     .togetherWith(fadeOut(animationSpec = tween(200)))
+                             } else {
+                                 fadeIn(animationSpec = tween(200))
+                                     .togetherWith(slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut(animationSpec = tween(200)))
+                             }
+                         },
+                         label = "DrawerTransition"
+                     ) { targetIsDrawerOpen ->
+                         if (targetIsDrawerOpen) {
+                             AppDrawer(
+                                 apps = allApps,
+                                 folders = folders,
+                                 onToggleFavorite = { pkg ->
+                                     val newFavs = LauncherLogic.toggleFavorite(favoritePackages, pkg)
+                                     if (newFavs != favoritePackages) {
+                                         saveFavorites(context, newFavs)
+                                         favoritePackages = newFavs
+                                     }
+                                 },
+                                 isFavorite = { pkg -> pkg in favoritePackages },
+                                 onUpdateFolders = { newFolders ->
+                                     scope.launch { folderManager.saveFolders(newFolders) }
+                                 },
+                                 onOpenFolderConfig = { folder ->
+                                     selectedFolderForConfig = folder
+                                 },
+                                 onClose = { isDrawerOpen = false },
+                                 onAppLaunchForReturn = { pkg, bounds ->
+                                    pendingReturnAnimation = ReturnAnimation(bounds, LaunchSource.DRAWER, pkg)
+                                 },
+                                 returnIconPackage = returnIconPackage
                             )
                         } else {
                             HomeScreen(
@@ -230,94 +277,108 @@ class MainActivity : ComponentActivity() {
                                 onToggleSettings = { isSettingsOpen = !isSettingsOpen },
                                 onOpenFavoritesConfig = { isFavoritesConfigOpen = true },
                                 onOpenColorConfig = { isColorConfigOpen = true },
-                                onOpenSizeConfig = { isSizeConfigOpen = true }
+                                onOpenSizeConfig = { isSizeConfigOpen = true },
+                                onAppLaunchForReturn = { pkg, bounds ->
+                                    pendingReturnAnimation = ReturnAnimation(bounds, LaunchSource.HOME, pkg)
+                                },
+                                returnIconPackage = returnIconPackage
                             )
                         }
-                    }
+                     }
 
                     AnimatedVisibility(
-                        visible = isFavoritesConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
-                            FavoritesConfigMenu(
-                                apps = allApps,
-                                initialFavoritePackages = favoritePackages,
-                                onConfirm = { newFavs ->
-                                    saveFavorites(context, newFavs)
-                                    favoritePackages = newFavs
-                                    isFavoritesConfigOpen = false
-                                },
-                                onClose = { isFavoritesConfigOpen = false }
-                            )
-                        }
-                    }
+                         visible = isFavoritesConfigOpen,
+                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                     ) {
+                         Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
+                             FavoritesConfigMenu(
+                                 apps = allApps,
+                                 initialFavoritePackages = favoritePackages,
+                                 onConfirm = { newFavs ->
+                                     saveFavorites(context, newFavs)
+                                     favoritePackages = newFavs
+                                     isFavoritesConfigOpen = false
+                                 },
+                                 onClose = { isFavoritesConfigOpen = false }
+                             )
+                         }
+                     }
 
                     AnimatedVisibility(
-                        visible = selectedFolderForConfig != null,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
-                    ) {
-                        selectedFolderForConfig?.let { folder ->
-                            Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
-                                FolderConfigMenu(
-                                    folder = folder,
-                                    allApps = allApps,
-                                    onConfirm = { updatedFolder ->
-                                        val newFolders = folders.map { if (it.id == updatedFolder.id) updatedFolder else it }
-                                        scope.launch { folderManager.saveFolders(newFolders) }
-                                        selectedFolderForConfig = null
-                                    },
-                                    onDelete = { folderId ->
-                                        val newFolders = folders.filter { it.id != folderId }
-                                        scope.launch { folderManager.saveFolders(newFolders) }
-                                        selectedFolderForConfig = null
-                                    },
-                                    onClose = { selectedFolderForConfig = null }
-                                )
-                            }
-                        }
-                    }
+                         visible = selectedFolderForConfig != null,
+                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                     ) {
+                         selectedFolderForConfig?.let { folder ->
+                             Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
+                                 FolderConfigMenu(
+                                     folder = folder,
+                                     allApps = allApps,
+                                     onConfirm = { updatedFolder ->
+                                         val newFolders = folders.map { if (it.id == updatedFolder.id) updatedFolder else it }
+                                         scope.launch { folderManager.saveFolders(newFolders) }
+                                         selectedFolderForConfig = null
+                                     },
+                                     onDelete = { folderId ->
+                                         val newFolders = folders.filter { it.id != folderId }
+                                         scope.launch { folderManager.saveFolders(newFolders) }
+                                         selectedFolderForConfig = null
+                                     },
+                                     onClose = { selectedFolderForConfig = null }
+                                 )
+                             }
+                         }
+                     }
 
                     AnimatedVisibility(
-                        visible = isColorConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
-                            ColorConfigMenu(
-                                selectedTheme = currentTheme,
-                                onThemeSelected = { theme ->
-                                    scope.launch { themeManager.setTheme(theme) }
-                                },
-                                isDarkTextEnabled = isDarkTextEnabled,
-                                onDarkTextToggled = { enabled ->
-                                    scope.launch { themeManager.setDarkTextEnabled(enabled) }
-                                },
-                                onClose = { isColorConfigOpen = false }
-                            )
-                        }
-                    }
+                         visible = isColorConfigOpen,
+                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                     ) {
+                         Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
+                             ColorConfigMenu(
+                                 selectedTheme = currentTheme,
+                                 onThemeSelected = { theme ->
+                                     scope.launch { themeManager.setTheme(theme) }
+                                 },
+                                 isDarkTextEnabled = isDarkTextEnabled,
+                                 onDarkTextToggled = { enabled ->
+                                     scope.launch { themeManager.setDarkTextEnabled(enabled) }
+                                 },
+                                 onClose = { isColorConfigOpen = false }
+                             )
+                         }
+                     }
 
                     AnimatedVisibility(
-                        visible = isSizeConfigOpen,
-                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
-                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
-                            SizeConfigMenu(
-                                currentFontSize = currentFontSize,
-                                onFontSizeSelected = { size ->
-                                    scope.launch { themeManager.setFontSize(size) }
-                                },
-                                currentIconSize = currentIconSize,
-                                onIconSizeSelected = { size ->
-                                    scope.launch { themeManager.setIconSize(size) }
-                                },
-                                onClose = { isSizeConfigOpen = false }
-                            )
-                        }
+                         visible = isSizeConfigOpen,
+                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                     ) {
+                         Box(modifier = Modifier.fillMaxSize().background(currentTheme.drawerBackground)) {
+                             SizeConfigMenu(
+                                 currentFontSize = currentFontSize,
+                                 onFontSizeSelected = { size ->
+                                     scope.launch { themeManager.setFontSize(size) }
+                                 },
+                                 currentIconSize = currentIconSize,
+                                 onIconSizeSelected = { size ->
+                                     scope.launch { themeManager.setIconSize(size) }
+                                 },
+                                 onClose = { isSizeConfigOpen = false }
+                             )
+                         }
+                     }
+
+                    activeReturnAnimation?.let { animation ->
+                        ReturnAnimationOverlay(
+                            bounds = animation.bounds,
+                            rootSize = rootSize,
+                            background = currentTheme.drawerBackground,
+                            onFinished = { activeReturnAnimation = null },
+                            targetScale = if (animation.source == LaunchSource.DRAWER) 0.65f else 0.7f
+                        )
                     }
                 }
             }
@@ -388,7 +449,9 @@ fun HomeScreen(
     onToggleSettings: () -> Unit,
     onOpenFavoritesConfig: () -> Unit,
     onOpenColorConfig: () -> Unit,
-    onOpenSizeConfig: () -> Unit
+    onOpenSizeConfig: () -> Unit,
+    onAppLaunchForReturn: (String, Rect?) -> Unit,
+    returnIconPackage: String?
 ) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
@@ -459,6 +522,14 @@ fun HomeScreen(
                     } else {
                         favorites.forEach { app ->
                             val intSrc = remember { MutableInteractionSource() }
+                            val bounceScale by animateFloatAsState(
+                                targetValue = if (returnIconPackage == app.packageName) 1.12f else 1f,
+                                animationSpec = spring(
+                                    dampingRatio = Spring.DampingRatioMediumBouncy,
+                                    stiffness = Spring.StiffnessMedium
+                                ),
+                                label = "HomeReturnBounce"
+                            )
                             val itemBounds = remember(app.packageName) { mutableStateOf<Rect?>(null) }
                             Surface(
                                 color = Color.Transparent,
@@ -473,11 +544,17 @@ fun HomeScreen(
                                         indication = null
                                     ) {
                                         if (launchRequest == null) {
+                                            onAppLaunchForReturn(app.packageName, itemBounds.value)
                                             launchRequest = HomeLaunchRequest(app, itemBounds.value)
                                         }
                                     }
                             ) {
-                                Box(modifier = Modifier.padding(6.dp)) { AppIconView(app) }
+                                Box(modifier = Modifier.padding(6.dp).graphicsLayer {
+                                    scaleX = bounceScale
+                                    scaleY = bounceScale
+                                }) {
+                                    AppIconView(app)
+                                }
                             }
                         }
                     }
@@ -520,7 +597,7 @@ fun HomeScreen(
 
         val launchTransition = updateTransition(targetState = launchRequest != null, label = "HomeLaunchTransition")
         val launchProgress by launchTransition.animateFloat(
-            transitionSpec = { tween(durationMillis = 280, easing = FastOutSlowInEasing) },
+            transitionSpec = { spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow) },
             label = "HomeLaunchProgress"
         ) { isVisible ->
             if (isVisible) 1f else 0f

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -46,16 +46,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.*
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
 import androidx.core.graphics.drawable.toBitmap
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
@@ -75,6 +79,7 @@ import com.example.androidlauncher.ui.AppDrawer
 import com.example.androidlauncher.ui.AppIconView
 import com.example.androidlauncher.ui.bounceClick
 import com.example.androidlauncher.ui.FolderConfigMenu
+import com.example.androidlauncher.ui.launchAppNoTransition
 import java.text.SimpleDateFormat
 import java.util.*
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -84,6 +89,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.math.max
 
 class MainActivity : ComponentActivity() {
     // OnBackPressedCallback als Instanzvariable um ihn später zu steuern
@@ -385,113 +391,207 @@ fun SystemWallpaperView() {
 
 @Composable
 fun HomeScreen(
-    favorites: List<AppInfo>, 
+    favorites: List<AppInfo>,
     isSettingsOpen: Boolean,
-    onOpenDrawer: () -> Unit, 
+    onOpenDrawer: () -> Unit,
     onToggleSettings: () -> Unit,
     onOpenFavoritesConfig: () -> Unit,
     onOpenColorConfig: () -> Unit,
     onOpenSizeConfig: () -> Unit
 ) {
     val context = LocalContext.current
+    val colorTheme = LocalColorTheme.current
+    var rootSize by remember { mutableStateOf(IntSize.Zero) }
+    var launchRequest by remember { mutableStateOf<HomeLaunchRequest?>(null) }
     val rotation by animateFloatAsState(
         targetValue = if (isSettingsOpen) 180f else 0f,
         animationSpec = tween(300, easing = EaseInOutCubic)
     )
-    
+
     val settingsButtonSize by animateDpAsState(
         targetValue = if (isSettingsOpen) 72.dp else 56.dp,
         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
     )
 
+    LaunchedEffect(launchRequest) {
+        val request = launchRequest ?: return@LaunchedEffect
+        delay(280)
+        context.packageManager.getLaunchIntentForPackage(request.app.packageName)?.let {
+            launchAppNoTransition(context, it)
+        }
+        launchRequest = null
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
             .testTag("home_screen")
+            .onGloballyPositioned { rootSize = it.size }
             .pointerInput(Unit) {
                 detectVerticalDragGestures { _, dragAmount ->
                     if (dragAmount < -50) onOpenDrawer()
                     else if (dragAmount > 50) expandNotifications(context)
                 }
             }
-            .padding(24.dp)
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            Spacer(modifier = Modifier.height(64.dp))
-            ClockHeader()
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(24.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                Spacer(modifier = Modifier.height(64.dp))
+                ClockHeader()
 
-            Spacer(modifier = Modifier.weight(1f))
+                Spacer(modifier = Modifier.weight(1f))
 
-            Column(
-                verticalArrangement = Arrangement.spacedBy(12.dp),
-                modifier = Modifier.padding(start = 12.dp)
-            ) {
-                if (favorites.isEmpty()) {
-                    val intSrc = remember { MutableInteractionSource() }
-                    Surface(
-                        color = Color.White.copy(alpha = 0.1f),
-                        shape = CircleShape,
-                        modifier = Modifier.size(56.dp).bounceClick(intSrc).clickable(
-                            interactionSource = intSrc,
-                            indication = null
-                        ) { onOpenFavoritesConfig() }
-                    ) {
-                        Box(contentAlignment = Alignment.Center) { Icon(Icons.Default.Add, contentDescription = null, tint = Color.White) }
-                    }
-                } else {
-                    favorites.forEach { app ->
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                    modifier = Modifier.padding(start = 12.dp)
+                ) {
+                    if (favorites.isEmpty()) {
                         val intSrc = remember { MutableInteractionSource() }
                         Surface(
-                            color = Color.Transparent,
-                            shape = RoundedCornerShape(12.dp),
-                            modifier = Modifier.bounceClick(intSrc).clickable(
+                            color = Color.White.copy(alpha = 0.1f),
+                            shape = CircleShape,
+                            modifier = Modifier.size(56.dp).bounceClick(intSrc).clickable(
                                 interactionSource = intSrc,
                                 indication = null
-                            ) {
-                                context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
-                            }
+                            ) { onOpenFavoritesConfig() }
                         ) {
-                            Box(modifier = Modifier.padding(6.dp)) { AppIconView(app) }
+                            Box(contentAlignment = Alignment.Center) { Icon(Icons.Default.Add, contentDescription = null, tint = Color.White) }
+                        }
+                    } else {
+                        favorites.forEach { app ->
+                            val intSrc = remember { MutableInteractionSource() }
+                            val itemBounds = remember(app.packageName) { mutableStateOf<Rect?>(null) }
+                            Surface(
+                                color = Color.Transparent,
+                                shape = RoundedCornerShape(12.dp),
+                                modifier = Modifier
+                                    .onGloballyPositioned { coordinates ->
+                                        itemBounds.value = coordinates.boundsInRoot()
+                                    }
+                                    .bounceClick(intSrc)
+                                    .clickable(
+                                        interactionSource = intSrc,
+                                        indication = null
+                                    ) {
+                                        if (launchRequest == null) {
+                                            launchRequest = HomeLaunchRequest(app, itemBounds.value)
+                                        }
+                                    }
+                            ) {
+                                Box(modifier = Modifier.padding(6.dp)) { AppIconView(app) }
+                            }
                         }
                     }
                 }
+                Spacer(modifier = Modifier.weight(1f))
             }
-            Spacer(modifier = Modifier.weight(1f))
+
+            SettingsPaletteMenu(
+                isSettingsOpen = isSettingsOpen,
+                onToggleSettings = onToggleSettings,
+                onOpenFavoritesConfig = onOpenFavoritesConfig,
+                onOpenColorConfig = onOpenColorConfig,
+                onOpenSizeConfig = onOpenSizeConfig,
+                onOpenSystemSettings = { context.startActivity(Intent(Settings.ACTION_SETTINGS)) },
+                onOpenInfo = { /* Action */ }
+            )
+
+            Box(modifier = Modifier.fillMaxSize().navigationBarsPadding(), contentAlignment = Alignment.BottomEnd) {
+                val intSrc = remember { MutableInteractionSource() }
+                Surface(
+                    modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).bounceClick(intSrc).clickable(
+                        interactionSource = intSrc,
+                        indication = null
+                    ) { onToggleSettings() },
+                    color = Color.White.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f),
+                    shape = CircleShape,
+                    border = if (isSettingsOpen) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null
+                ) {
+                    Box(contentAlignment = Alignment.Center, modifier = Modifier.rotate(rotation)) {
+                        Icon(
+                            imageVector = if (isSettingsOpen) Icons.Default.Close else Icons.Default.Settings,
+                            contentDescription = null,
+                            tint = Color.White,
+                            modifier = Modifier.size(if (isSettingsOpen) 32.dp else 28.dp)
+                        )
+                    }
+                }
+            }
         }
 
-        SettingsPaletteMenu(
-            isSettingsOpen = isSettingsOpen,
-            onToggleSettings = onToggleSettings,
-            onOpenFavoritesConfig = onOpenFavoritesConfig,
-            onOpenColorConfig = onOpenColorConfig,
-            onOpenSizeConfig = onOpenSizeConfig,
-            onOpenSystemSettings = { context.startActivity(Intent(Settings.ACTION_SETTINGS)) },
-            onOpenInfo = { /* Action */ }
-        )
+        val launchTransition = updateTransition(targetState = launchRequest != null, label = "HomeLaunchTransition")
+        val launchProgress by launchTransition.animateFloat(
+            transitionSpec = { tween(durationMillis = 280, easing = FastOutSlowInEasing) },
+            label = "HomeLaunchProgress"
+        ) { isVisible ->
+            if (isVisible) 1f else 0f
+        }
+        val launchOverlayAlpha by launchTransition.animateFloat(
+            transitionSpec = { tween(durationMillis = 220, easing = LinearEasing) },
+            label = "HomeLaunchOverlayAlpha"
+        ) { isVisible ->
+            if (isVisible) 1f else 0f
+        }
+        val launchBounds = launchRequest?.bounds
+        val launchTranslation = remember(launchBounds, rootSize) {
+            if (launchBounds != null && rootSize.width > 0 && rootSize.height > 0) {
+                val centerX = rootSize.width / 2f
+                val centerY = rootSize.height / 2f
+                Offset(launchBounds.center.x - centerX, launchBounds.center.y - centerY)
+            } else {
+                Offset.Zero
+            }
+        }
+        val launchStartScale = remember(launchBounds, rootSize) {
+            if (launchBounds != null && rootSize.width > 0 && rootSize.height > 0) {
+                val wScale = launchBounds.width / rootSize.width.toFloat()
+                val hScale = launchBounds.height / rootSize.height.toFloat()
+                max(wScale, hScale).coerceIn(0.06f, 0.35f)
+            } else {
+                0.08f
+            }
+        }
 
-        Box(modifier = Modifier.fillMaxSize().navigationBarsPadding(), contentAlignment = Alignment.BottomEnd) {
-            val intSrc = remember { MutableInteractionSource() }
-            Surface(
-                modifier = Modifier.padding(8.dp).size(settingsButtonSize).clip(CircleShape).bounceClick(intSrc).clickable(
-                    interactionSource = intSrc,
-                    indication = null
-                ) { onToggleSettings() }, 
-                color = Color.White.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f), 
-                shape = CircleShape,
-                border = if (isSettingsOpen) BorderStroke(1.dp, Color.White.copy(alpha = 0.2f)) else null
-            ) {
-                Box(contentAlignment = Alignment.Center, modifier = Modifier.rotate(rotation)) {
-                    Icon(
-                        imageVector = if (isSettingsOpen) Icons.Default.Close else Icons.Default.Settings, 
-                        contentDescription = null, 
-                        tint = Color.White, 
-                        modifier = Modifier.size(if (isSettingsOpen) 32.dp else 28.dp)
+        if (launchProgress > 0f) {
+            val scale = launchStartScale + (1f - launchStartScale) * launchProgress
+            val translationX = launchTranslation.x * (1f - launchProgress)
+            val translationY = launchTranslation.y * (1f - launchProgress)
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(2000f)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {}
                     )
-                }
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            this.scaleX = scale
+                            this.scaleY = scale
+                            this.translationX = translationX
+                            this.translationY = translationY
+                            this.transformOrigin = TransformOrigin.Center
+                            this.alpha = launchOverlayAlpha
+                        }
+                        .background(colorTheme.drawerBackground)
+                )
             }
         }
     }
 }
+
+private data class HomeLaunchRequest(
+    val app: AppInfo,
+    val bounds: Rect?
+)
 
 @Composable
 fun FavoritesConfigMenu(

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -840,25 +840,28 @@ fun ClockHeader(
                     interactionSource = intSrcTime,
                     indication = null
                 ) {
+                    val pm = context.packageManager
                     var clockIntent: Intent? = null
                     
-                    // nubia spezifische App-Suche zuerst
+                    // 1. nubia & bekannte Pakete direkt probieren
                     val packages = listOf(
                         "cn.nubia.deskclock.preset", 
                         "cn.nubia.deskclock",
+                        "cn.nubia.clock",
                         "com.android.deskclock",
                         "com.google.android.deskclock",
                         "com.sec.android.app.clockpackage",
                         "com.huawei.android.clock",
                         "com.miui.clock",
-                        "com.zte.deskclock"
+                        "com.zte.deskclock",
+                        "com.android.clock"
                     )
                     
                     for (pkg in packages) {
                         try {
-                            val launchIntent = context.packageManager.getLaunchIntentForPackage(pkg)
-                            if (launchIntent != null) {
-                                clockIntent = launchIntent
+                            val li = pm.getLaunchIntentForPackage(pkg)
+                            if (li != null) {
+                                clockIntent = li
                                 break
                             }
                         } catch (e: Exception) {}
@@ -866,40 +869,43 @@ fun ClockHeader(
 
                     if (clockIntent == null) {
                         try {
-                            clockIntent = Intent(Intent.ACTION_MAIN).apply {
-                                addCategory("android.intent.category.APP_CLOCK")
-                                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            val stdIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.APP_CLOCK")
+                            val res = pm.resolveActivity(stdIntent, 0)
+                            if (res != null) {
+                                clockIntent = pm.getLaunchIntentForPackage(res.activityInfo.packageName)
                             }
-                            if (context.packageManager.resolveActivity(clockIntent, 0) == null) { clockIntent = null }
-                        } catch (e: Exception) { clockIntent = null }
+                        } catch (e: Exception) {}
                     }
 
                     if (clockIntent == null) {
                         try {
-                            clockIntent = Intent(AlarmClock.ACTION_SHOW_ALARMS).apply {
-                                flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            val alarmIntent = Intent(AlarmClock.ACTION_SHOW_ALARMS)
+                            val res = pm.resolveActivity(alarmIntent, 0)
+                            if (res != null) {
+                                clockIntent = pm.getLaunchIntentForPackage(res.activityInfo.packageName)
                             }
-                            if (context.packageManager.resolveActivity(clockIntent, 0) == null) { clockIntent = null }
-                        } catch (e: Exception) { clockIntent = null }
+                        } catch (e: Exception) {}
                     }
 
                     if (clockIntent == null) {
                         try {
-                            val pm = context.packageManager
                             val apps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
-                            val clockApp = apps.find { 
-                                val label = it.loadLabel(pm).toString().lowercase()
+                            val foundApp = apps.find { 
                                 val pkg = it.packageName.lowercase()
-                                (pkg.contains("clock") || pkg.contains("deskclock") || label.contains("uhr") || label.contains("clock")) && 
+                                val label = it.loadLabel(pm).toString().lowercase()
+                                (pkg.contains("deskclock") || pkg.contains("uhr") || pkg.contains("clock")) && 
                                 pm.getLaunchIntentForPackage(it.packageName) != null
                             }
-                            clockApp?.let {
+                            foundApp?.let {
                                 clockIntent = pm.getLaunchIntentForPackage(it.packageName)
                             }
                         } catch (e: Exception) {}
                     }
 
                     if (clockIntent != null) {
+                        // Wichtige Flags für Launcher-Starts
+                        clockIntent?.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+                        
                         val pkg = clockIntent?.`package` ?: clockIntent?.component?.packageName ?: "clock"
                         onAppLaunchForReturn(pkg, clockBounds.value)
                         onLaunchRequest(HomeLaunchRequest(pkg, clockBounds.value, clockIntent))
@@ -923,11 +929,11 @@ fun ClockHeader(
                 ) {
                     var calendarIntent = Intent(Intent.ACTION_VIEW).apply {
                         data = CalendarContract.CONTENT_URI.buildUpon().appendPath("time").appendPath(System.currentTimeMillis().toString()).build()
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
                     }
                     if (context.packageManager.resolveActivity(calendarIntent, 0) == null) {
                         calendarIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
-                            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED
                         }
                     }
                     

--- a/app/src/main/java/com/example/androidlauncher/ReturnAnimation.kt
+++ b/app/src/main/java/com/example/androidlauncher/ReturnAnimation.kt
@@ -1,0 +1,12 @@
+package com.example.androidlauncher
+
+enum class LaunchSource {
+    HOME,
+    DRAWER
+}
+
+data class ReturnAnimation(
+    val bounds: androidx.compose.ui.geometry.Rect?,
+    val source: LaunchSource,
+    val packageName: String
+)

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.LocalOverscrollConfiguration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -42,6 +44,9 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
@@ -55,6 +60,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
@@ -91,7 +97,7 @@ fun AppDrawer(
     val keyboardController = LocalSoftwareKeyboardController.current
     val density = LocalDensity.current
     val haptic = LocalHapticFeedback.current
-    
+
     var searchQuery by remember { mutableStateOf("") }
 
     val visibleApps = remember(apps.toList(), folders, searchQuery) {
@@ -240,35 +246,78 @@ fun AppDrawer(
                 IconSize.LARGE -> 3
             }
 
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(adaptiveColumns),
-                modifier = Modifier.fillMaxSize(),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalArrangement = Arrangement.spacedBy(32.dp),
-                contentPadding = PaddingValues(bottom = 32.dp)
-            ) {
-                if (searchQuery.isBlank()) {
-                    itemsIndexed(items = folders, key = { _, folder -> folder.id }) { _, folder ->
-                        FolderItem(
-                            folder = folder, 
-                            onClick = { pos -> 
-                                folderPosition = pos
-                                activeFolderId = folder.id 
-                            }, 
-                            onOpenFolderConfig = onOpenFolderConfig
-                        )
+            val gridState = rememberLazyGridState()
+            var swipeDragY by remember { mutableStateOf(0f) }
+            val swipeCloseThresholdPx = with(density) { 64.dp.toPx() }
+            val swipeToCloseConnection = remember(gridState, swipeCloseThresholdPx, onClose) {
+                object : NestedScrollConnection {
+                    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                        val atTop = gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
+                        if (source == NestedScrollSource.UserInput && atTop && available.y > 0f) {
+                            swipeDragY += available.y
+                            if (swipeDragY >= swipeCloseThresholdPx) {
+                                swipeDragY = 0f
+                                onClose()
+                            }
+                            return Offset(0f, available.y)
+                        }
+                        if (!atTop || available.y < 0f) {
+                            swipeDragY = 0f
+                        }
+                        return Offset.Zero
+                    }
+
+                    override suspend fun onPreFling(available: Velocity): Velocity {
+                        val atTop = gridState.firstVisibleItemIndex == 0 && gridState.firstVisibleItemScrollOffset == 0
+                        if (atTop && available.y > 1500f) {
+                            swipeDragY = 0f
+                            onClose()
+                            return available
+                        }
+                        return Velocity.Zero
+                    }
+
+                    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                        swipeDragY = 0f
+                        return Velocity.Zero
                     }
                 }
+            }
 
-                itemsIndexed(items = visibleApps, key = { _, app -> app.packageName }) { _, app ->
-                    AppItem(
-                        app = app,
-                        adaptiveColumns = adaptiveColumns,
-                        isFavorite = isFavorite(app.packageName),
-                        onToggleFavorite = onToggleFavorite,
-                        folders = folders,
-                        onUpdateFolders = onUpdateFolders
-                    )
+            CompositionLocalProvider(LocalOverscrollConfiguration provides null) {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(adaptiveColumns),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .nestedScroll(swipeToCloseConnection),
+                    state = gridState,
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalArrangement = Arrangement.spacedBy(32.dp),
+                    contentPadding = PaddingValues(bottom = 32.dp)
+                ) {
+                    if (searchQuery.isBlank()) {
+                        itemsIndexed(items = folders, key = { _, folder -> folder.id }) { _, folder ->
+                            FolderItem(
+                                folder = folder,
+                                onClick = { pos ->
+                                    folderPosition = pos
+                                    activeFolderId = folder.id
+                            },
+                            onOpenFolderConfig = onOpenFolderConfig
+                            )
+                        }
+                    }
+
+                    itemsIndexed(items = visibleApps, key = { _, app -> app.packageName }) { _, app ->
+                        AppItem(
+                            app = app,
+                            adaptiveColumns = adaptiveColumns,
+                            isFavorite = isFavorite(app.packageName),
+                            onToggleFavorite = onToggleFavorite,
+                            folders = folders,
+                            onUpdateFolders = onUpdateFolders
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -344,7 +344,7 @@ fun AppDrawer(
 
         val launchTransition = updateTransition(targetState = launchRequest != null, label = "LaunchTransition")
         val launchProgress by launchTransition.animateFloat(
-            transitionSpec = { spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow) },
+            transitionSpec = { spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessMedium) },
             label = "LaunchProgress"
         ) { isVisible ->
             if (isVisible) 1f else 0f

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.TransformOrigin
@@ -50,6 +51,7 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
+import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -77,6 +79,7 @@ import com.composables.icons.lucide.FolderPlus
 import com.composables.icons.lucide.Pencil
 import com.composables.icons.lucide.Check
 import kotlinx.coroutines.delay
+import kotlin.math.max
 import kotlin.math.roundToInt
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -127,6 +130,7 @@ fun AppDrawer(
     
     var drawerSize by remember { mutableStateOf(IntSize.Zero) }
     var folderPosition by remember { mutableStateOf(Offset.Zero) }
+    var launchRequest by remember { mutableStateOf<LaunchRequest?>(null) }
     var isEditMode by remember { mutableStateOf(false) }
     var editingFolderName by remember { mutableStateOf("") }
     
@@ -151,6 +155,15 @@ fun AppDrawer(
             isEditMode = false
             draggingItemPkg = null
         }
+    }
+
+    LaunchedEffect(launchRequest) {
+        val request = launchRequest ?: return@LaunchedEffect
+        delay(280)
+        context.packageManager.getLaunchIntentForPackage(request.app.packageName)?.let {
+            launchAppNoTransition(context, it)
+        }
+        launchRequest = null
     }
 
     Box(modifier = Modifier.fillMaxSize().onGloballyPositioned { drawerSize = it.size }) {
@@ -315,10 +328,78 @@ fun AppDrawer(
                             isFavorite = isFavorite(app.packageName),
                             onToggleFavorite = onToggleFavorite,
                             folders = folders,
-                            onUpdateFolders = onUpdateFolders
+                            onUpdateFolders = onUpdateFolders,
+                            onAppLaunchRequested = { requestedApp, bounds ->
+                                if (launchRequest == null) {
+                                    launchRequest = LaunchRequest(requestedApp, bounds)
+                                }
+                            }
                         )
                     }
                 }
+            }
+        }
+
+        val launchTransition = updateTransition(targetState = launchRequest != null, label = "LaunchTransition")
+        val launchProgress by launchTransition.animateFloat(
+            transitionSpec = { tween(durationMillis = 280, easing = FastOutSlowInEasing) },
+            label = "LaunchProgress"
+        ) { isVisible ->
+            if (isVisible) 1f else 0f
+        }
+        val launchOverlayAlpha by launchTransition.animateFloat(
+            transitionSpec = { tween(durationMillis = 220, easing = LinearEasing) },
+            label = "LaunchOverlayAlpha"
+        ) { isVisible ->
+            if (isVisible) 1f else 0f
+        }
+        val launchBounds = launchRequest?.bounds
+        val launchTranslation = remember(launchBounds, drawerSize) {
+            if (launchBounds != null && drawerSize.width > 0 && drawerSize.height > 0) {
+                val centerX = drawerSize.width / 2f
+                val centerY = drawerSize.height / 2f
+                Offset(launchBounds.center.x - centerX, launchBounds.center.y - centerY)
+            } else {
+                Offset.Zero
+            }
+        }
+        val launchStartScale = remember(launchBounds, drawerSize) {
+            if (launchBounds != null && drawerSize.width > 0 && drawerSize.height > 0) {
+                val wScale = launchBounds.width / drawerSize.width.toFloat()
+                val hScale = launchBounds.height / drawerSize.height.toFloat()
+                max(wScale, hScale).coerceIn(0.06f, 0.35f)
+            } else {
+                0.08f
+            }
+        }
+
+        if (launchProgress > 0f) {
+            val scale = launchStartScale + (1f - launchStartScale) * launchProgress
+            val translationX = launchTranslation.x * (1f - launchProgress)
+            val translationY = launchTranslation.y * (1f - launchProgress)
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zIndex(2000f)
+                    .clickable(
+                        interactionSource = remember { MutableInteractionSource() },
+                        indication = null,
+                        onClick = {}
+                    )
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            this.scaleX = scale
+                            this.scaleY = scale
+                            this.translationX = translationX
+                            this.translationY = translationY
+                            this.transformOrigin = TransformOrigin.Center
+                            this.alpha = launchOverlayAlpha
+                        }
+                        .background(colorTheme.drawerBackground)
+                )
             }
         }
 
@@ -596,7 +677,12 @@ fun AppDrawer(
                                                         onUpdateFolders = onUpdateFolders,
                                                         isInFolder = true,
                                                         currentFolderId = currentActiveFolder.id,
-                                                        isEditMode = isEditMode
+                                                        isEditMode = isEditMode,
+                                                        onAppLaunchRequested = { requestedApp, bounds ->
+                                                            if (launchRequest == null) {
+                                                                launchRequest = LaunchRequest(requestedApp, bounds)
+                                                            }
+                                                        }
                                                     )
                                                 }
                                             }
@@ -629,7 +715,8 @@ fun AppDrawer(
                                                     onUpdateFolders = onUpdateFolders,
                                                     isInFolder = true,
                                                     currentFolderId = currentActiveFolder.id,
-                                                    isEditMode = true
+                                                    isEditMode = true,
+                                                    onAppLaunchRequested = null
                                                 )
                                             }
                                         }
@@ -716,26 +803,43 @@ fun AppItem(
     onUpdateFolders: (List<FolderInfo>) -> Unit,
     isInFolder: Boolean = false,
     currentFolderId: String? = null,
-    isEditMode: Boolean = false
+    isEditMode: Boolean = false,
+    onAppLaunchRequested: ((AppInfo, Rect?) -> Unit)? = null
 ) {
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
     var showActions by remember { mutableStateOf(false) }
     var showFolderSelection by remember { mutableStateOf(false) }
     val intSrc = remember { MutableInteractionSource() }
+    var itemBounds by remember { mutableStateOf<Rect?>(null) }
 
     Box(modifier = Modifier.width(if (adaptiveColumns == 5) 64.dp else 80.dp), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.bounceClick(intSrc, enabled = !isEditMode).combinedClickable(
-            interactionSource = intSrc,
-            indication = null,
-            enabled = !isEditMode,
-            onClick = { 
-                context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) } 
-            },
-            onLongClick = { 
-                showActions = true
-            }
-        )) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .onGloballyPositioned { coordinates ->
+                    itemBounds = coordinates.boundsInRoot()
+                }
+                .bounceClick(intSrc, enabled = !isEditMode)
+                .combinedClickable(
+                    interactionSource = intSrc,
+                    indication = null,
+                    enabled = !isEditMode,
+                    onClick = {
+                        val handled = onAppLaunchRequested != null
+                        if (handled) {
+                            onAppLaunchRequested?.invoke(app, itemBounds)
+                        } else {
+                            context.packageManager.getLaunchIntentForPackage(app.packageName)?.let {
+                                context.startActivity(it)
+                            }
+                        }
+                    },
+                    onLongClick = {
+                        showActions = true
+                    }
+                )
+        ) {
             AppIconView(app)
             Spacer(modifier = Modifier.height(8.dp))
             Text(text = app.label, fontSize = 11.sp * fontSize.scale, color = Color.White.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
@@ -774,3 +878,8 @@ fun AppItem(
         }
     }
 }
+
+private data class LaunchRequest(
+    val app: AppInfo,
+    val bounds: Rect?
+)

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -677,6 +677,7 @@ fun AppDrawer(
                                                         isInFolder = true,
                                                         currentFolderId = currentActiveFolder.id,
                                                         isEditMode = isEditMode,
+                                                        bouncePackage = returnIconPackage,
                                                         onAppLaunchRequested = { requestedApp, bounds ->
                                                             if (launchRequest == null) {
                                                                 onAppLaunchForReturn(requestedApp.packageName, bounds)

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -323,47 +323,65 @@ fun AppDrawer(
         }
 
         // Folder Popup Overlay with symmetric animation
-        val pivotOrigin = remember(folderPosition, drawerSize) {
-            if (drawerSize.width > 0 && drawerSize.height > 0) {
-                TransformOrigin(
-                    pivotFractionX = folderPosition.x / drawerSize.width.toFloat(),
-                    pivotFractionY = folderPosition.y / drawerSize.height.toFloat()
+        val showFolder = activeFolderId != null
+        val folderTransition = updateTransition(targetState = showFolder, label = "FolderTransition")
+        val folderProgress by folderTransition.animateFloat(
+            transitionSpec = {
+                tween(
+                    durationMillis = if (targetState) 420 else 320,
+                    easing = FastOutSlowInEasing
                 )
-            } else TransformOrigin.Center
+            },
+            label = "FolderProgress"
+        ) { isVisible ->
+            if (isVisible) 1f else 0f
+        }
+        val overlayAlpha by folderTransition.animateFloat(
+            transitionSpec = { tween(durationMillis = 260, easing = LinearEasing) },
+            label = "OverlayAlpha"
+        ) { isVisible ->
+            if (isVisible) 0.35f else 0f
+        }
+        val folderTranslation = remember(folderPosition, drawerSize) {
+            if (drawerSize.width > 0 && drawerSize.height > 0) {
+                val centerX = drawerSize.width / 2f
+                val centerY = drawerSize.height / 2f
+                Offset(folderPosition.x - centerX, folderPosition.y - centerY)
+            } else {
+                Offset.Zero
+            }
         }
 
-        AnimatedVisibility(
-            visible = activeFolderId != null,
-            enter = fadeIn(animationSpec = tween(250)) + scaleIn(
-                initialScale = 0.05f,
-                transformOrigin = pivotOrigin,
-                animationSpec = tween(400, easing = FastOutSlowInEasing)
-            ),
-            exit = fadeOut(animationSpec = tween(250)) + scaleOut(
-                targetScale = 0.05f,
-                transformOrigin = pivotOrigin,
-                animationSpec = tween(400, easing = FastOutSlowInEasing)
-            )
-        ) {
+        if (folderProgress > 0f || showFolder) {
             // Nutze lastValidFolder, damit der Inhalt während der gesamten Schließanimation bleibt
             lastValidFolder?.let { currentActiveFolder ->
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color.Black.copy(alpha = 0.35f))
+                        .background(Color.Black.copy(alpha = overlayAlpha))
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null,
-                            onClick = { 
-                                if (isEditMode) isEditMode = false else activeFolderId = null 
+                            onClick = {
+                                if (isEditMode) isEditMode = false else activeFolderId = null
                             }
                         ),
                     contentAlignment = Alignment.Center
                 ) {
+                    val scale = 0.05f + (1f - 0.05f) * folderProgress
+                    val translationX = folderTranslation.x * (1f - folderProgress)
+                    val translationY = folderTranslation.y * (1f - folderProgress)
                     Surface(
                         modifier = Modifier
                             .fillMaxWidth(0.85f)
                             .wrapContentHeight()
+                            .graphicsLayer {
+                                this.scaleX = scale
+                                this.scaleY = scale
+                                this.translationX = translationX
+                                this.translationY = translationY
+                                this.transformOrigin = TransformOrigin.Center
+                            }
                             .clickable(enabled = false) {},
                         color = colorTheme.drawerBackground.copy(alpha = 0.98f),
                         shape = RoundedCornerShape(32.dp),
@@ -593,11 +611,11 @@ fun AppDrawer(
                                                 modifier = Modifier
                                                     .size(80.dp)
                                                     .graphicsLayer {
-                                                        translationX = touchPosition.x - initialTouchOffsetInItem.x
-                                                        translationY = touchPosition.y - initialTouchOffsetInItem.y
-                                                        scaleX = 1.3f
-                                                        scaleY = 1.3f
-                                                        alpha = 0.9f
+                                                        this.translationX = touchPosition.x - initialTouchOffsetInItem.x
+                                                        this.translationY = touchPosition.y - initialTouchOffsetInItem.y
+                                                        this.scaleX = 1.3f
+                                                        this.scaleY = 1.3f
+                                                        this.alpha = 0.9f
                                                     }
                                                     .zIndex(1000f)
                                                     .shadow(24.dp, RoundedCornerShape(16.dp))

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -90,7 +90,9 @@ fun AppDrawer(
     isFavorite: (String) -> Boolean,
     onUpdateFolders: (List<FolderInfo>) -> Unit,
     onOpenFolderConfig: (FolderInfo) -> Unit,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    onAppLaunchForReturn: (String, Rect?) -> Unit,
+    returnIconPackage: String?
 ) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
@@ -327,8 +329,10 @@ fun AppDrawer(
                             onToggleFavorite = onToggleFavorite,
                             folders = folders,
                             onUpdateFolders = onUpdateFolders,
+                            bouncePackage = returnIconPackage,
                             onAppLaunchRequested = { requestedApp, bounds ->
                                 if (launchRequest == null) {
+                                    onAppLaunchForReturn(requestedApp.packageName, bounds)
                                     launchRequest = LaunchRequest(requestedApp, bounds)
                                 }
                             }
@@ -340,7 +344,7 @@ fun AppDrawer(
 
         val launchTransition = updateTransition(targetState = launchRequest != null, label = "LaunchTransition")
         val launchProgress by launchTransition.animateFloat(
-            transitionSpec = { tween(durationMillis = 280, easing = FastOutSlowInEasing) },
+            transitionSpec = { spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow) },
             label = "LaunchProgress"
         ) { isVisible ->
             if (isVisible) 1f else 0f
@@ -675,6 +679,7 @@ fun AppDrawer(
                                                         isEditMode = isEditMode,
                                                         onAppLaunchRequested = { requestedApp, bounds ->
                                                             if (launchRequest == null) {
+                                                                onAppLaunchForReturn(requestedApp.packageName, bounds)
                                                                 launchRequest = LaunchRequest(requestedApp, bounds)
                                                             }
                                                         }
@@ -801,7 +806,8 @@ fun AppItem(
     isInFolder: Boolean = false,
     currentFolderId: String? = null,
     isEditMode: Boolean = false,
-    onAppLaunchRequested: ((AppInfo, Rect?) -> Unit)? = null
+    onAppLaunchRequested: ((AppInfo, Rect?) -> Unit)? = null,
+    bouncePackage: String? = null
 ) {
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
@@ -814,6 +820,14 @@ fun AppItem(
     var showFolderSelection by remember { mutableStateOf(false) }
     val intSrc = remember { MutableInteractionSource() }
     var itemBounds by remember { mutableStateOf<Rect?>(null) }
+    val bounceScale by animateFloatAsState(
+        targetValue = if (bouncePackage == app.packageName) 1.12f else 1f,
+        animationSpec = spring(
+            dampingRatio = Spring.DampingRatioMediumBouncy,
+            stiffness = Spring.StiffnessMedium
+        ),
+        label = "DrawerReturnBounce"
+    )
 
     Box(modifier = Modifier.width(if (adaptiveColumns == 5) 64.dp else 80.dp), contentAlignment = Alignment.Center) {
         Column(
@@ -821,6 +835,10 @@ fun AppItem(
             modifier = Modifier
                 .onGloballyPositioned { coordinates ->
                     itemBounds = coordinates.boundsInRoot()
+                }
+                .graphicsLayer {
+                    scaleX = bounceScale
+                    scaleY = bounceScale
                 }
                 .bounceClick(intSrc, enabled = !isEditMode)
                 .combinedClickable(

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -5,6 +5,7 @@ import android.app.ActivityOptions
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
+import android.widget.Toast
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
@@ -84,17 +85,22 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
 }
 
 fun launchAppNoTransition(context: Context, intent: Intent) {
-    // Aggressive Unterdrückung der System-Animation
-    intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-    
     val activity = context.findActivity()
-    activity?.overridePendingTransition(0, 0)
-    
-    val options = ActivityOptions.makeCustomAnimation(context, 0, 0)
-    context.startActivity(intent, options.toBundle())
-    
-    activity?.overridePendingTransition(0, 0)
+    try {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        val options = ActivityOptions.makeCustomAnimation(context, 0, 0)
+        context.startActivity(intent, options.toBundle())
+        activity?.overridePendingTransition(0, 0)
+    } catch (e: Exception) {
+        try {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            context.startActivity(intent)
+            activity?.overridePendingTransition(0, 0)
+        } catch (e2: Exception) {
+            Toast.makeText(context, "Start fehlgeschlagen", Toast.LENGTH_SHORT).show()
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -1,5 +1,9 @@
 package com.example.androidlauncher.ui
 
+import android.app.Activity
+import android.app.ActivityOptions
+import android.content.Context
+import android.content.Intent
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
@@ -44,5 +48,14 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
         app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = modifier.size(iconSize), tint = Color.White)
         app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = modifier.size(iconSize), colorFilter = ColorFilter.tint(Color.White))
         else -> Box(modifier = modifier.size(iconSize).background(Color.White.copy(alpha = 0.05f), CircleShape))
+    }
+}
+
+fun launchAppNoTransition(context: Context, intent: Intent) {
+    intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+    val options = ActivityOptions.makeCustomAnimation(context, 0, 0)
+    context.startActivity(intent, options.toBundle())
+    if (context is Activity) {
+        context.overridePendingTransition(0, 0)
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -5,6 +5,7 @@ import android.app.ActivityOptions
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
+import android.os.Build
 import android.widget.Toast
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -89,16 +90,23 @@ fun launchAppNoTransition(context: Context, intent: Intent) {
     try {
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        
         val options = ActivityOptions.makeCustomAnimation(context, 0, 0)
         context.startActivity(intent, options.toBundle())
-        activity?.overridePendingTransition(0, 0)
+        
+        if (activity != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                activity.overrideActivityTransition(Activity.OVERRIDE_TRANSITION_OPEN, 0, 0)
+            } else {
+                activity.overridePendingTransition(0, 0)
+            }
+        }
     } catch (e: Exception) {
         try {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             context.startActivity(intent)
-            activity?.overridePendingTransition(0, 0)
         } catch (e2: Exception) {
-            Toast.makeText(context, "Start fehlgeschlagen", Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, "App konnte nicht gestartet werden", Toast.LENGTH_SHORT).show()
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -3,6 +3,7 @@ package com.example.androidlauncher.ui
 import android.app.Activity
 import android.app.ActivityOptions
 import android.content.Context
+import android.content.ContextWrapper
 import android.content.Intent
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -45,6 +46,15 @@ import com.example.androidlauncher.ui.theme.LocalIconSize
 import kotlin.math.max
 import kotlin.math.roundToInt
 
+fun Context.findActivity(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return null
+}
+
 // Verbesserter bounceClick Modifier
 fun Modifier.bounceClick(interactionSource: MutableInteractionSource, enabled: Boolean = true) = composed {
     val isPressed by interactionSource.collectIsPressedAsState()
@@ -74,12 +84,17 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
 }
 
 fun launchAppNoTransition(context: Context, intent: Intent) {
+    // Aggressive Unterdrückung der System-Animation
     intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    
+    val activity = context.findActivity()
+    activity?.overridePendingTransition(0, 0)
+    
     val options = ActivityOptions.makeCustomAnimation(context, 0, 0)
     context.startActivity(intent, options.toBundle())
-    if (context is Activity) {
-        context.overridePendingTransition(0, 0)
-    }
+    
+    activity?.overridePendingTransition(0, 0)
 }
 
 @Composable

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -4,28 +4,46 @@ import android.app.Activity
 import android.app.ActivityOptions
 import android.content.Context
 import android.content.Intent
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalIconSize
+import kotlin.math.max
+import kotlin.math.roundToInt
 
 // Verbesserter bounceClick Modifier
 fun Modifier.bounceClick(interactionSource: MutableInteractionSource, enabled: Boolean = true) = composed {
@@ -61,5 +79,64 @@ fun launchAppNoTransition(context: Context, intent: Intent) {
     context.startActivity(intent, options.toBundle())
     if (context is Activity) {
         context.overridePendingTransition(0, 0)
+    }
+}
+
+@Composable
+fun ReturnAnimationOverlay(
+    bounds: Rect?,
+    rootSize: IntSize,
+    background: Color,
+    onFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+    targetScale: Float = 0.7f
+) {
+    if (bounds == null || rootSize.width == 0 || rootSize.height == 0) {
+        LaunchedEffect(bounds, rootSize) { onFinished() }
+        return
+    }
+
+    val density = LocalDensity.current
+    val progress = remember { Animatable(0f) }
+    LaunchedEffect(bounds, rootSize) {
+        progress.snapTo(0f)
+        progress.animateTo(1f, tween(durationMillis = 220, easing = FastOutSlowInEasing))
+        onFinished()
+    }
+
+    val centerX = rootSize.width / 2f
+    val centerY = rootSize.height / 2f
+    val launchTranslation = Offset(bounds.center.x - centerX, bounds.center.y - centerY)
+    val targetWidthPx = (bounds.width * targetScale).coerceAtLeast(with(density) { 24.dp.toPx() })
+    val targetHeightPx = (bounds.height * targetScale).coerceAtLeast(with(density) { 24.dp.toPx() })
+    val translationX = launchTranslation.x * progress.value
+    val translationY = launchTranslation.y * progress.value
+
+    // Shrink the overlay rectangle toward the icon size instead of scaling a full-screen box.
+    val currentWidthPx = rootSize.width - (rootSize.width - targetWidthPx) * progress.value
+    val currentHeightPx = rootSize.height - (rootSize.height - targetHeightPx) * progress.value
+    val currentCenterX = centerX + translationX
+    val currentCenterY = centerY + translationY
+    val topLeftX = (currentCenterX - currentWidthPx / 2f).toInt()
+    val topLeftY = (currentCenterY - currentHeightPx / 2f).toInt()
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .zIndex(2000f)
+            .graphicsLayer {
+                this.transformOrigin = TransformOrigin.Center
+                this.alpha = 1f - progress.value
+            }
+    ) {
+        Box(
+            modifier = Modifier
+                .offset { IntOffset(topLeftX, topLeftY) }
+                .size(
+                    width = with(density) { currentWidthPx.toDp() },
+                    height = with(density) { currentHeightPx.toDp() }
+                )
+                .background(background)
+        )
     }
 }


### PR DESCRIPTION
# 🎬 Issue: Systemnahe Öffnungs- & Schließanimationen + AppDrawer Swipe-Verhalten

## 🎯 Ziel

Der Launcher soll flüssigere, systemnahe Animationen erhalten und ein konsistentes Swipe-Verhalten im AppDrawer bieten.

---

# 🗂️ 1️⃣ App-Animationen anpassen

## Öffnen-Animation

- App soll sich visuell von der tatsächlichen Icon-Position aus öffnen
- Scale + leichte Translation vom App-Ort aus
- Kein abruptes Einblenden

## Schließen-Animation

- Ordner schrumpft zurück zur ursprünglichen Icon-Position
- Kein einfaches Fade-Out
- Animation synchron zur UI ohne Frame-Drops

---

# 📱 2️⃣ AppDrawer Swipe-to-Close

## Beschreibung

Wenn der Nutzer im AppDrawer ganz oben angekommen ist  
und erneut nach unten swiped,  
soll sich der AppDrawer schließen.

## Erwartetes Verhalten

- Kein leeres Scrollen am Listenende
- Kein unnötiger Bounce-Effekt
- Flüssiger Übergang zurück zum Homescreen

---

# 🏠 3️⃣ Animation beim Zurück-Swipe (Home-Geste)

## Beschreibung

Beim schnellen Zurück-Swipe (System-Geste zum Verlassen einer App) soll die Schließen-Animation visuell so wirken, als würde die App zurück in ihr Icon auf dem Startbildschirm oder im AppDrawer schrumpfen.

Aktuell erfolgt das Schließen ohne Bezug zur tatsächlichen Position des App-Icons.

---

## Ziel

Ein flüssiges, systemnahes Animationserlebnis schaffen, bei dem die App beim Verlassen visuell in die Position ihres Icons zurückkehrt.

---

## Erwartetes Verhalten

- [x] Beim schnellen Zurück-Swipe verkleinert sich die App
- [x] Die Animation bewegt sich zur tatsächlichen Icon-Position
- [x] Zielposition ist:
  - [x ] Startseite (Favoriten), wenn App dort liegt
  - [x] AppDrawer, wenn App dort sichtbar ist
- [x] Animation wirkt flüssig und ohne Frame-Drops
- [x] Kein visuelles Springen oder falsche Zielposition

---

## Anforderungen

- [x] Ermittlung der Bildschirmposition des App-Icons
- [x] Übergabe dieser Position an die Schließ-Animation
- [x] Kombination aus Scale + Translation
- [x] Fallback-Verhalten, wenn Icon-Position nicht bestimmbar ist
- [x] Performance-optimierte Umsetzung

---

## 🧪 Akzeptanzkriterien

- Ordner öffnen und schließen sich vom tatsächlichen Icon-Ort aus
- AppDrawer schließt sich bei weiterem Down-Swipe am Ende
- App schrumpft beim Zurück-Swipe in ihre Icon-Position
- Animationen sind flüssig
- Keine Layout-Verschiebungen
- Projekt buildet ohne Fehler