### PR TITLE
#32 🎛️ Issue: Option zur Anzeige von App-Titeln in der Favoritenleiste

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -428,7 +428,7 @@ fun HomeScreen(
             Spacer(modifier = Modifier.weight(1f))
 
             Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier.padding(start = 12.dp)
             ) {
                 if (favorites.isEmpty()) {
@@ -446,27 +446,25 @@ fun HomeScreen(
                 } else {
                     favorites.forEach { app ->
                         val intSrc = remember { MutableInteractionSource() }
-                        Column(
+                        Row(
                             modifier = Modifier.bounceClick(intSrc).clickable(
                                 interactionSource = intSrc,
                                 indication = null
                             ) {
                                 context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
-                            },
-                            horizontalAlignment = Alignment.CenterHorizontally
+                            }.padding(6.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
                             AppIconView(app)
                             if (showLabels) {
-                                Spacer(modifier = Modifier.height(8.dp))
                                 Text(
                                     text = app.label,
                                     color = mainTextColor,
-                                    fontSize = 14.sp * fontSize.scale,
-                                    fontWeight = FontWeight.Light,
+                                    fontSize = 18.sp * fontSize.scale,
+                                    fontWeight = FontWeight.Normal,
                                     maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier.widthIn(max = 80.dp)
+                                    overflow = TextOverflow.Ellipsis
                                 )
                             }
                         }
@@ -569,8 +567,8 @@ fun FavoritesConfigMenu(
                                 Modifier.drawBehind {
                                     drawLine(
                                         color = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A),
-                                        start = Offset(0f, size.height),
-                                        end = Offset(size.width, 0f),
+                                        start = Offset(0f, 0f),
+                                        end = Offset(size.width, size.height),
                                         strokeWidth = 1.5.dp.toPx()
                                     )
                                 }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -8,11 +8,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.Canvas
 import android.graphics.drawable.AdaptiveIconDrawable
-import android.graphics.drawable.Drawable
-import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.provider.AlarmClock
 import android.provider.CalendarContract
@@ -34,8 +30,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
@@ -54,15 +48,16 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.edit
+import androidx.core.graphics.applyCanvas
+import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalFontSize
-import com.example.androidlauncher.ui.theme.LocalIconSize
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.data.FontSize
@@ -151,7 +146,7 @@ class MainActivity : ComponentActivity() {
 
                         sortedIndices.forEachIndexed { loopIdx, appIdx ->
                             val app = allApps[appIdx]
-                            val bitmap = loadSingleIcon(context, pm, cacheDir, app.packageName)
+                            val bitmap = loadSingleIcon(pm, cacheDir, app.packageName)
                             if (bitmap != null) {
                                 withContext(Dispatchers.Main) {
                                     allApps[appIdx] = app.copy(iconBitmap = bitmap)
@@ -184,8 +179,6 @@ class MainActivity : ComponentActivity() {
                     else if (isColorConfigOpen) isColorConfigOpen = false
                     else if (isSizeConfigOpen) isSizeConfigOpen = false
                 }
-
-                val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
 
                 Box(modifier = Modifier.fillMaxSize()) {
                     SystemWallpaperView()
@@ -331,13 +324,11 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun enforceExcludeFromRecents() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            val am = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-            am.appTasks?.forEach { task ->
-                val base = task.taskInfo.baseIntent.component
-                if (base != null && base.className == componentName.className) {
-                    task.setExcludeFromRecents(true)
-                }
+        val am = getSystemService(ACTIVITY_SERVICE) as ActivityManager
+        am.appTasks?.forEach { task ->
+            val base = task.taskInfo.baseIntent.component
+            if (base != null && base.className == componentName.className) {
+                task.setExcludeFromRecents(true)
             }
         }
     }
@@ -350,9 +341,7 @@ private fun expandNotifications(context: Context) {
         val statusBarManager = Class.forName("android.app.StatusBarManager")
         val method = statusBarManager.getMethod("expandNotificationsPanel")
         method.invoke(statusBarService)
-    } catch (e: Exception) {
-        e.printStackTrace()
-    }
+    } catch (_: Exception) {}
 }
 
 @SuppressLint("MissingPermission")
@@ -369,7 +358,7 @@ fun SystemWallpaperView() {
             try {
                 val drawable = wallpaperManager.drawable
                 drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
-            } catch (e: Exception) { e.printStackTrace() }
+            } catch (_: Exception) {}
         }
     }
 
@@ -397,12 +386,12 @@ fun HomeScreen(
 
     val rotation by animateFloatAsState(
         targetValue = if (isSettingsOpen) 180f else 0f,
-        animationSpec = tween(300, easing = EaseInOutCubic)
+        animationSpec = tween(300, easing = EaseInOutCubic), label = ""
     )
     
     val settingsButtonSize by animateFloatAsState(
         targetValue = if (isSettingsOpen) 72f else 56f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy)
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy), label = ""
     )
 
     Box(
@@ -504,7 +493,6 @@ fun FavoritesConfigMenu(
     val context = LocalContext.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
-    // Der von dir gewünschte Grauton (basierend auf dem Counter-Text)
     val grayTone = Color.White.copy(alpha = 0.6f)
 
     var searchQuery by remember { mutableStateOf("") }
@@ -556,11 +544,9 @@ fun FavoritesConfigMenu(
                                 Spacer(modifier = Modifier.width(16.dp))
                                 Text(app.label, color = mainTextColor, fontSize = 16.sp, modifier = Modifier.weight(1f))
                                 IconButton(onClick = { selectedPackages = LauncherLogic.moveFavoriteUp(selectedPackages, index) }, enabled = index > 0) { 
-                                    // Inaktiv (unmöglich) -> Solid Schwarz | Aktiv (möglich) -> Wunsch-Grauton
                                     Icon(Icons.Default.KeyboardArrowUp, contentDescription = null, tint = if (index > 0) grayTone else mainTextColor) 
                                 }
                                 IconButton(onClick = { selectedPackages = LauncherLogic.moveFavoriteDown(selectedPackages, index) }, enabled = index < selectedPackages.size - 1) { 
-                                    // Inaktiv (unmöglich) -> Solid Schwarz | Aktiv (möglich) -> Wunsch-Grauton
                                     Icon(Icons.Default.KeyboardArrowDown, contentDescription = null, tint = if (index < selectedPackages.size - 1) grayTone else mainTextColor) 
                                 }
                             }
@@ -669,7 +655,7 @@ fun ClockHeader() {
                         }
                         context.startActivity(intent)
                         started = true
-                    } catch (e: Exception) {}
+                    } catch (_: Exception) {}
 
                     if (!started) {
                         try {
@@ -678,7 +664,7 @@ fun ClockHeader() {
                             }
                             context.startActivity(intent)
                             started = true
-                        } catch (e: Exception) {}
+                        } catch (_: Exception) {}
                     }
 
                     if (!started) {
@@ -700,25 +686,25 @@ fun ClockHeader() {
                                     started = true
                                     break
                                 }
-                            } catch (e: Exception) {}
+                            } catch (_: Exception) {}
                         }
                     }
 
                     if (!started) {
                         try {
                             val pm = context.packageManager
-                            val apps = pm.getInstalledApplications(PackageManager.GET_META_DATA)
+                            val apps = pm.queryIntentActivities(Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER), 0)
                             val clockApp = apps.find { 
                                 val label = it.loadLabel(pm).toString().lowercase()
-                                val pkg = it.packageName.lowercase()
+                                val pkg = it.activityInfo.packageName.lowercase()
                                 (pkg.contains("clock") || pkg.contains("deskclock") || label.contains("uhr") || label.contains("clock")) && 
-                                pm.getLaunchIntentForPackage(it.packageName) != null
+                                pm.getLaunchIntentForPackage(it.activityInfo.packageName) != null
                             }
                             clockApp?.let {
-                                context.startActivity(pm.getLaunchIntentForPackage(it.packageName))
+                                context.startActivity(pm.getLaunchIntentForPackage(it.activityInfo.packageName))
                                 started = true
                             }
-                        } catch (e: Exception) {}
+                        } catch (_: Exception) {}
                     }
 
                     if (!started) {
@@ -744,13 +730,13 @@ fun ClockHeader() {
                     }
                     try {
                         context.startActivity(calendarIntent)
-                    } catch (e: Exception) {
+                    } catch (_: Exception) {
                         val selectorIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
                             flags = Intent.FLAG_ACTIVITY_NEW_TASK
                         }
                         try {
                             context.startActivity(selectorIntent)
-                        } catch (e2: Exception) {}
+                        } catch (_: Exception) {}
                     }
                 }
                 .padding(horizontal = 4.dp, vertical = 2.dp)
@@ -769,7 +755,7 @@ private fun getAppListBasic(context: Context): List<AppInfo> {
     }.distinctBy { it.packageName }.sortedBy { it.label.lowercase() }
 }
 
-private suspend fun loadSingleIcon(context: Context, pm: PackageManager, cacheDir: File, packageName: String): ImageBitmap? {
+private suspend fun loadSingleIcon(pm: PackageManager, cacheDir: File, packageName: String): ImageBitmap? {
     val iconFile = File(cacheDir, "$packageName.png")
     if (iconFile.exists()) {
         try {
@@ -779,7 +765,7 @@ private suspend fun loadSingleIcon(context: Context, pm: PackageManager, cacheDi
                 ib.prepareToDraw()
                 return ib
             }
-        } catch (e: Exception) { }
+        } catch (_: Exception) { }
     }
     return withContext(Dispatchers.IO) {
         try {
@@ -791,10 +777,11 @@ private suspend fun loadSingleIcon(context: Context, pm: PackageManager, cacheDi
                 icon
             }
             
-            val b = Bitmap.createBitmap(144, 144, Bitmap.Config.ARGB_8888)
-            val canvas = Canvas(b)
-            foregroundDrawable.setBounds(0, 0, 144, 144)
-            foregroundDrawable.draw(canvas)
+            val b = createBitmap(144, 144)
+            b.applyCanvas {
+                foregroundDrawable.setBounds(0, 0, 144, 144)
+                foregroundDrawable.draw(this)
+            }
             
             val ib = b.asImageBitmap()
             ib.prepareToDraw()
@@ -803,7 +790,7 @@ private suspend fun loadSingleIcon(context: Context, pm: PackageManager, cacheDi
                 b.compress(Bitmap.CompressFormat.PNG, 100, out)
             }
             ib
-        } catch (e: Exception) { null }
+        } catch (_: Exception) { null }
     }
 }
 
@@ -815,5 +802,5 @@ private fun getSavedFavorites(context: Context): List<String> {
 
 private fun saveFavorites(context: Context, favorites: List<String>) {
     val prefs = context.getSharedPreferences("launcher_prefs", Context.MODE_PRIVATE)
-    prefs.edit().putString("favorites_list", favorites.joinToString(",")).apply()
+    prefs.edit { putString("favorites_list", favorites.joinToString(",")) }
 }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -524,6 +525,10 @@ fun FavoritesConfigMenu(
 ) {
     val context = LocalContext.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
+    
+    // Einheitliche Textfarbe für "App-Titel" (Grau wie im White Mode)
+    val labelTextColor = Color.White.copy(alpha = 0.6f)
+    
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
     val grayTone = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.6f)
 
@@ -549,35 +554,43 @@ fun FavoritesConfigMenu(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Text("App-Titel", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp)
+            Text("App-Titel", color = labelTextColor, fontSize = 14.sp)
+            
+            // Toggle Logik: 
+            // White Mode: Kreis Schwarz, Symbole Weiß
+            // Dark Mode: Kreis Weiß, Symbole Schwarz
+            val thumbColor = if (isDarkTextEnabled) Color.Black else Color.White
+            val symbolColor = if (isDarkTextEnabled) Color.White else Color.Black
+            
             Switch(
                 checked = showFavoriteLabels,
                 onCheckedChange = onShowLabelsToggled,
                 colors = SwitchDefaults.colors(
                     checkedTrackColor = Color.White.copy(alpha = 0.2f),
                     uncheckedTrackColor = Color.White.copy(alpha = 0.2f),
-                    checkedThumbColor = Color.White,
-                    uncheckedThumbColor = Color.White.copy(alpha = 0.9f),
+                    checkedThumbColor = thumbColor,
+                    uncheckedThumbColor = thumbColor,
                     checkedBorderColor = Color.White.copy(alpha = 0.1f),
                     uncheckedBorderColor = Color.White.copy(alpha = 0.1f)
                 ),
                 thumbContent = {
                     Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            imageVector = Lucide.Type,
-                            contentDescription = null,
-                            modifier = Modifier.size(16.dp).drawBehind {
-                                if (!showFavoriteLabels) {
-                                    drawLine(
-                                        color = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A),
-                                        start = Offset(0f, 0f),
-                                        end = Offset(size.width, size.height),
-                                        strokeWidth = 2.dp.toPx()
-                                    )
-                                }
-                            },
-                            tint = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A)
-                        )
+                        if (showFavoriteLabels) {
+                            // Symbol für AN (I)
+                            Box(
+                                modifier = Modifier
+                                    .size(width = 1.5.dp, height = 12.dp)
+                                    .background(symbolColor, RoundedCornerShape(0.5.dp))
+                            )
+                        } else {
+                            // Symbol für AUS (0)
+                            Surface(
+                                modifier = Modifier.size(width = 8.dp, height = 12.dp),
+                                color = Color.Transparent,
+                                border = BorderStroke(1.5.dp, symbolColor),
+                                shape = RoundedCornerShape(4.dp)
+                            ) {}
+                        }
                     }
                 }
             )
@@ -753,9 +766,9 @@ fun ClockHeader() {
                             "cn.nubia.deskclock",
                             "com.zte.deskclock"
                         )
-                        for (pkg in packages) {
+                        for (pName in packages) {
                             try {
-                                val launchIntent = context.packageManager.getLaunchIntentForPackage(pkg)
+                                val launchIntent = context.packageManager.getLaunchIntentForPackage(pName)
                                 if (launchIntent != null) {
                                     context.startActivity(launchIntent)
                                     started = true
@@ -770,9 +783,9 @@ fun ClockHeader() {
                             val pm = context.packageManager
                             val apps = pm.queryIntentActivities(Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER), 0)
                             val clockApp = apps.find { 
-                                val label = it.loadLabel(pm).toString().lowercase()
-                                val pkg = it.activityInfo.packageName.lowercase()
-                                (pkg.contains("clock") || pkg.contains("deskclock") || label.contains("uhr") || label.contains("clock")) && 
+                                val labelText = it.loadLabel(pm).toString().lowercase()
+                                val appPackageName = it.activityInfo.packageName.lowercase()
+                                (appPackageName.contains("clock") || appPackageName.contains("deskclock") || labelText.contains("uhr") || labelText.contains("clock")) && 
                                 pm.getLaunchIntentForPackage(it.activityInfo.packageName) != null
                             }
                             clockApp?.let {

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -59,7 +59,9 @@ import androidx.core.content.edit
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
+import com.composables.icons.lucide.ALargeSmall
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Type
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
@@ -447,12 +449,15 @@ fun HomeScreen(
                     favorites.forEach { app ->
                         val intSrc = remember { MutableInteractionSource() }
                         Row(
-                            modifier = Modifier.bounceClick(intSrc).clickable(
-                                interactionSource = intSrc,
-                                indication = null
-                            ) {
-                                context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
-                            }.padding(6.dp),
+                            modifier = Modifier
+                                .bounceClick(intSrc)
+                                .clickable(
+                                    interactionSource = intSrc,
+                                    indication = null
+                                ) {
+                                    context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
+                                }
+                                .padding(vertical = 4.dp, horizontal = 4.dp),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.spacedBy(16.dp)
                         ) {
@@ -558,21 +563,20 @@ fun FavoritesConfigMenu(
                 ),
                 thumbContent = {
                     Box(contentAlignment = Alignment.Center) {
-                        Text(
-                            text = "T",
-                            color = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A),
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Normal,
-                            modifier = if (!showFavoriteLabels) {
-                                Modifier.drawBehind {
+                        Icon(
+                            imageVector = Lucide.Type,
+                            contentDescription = null,
+                            modifier = Modifier.size(16.dp).drawBehind {
+                                if (!showFavoriteLabels) {
                                     drawLine(
                                         color = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A),
                                         start = Offset(0f, 0f),
                                         end = Offset(size.width, size.height),
-                                        strokeWidth = 1.5.dp.toPx()
+                                        strokeWidth = 2.dp.toPx()
                                     )
                                 }
-                            } else Modifier
+                            },
+                            tint = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A)
                         )
                     }
                 }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -41,24 +41,31 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.*
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
+import com.composables.icons.lucide.Lucide
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalFontSize
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalShowFavoriteLabels
 import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.IconSize
@@ -107,6 +114,7 @@ class MainActivity : ComponentActivity() {
             val currentFontSize by themeManager.selectedFontSize.collectAsState(initial = FontSize.STANDARD)
             val currentIconSize by themeManager.selectedIconSize.collectAsState(initial = IconSize.STANDARD)
             val isDarkTextEnabled by themeManager.isDarkTextEnabled.collectAsState(initial = false)
+            val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val folders by folderManager.folders.collectAsState(initial = emptyList())
 
             val scope = rememberCoroutineScope()
@@ -115,7 +123,8 @@ class MainActivity : ComponentActivity() {
                 colorTheme = currentTheme,
                 fontSize = currentFontSize,
                 iconSize = currentIconSize,
-                darkTextEnabled = isDarkTextEnabled
+                darkTextEnabled = isDarkTextEnabled,
+                showFavoriteLabels = showFavoriteLabels
             ) {
                 var isDrawerOpen by remember { mutableStateOf(false) }
                 var isSettingsOpen by remember { mutableStateOf(false) }
@@ -238,6 +247,10 @@ class MainActivity : ComponentActivity() {
                             FavoritesConfigMenu(
                                 apps = allApps,
                                 initialFavoritePackages = favoritePackages,
+                                showFavoriteLabels = showFavoriteLabels,
+                                onShowLabelsToggled = { show ->
+                                    scope.launch { themeManager.setShowFavoriteLabels(show) }
+                                },
                                 onConfirm = { newFavs ->
                                     saveFavorites(context, newFavs)
                                     favoritePackages = newFavs
@@ -382,6 +395,8 @@ fun HomeScreen(
 ) {
     val context = LocalContext.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val showLabels = LocalShowFavoriteLabels.current
+    val fontSize = LocalFontSize.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
 
     val rotation by animateFloatAsState(
@@ -413,7 +428,7 @@ fun HomeScreen(
             Spacer(modifier = Modifier.weight(1f))
 
             Column(
-                verticalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
                 modifier = Modifier.padding(start = 12.dp)
             ) {
                 if (favorites.isEmpty()) {
@@ -431,17 +446,29 @@ fun HomeScreen(
                 } else {
                     favorites.forEach { app ->
                         val intSrc = remember { MutableInteractionSource() }
-                        Surface(
-                            color = Color.Transparent,
-                            shape = RoundedCornerShape(12.dp),
+                        Column(
                             modifier = Modifier.bounceClick(intSrc).clickable(
                                 interactionSource = intSrc,
                                 indication = null
                             ) {
                                 context.packageManager.getLaunchIntentForPackage(app.packageName)?.let { context.startActivity(it) }
-                            }
+                            },
+                            horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-                            Box(modifier = Modifier.padding(6.dp)) { AppIconView(app) }
+                            AppIconView(app)
+                            if (showLabels) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = app.label,
+                                    color = mainTextColor,
+                                    fontSize = 14.sp * fontSize.scale,
+                                    fontWeight = FontWeight.Light,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.widthIn(max = 80.dp)
+                                )
+                            }
                         }
                     }
                 }
@@ -487,13 +514,15 @@ fun HomeScreen(
 fun FavoritesConfigMenu(
     apps: List<AppInfo>,
     initialFavoritePackages: List<String>,
+    showFavoriteLabels: Boolean,
+    onShowLabelsToggled: (Boolean) -> Unit,
     onConfirm: (List<String>) -> Unit,
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
-    val grayTone = Color.White.copy(alpha = 0.6f)
+    val grayTone = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.6f)
 
     var searchQuery by remember { mutableStateOf("") }
     var selectedPackages by remember { mutableStateOf(initialFavoritePackages) }
@@ -503,12 +532,56 @@ fun FavoritesConfigMenu(
     Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
             Column {
-                Text("Favoriten", fontSize = 24.sp, fontWeight = FontWeight.Light, color = mainTextColor)
-                Text("${selectedPackages.size} von 8 ausgewählt", fontSize = 14.sp, color = grayTone)
+                Text(stringResource(R.string.favorites_title), fontSize = 24.sp, fontWeight = FontWeight.Light, color = mainTextColor)
+                Text(stringResource(R.string.favorites_count, selectedPackages.size, LauncherLogic.MAX_FAVORITES), fontSize = 14.sp, color = grayTone)
             }
             IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = mainTextColor) }
         }
-        Spacer(modifier = Modifier.height(16.dp))
+        
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Option Toggle
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text("App-Titel", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp)
+            Switch(
+                checked = showFavoriteLabels,
+                onCheckedChange = onShowLabelsToggled,
+                colors = SwitchDefaults.colors(
+                    checkedTrackColor = Color.White.copy(alpha = 0.2f),
+                    uncheckedTrackColor = Color.White.copy(alpha = 0.2f),
+                    checkedThumbColor = Color.White,
+                    uncheckedThumbColor = Color.White.copy(alpha = 0.9f),
+                    checkedBorderColor = Color.White.copy(alpha = 0.1f),
+                    uncheckedBorderColor = Color.White.copy(alpha = 0.1f)
+                ),
+                thumbContent = {
+                    Box(contentAlignment = Alignment.Center) {
+                        Text(
+                            text = "T",
+                            color = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A),
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Normal,
+                            modifier = if (!showFavoriteLabels) {
+                                Modifier.drawBehind {
+                                    drawLine(
+                                        color = if (isDarkTextEnabled) Color.Black else Color(0xFF0F172A),
+                                        start = Offset(0f, size.height),
+                                        end = Offset(size.width, 0f),
+                                        strokeWidth = 1.5.dp.toPx()
+                                    )
+                                }
+                            } else Modifier
+                        )
+                    }
+                }
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
         
         val searchIntSrc = remember { MutableInteractionSource() }
         Box(modifier = Modifier.fillMaxWidth().background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp)).padding(horizontal = 16.dp, vertical = 12.dp).clickable(
@@ -525,7 +598,7 @@ fun FavoritesConfigMenu(
                     textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 15.sp),
                     cursorBrush = SolidColor(mainTextColor),
                     singleLine = true,
-                    decorationBox = { if (searchQuery.isEmpty()) Text("Apps suchen...", color = grayTone, fontSize = 15.sp); it() }
+                    decorationBox = { if (searchQuery.isEmpty()) Text(stringResource(R.string.search_apps), color = grayTone, fontSize = 15.sp); it() }
                 )
             }
         }
@@ -534,7 +607,7 @@ fun FavoritesConfigMenu(
         
         LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp), contentPadding = PaddingValues(bottom = 150.dp)) {
             if (selectedPackages.isNotEmpty()) {
-                item { Text("Reihenfolge", color = grayTone, fontSize = 12.sp) }
+                item { Text(stringResource(R.string.order_label), color = grayTone, fontSize = 12.sp) }
                 itemsIndexed(selectedPackages) { index, pkg ->
                     apps.find { it.packageName == pkg }?.let { app ->
                         Surface(color = Color.White.copy(alpha = 0.05f), shape = RoundedCornerShape(12.dp), modifier = Modifier.fillMaxWidth()) {
@@ -555,7 +628,7 @@ fun FavoritesConfigMenu(
                 }
                 item { Spacer(modifier = Modifier.height(24.dp)) }
             }
-            item { Text("Alle Apps", color = grayTone, fontSize = 12.sp) }
+            item { Text(stringResource(R.string.all_apps_label), color = grayTone, fontSize = 12.sp) }
             items(filteredApps) { app ->
                 val isFav = app.packageName in selectedPackages
                 val intSrc = remember { MutableInteractionSource() }
@@ -564,7 +637,7 @@ fun FavoritesConfigMenu(
                     indication = null
                 ) {
                     val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
-                    if (newFavs.size <= LauncherLogic.MAX_FAVORITES) selectedPackages = newFavs else Toast.makeText(context, "Maximal 8 erlaubt", Toast.LENGTH_SHORT).show()
+                    if (newFavs.size <= LauncherLogic.MAX_FAVORITES) selectedPackages = newFavs else Toast.makeText(context, context.getString(R.string.max_favorites_reached), Toast.LENGTH_SHORT).show()
                 }) {
                     Row(modifier = Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) {
                         AppIconView(app)
@@ -575,7 +648,7 @@ fun FavoritesConfigMenu(
                             onCheckedChange = null, 
                             colors = CheckboxDefaults.colors(
                                 checkedColor = mainTextColor, 
-                                uncheckedColor = Color.White.copy(alpha = 0.4f), 
+                                uncheckedColor = mainTextColor.copy(alpha = 0.4f), 
                                 checkmarkColor = if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)
                             )
                         )
@@ -603,7 +676,7 @@ fun FavoritesConfigMenu(
                 .clickable(
                     interactionSource = intSrc,
                     indication = null,
-                    onClick = { if (selectedPackages.isNotEmpty()) onConfirm(selectedPackages) else Toast.makeText(context, "Keine Auswahl", Toast.LENGTH_SHORT).show() }
+                    onClick = { if (selectedPackages.isNotEmpty()) onConfirm(selectedPackages) else Toast.makeText(context, context.getString(R.string.no_selection), Toast.LENGTH_SHORT).show() }
                 ),
             contentAlignment = Alignment.Center
         ) {

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -17,6 +17,7 @@ class ThemeManager(private val context: Context) {
         private val FONT_SIZE_KEY = stringPreferencesKey("font_size")
         private val ICON_SIZE_KEY = stringPreferencesKey("icon_size")
         private val DARK_TEXT_KEY = booleanPreferencesKey("dark_text_enabled")
+        private val SHOW_FAVORITE_LABELS_KEY = booleanPreferencesKey("show_favorite_labels")
     }
 
     val selectedTheme: Flow<ColorTheme> = context.dataStore.data
@@ -54,6 +55,11 @@ class ThemeManager(private val context: Context) {
             preferences[DARK_TEXT_KEY] ?: false
         }
 
+    val showFavoriteLabels: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[SHOW_FAVORITE_LABELS_KEY] ?: false
+        }
+
     suspend fun setTheme(theme: ColorTheme) {
         context.dataStore.edit { preferences ->
             preferences[THEME_KEY] = theme.name
@@ -75,6 +81,12 @@ class ThemeManager(private val context: Context) {
     suspend fun setDarkTextEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[DARK_TEXT_KEY] = enabled
+        }
+    }
+
+    suspend fun setShowFavoriteLabels(show: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[SHOW_FAVORITE_LABELS_KEY] = show
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -20,6 +20,7 @@ val LocalColorTheme = staticCompositionLocalOf { ColorTheme.LAUNCHER }
 val LocalFontSize = staticCompositionLocalOf { FontSize.STANDARD }
 val LocalIconSize = staticCompositionLocalOf { IconSize.STANDARD }
 val LocalDarkTextEnabled = staticCompositionLocalOf { false }
+val LocalShowFavoriteLabels = staticCompositionLocalOf { false }
 
 @Composable
 fun AndroidLauncherTheme(
@@ -27,6 +28,7 @@ fun AndroidLauncherTheme(
     fontSize: FontSize = FontSize.STANDARD,
     iconSize: IconSize = IconSize.STANDARD,
     darkTextEnabled: Boolean = false,
+    showFavoriteLabels: Boolean = false,
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
@@ -51,7 +53,8 @@ fun AndroidLauncherTheme(
         LocalColorTheme provides colorTheme,
         LocalFontSize provides fontSize,
         LocalIconSize provides iconSize,
-        LocalDarkTextEnabled provides darkTextEnabled
+        LocalDarkTextEnabled provides darkTextEnabled,
+        LocalShowFavoriteLabels provides showFavoriteLabels
     ) {
         MaterialTheme(
             colorScheme = colorScheme,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,11 @@
 <resources>
     <string name="app_name">Android Launcher</string>
+    <string name="show_app_titles">App-Titel anzeigen</string>
+    <string name="favorites_title">Favoriten</string>
+    <string name="favorites_count">%1$d von %2$d ausgewählt</string>
+    <string name="search_apps">Apps suchen...</string>
+    <string name="order_label">Reihenfolge</string>
+    <string name="all_apps_label">Alle Apps</string>
+    <string name="max_favorites_reached">Maximal 8 erlaubt</string>
+    <string name="no_selection">Keine Auswahl</string>
 </resources>


### PR DESCRIPTION
# 🎛️ Issue: Option zur Anzeige von App-Titeln in der Favoritenleiste

## 🎯 Ziel
Im Einstellungsmenü der Favoriteneinstellungen soll eine Option hinzugefügt werden, mit der Nutzer festlegen können, ob die App-Titel in der Favoritenleiste angezeigt werden.

Standardmäßig sollen die Titel **nicht angezeigt** werden (minimalistisches Design).  
Erst nach Aktivierung der Option werden die App-Namen sichtbar.

---

## 🧩 User Story

Als Nutzer  
möchte ich selbst entscheiden können, ob die App-Titel in der Favoritenleiste angezeigt werden,  
damit ich zwischen einem minimalistischen Layout und besserer Lesbarkeit wählen kann.

---

## ⚙️ Funktionales Verhalten

- Standardzustand: **Deaktiviert**
- Wenn deaktiviert:
  - Es werden nur App-Icons angezeigt
  - Keine Textanzeige unter oder neben den Icons
- Wenn aktiviert:
  - App-Titel werden unter den jeweiligen Icons angezeigt
- Die Einstellung soll dauerhaft gespeichert werden (SharedPreferences / DataStore)

---

## 🛠️ Technische Anforderungen

- [x] Neuer Toggle im Einstellungsmenü
- [x] Default-Wert = `false`
- [x] Speicherung der Einstellung persistent
- [x] Dynamisches Neuladen der Favoritenleiste bei Änderung
- [x] Saubere Trennung zwischen UI-Logik und Settings-Handling
- [x] Texte für die Option in `strings.xml` auslagern (Internationalisierung beachten)

---

## 🧪 Testfälle

- [x] Beim ersten App-Start sind keine Titel sichtbar
- [x] Nach Aktivierung erscheinen die Titel korrekt
- [x] Nach Neustart bleibt die Einstellung erhalten
- [x] Keine Layout-Verschiebung oder Überlappung bei langen App-Namen

---

## 🎨 Design-Hinweis

Das Layout soll auch mit aktivierten Titeln sauber, zentriert und konsistent wirken.  
Lange App-Namen sollten ggf. gekürzt oder mit Ellipsen (…) dargestellt werden.