### PR TITLE
#8 Custom App Icons mit Lucide Icons auswählbar machen

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -80,15 +80,7 @@ import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.data.FolderInfo
 import com.example.androidlauncher.data.FolderManager
 import com.example.androidlauncher.data.AppInfo
-import com.example.androidlauncher.ui.ColorConfigMenu
-import com.example.androidlauncher.ui.SettingsPaletteMenu
-import com.example.androidlauncher.ui.SizeConfigMenu
-import com.example.androidlauncher.ui.AppDrawer
-import com.example.androidlauncher.ui.AppIconView
-import com.example.androidlauncher.ui.bounceClick
-import com.example.androidlauncher.ui.FolderConfigMenu
-import com.example.androidlauncher.ui.launchAppNoTransition
-import com.example.androidlauncher.ui.ReturnAnimationOverlay
+import com.example.androidlauncher.ui.*
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import java.text.SimpleDateFormat
@@ -163,6 +155,7 @@ class MainActivity : ComponentActivity() {
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
                 var isColorConfigOpen by remember { mutableStateOf(false) }
                 var isSizeConfigOpen by remember { mutableStateOf(false) }
+                var isEditConfigOpen by remember { mutableStateOf(false) }
                 var isInfoOpen by remember { mutableStateOf(false) }
                 var selectedFolderForConfig by remember { mutableStateOf<FolderInfo?>(null) }
 
@@ -176,6 +169,7 @@ class MainActivity : ComponentActivity() {
                                     isFavoritesConfigOpen = false
                                     isColorConfigOpen = false
                                     isSizeConfigOpen = false
+                                    isEditConfigOpen = false
                                     isInfoOpen = false
                                     selectedFolderForConfig = null
                                 }
@@ -274,23 +268,25 @@ class MainActivity : ComponentActivity() {
                         isFavoritesConfigOpen = false
                         isColorConfigOpen = false
                         isSizeConfigOpen = false
+                        isEditConfigOpen = false
                         isInfoOpen = false
                         selectedFolderForConfig = null
                     }
                 }
 
-                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
-                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
+                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isEditConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
+                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
                     backCallback.isEnabled = !anyModalOpen
                 }
 
-                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
+                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
                     if (selectedFolderForConfig != null) selectedFolderForConfig = null
                     else if (isSearchOpen) isSearchOpen = false
                     else if (isDrawerOpen) isDrawerOpen = false
                     else if (isFavoritesConfigOpen) isFavoritesConfigOpen = false
                     else if (isColorConfigOpen) isColorConfigOpen = false
                     else if (isSizeConfigOpen) isSizeConfigOpen = false
+                    else if (isEditConfigOpen) isEditConfigOpen = false
                     else if (isInfoOpen) isInfoOpen = false
                 }
 
@@ -348,6 +344,7 @@ class MainActivity : ComponentActivity() {
                                 onOpenFavoritesConfig = { isFavoritesConfigOpen = true },
                                 onOpenColorConfig = { isColorConfigOpen = true },
                                 onOpenSizeConfig = { isSizeConfigOpen = true },
+                                onOpenSystemSettings = { isEditConfigOpen = true },
                                 onOpenInfo = { isInfoOpen = true },
                                 onAppLaunchForReturn = { pkg, bounds ->
                                     pendingReturnAnimation = ReturnAnimation(bounds, LaunchSource.HOME, pkg)
@@ -464,6 +461,18 @@ class MainActivity : ComponentActivity() {
                                      scope.launch { themeManager.setIconSize(size) }
                                  },
                                  onClose = { isSizeConfigOpen = false }
+                             )
+                         }
+                     }
+
+                    AnimatedVisibility(
+                         visible = isEditConfigOpen,
+                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                     ) {
+                         Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
+                             EditConfigMenu(
+                                 onClose = { isEditConfigOpen = false }
                              )
                          }
                      }
@@ -642,6 +651,7 @@ fun HomeScreen(
     onOpenFavoritesConfig: () -> Unit,
     onOpenColorConfig: () -> Unit,
     onOpenSizeConfig: () -> Unit,
+    onOpenSystemSettings: () -> Unit,
     onOpenInfo: () -> Unit,
     onAppLaunchForReturn: (String, Rect?) -> Unit,
     returnIconPackage: String?
@@ -829,7 +839,7 @@ fun HomeScreen(
                     onOpenFavoritesConfig = onOpenFavoritesConfig,
                     onOpenColorConfig = onOpenColorConfig,
                     onOpenSizeConfig = onOpenSizeConfig,
-                    onOpenSystemSettings = { context.startActivity(Intent(Settings.ACTION_SETTINGS)) },
+                    onOpenSystemSettings = onOpenSystemSettings,
                     onOpenInfo = onOpenInfo
                 )
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -80,6 +80,7 @@ import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.data.FolderInfo
 import com.example.androidlauncher.data.FolderManager
 import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.ui.*
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -122,6 +123,7 @@ class MainActivity : ComponentActivity() {
             // Initialize data managers
             val themeManager = remember { ThemeManager(context) }
             val folderManager = remember { FolderManager(context) }
+            val iconManager = remember { IconManager(context) }
 
             // Observe settings as State
             val currentTheme by themeManager.selectedTheme.collectAsState(initial = ColorTheme.SIGNATURE)
@@ -131,6 +133,7 @@ class MainActivity : ComponentActivity() {
             val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val isLiquidGlassEnabled by themeManager.isLiquidGlassEnabled.collectAsState(initial = true)
             val folders by folderManager.folders.collectAsState(initial = emptyList())
+            val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
 
             val menuBackgroundColor = if (isDarkTextEnabled) currentTheme.lightBackground else currentTheme.drawerBackground
 
@@ -156,6 +159,7 @@ class MainActivity : ComponentActivity() {
                 var isColorConfigOpen by remember { mutableStateOf(false) }
                 var isSizeConfigOpen by remember { mutableStateOf(false) }
                 var isEditConfigOpen by remember { mutableStateOf(false) }
+                var isIconConfigOpen by remember { mutableStateOf(false) }
                 var isInfoOpen by remember { mutableStateOf(false) }
                 var selectedFolderForConfig by remember { mutableStateOf<FolderInfo?>(null) }
 
@@ -170,6 +174,7 @@ class MainActivity : ComponentActivity() {
                                     isColorConfigOpen = false
                                     isSizeConfigOpen = false
                                     isEditConfigOpen = false
+                                    isIconConfigOpen = false
                                     isInfoOpen = false
                                     selectedFolderForConfig = null
                                 }
@@ -269,19 +274,21 @@ class MainActivity : ComponentActivity() {
                         isColorConfigOpen = false
                         isSizeConfigOpen = false
                         isEditConfigOpen = false
+                        isIconConfigOpen = false
                         isInfoOpen = false
                         selectedFolderForConfig = null
                     }
                 }
 
-                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isEditConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
-                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
+                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isEditConfigOpen, isIconConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
+                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
                     backCallback.isEnabled = !anyModalOpen
                 }
 
-                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
+                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
                     if (selectedFolderForConfig != null) selectedFolderForConfig = null
                     else if (isSearchOpen) isSearchOpen = false
+                    else if (isIconConfigOpen) isIconConfigOpen = false
                     else if (isDrawerOpen) isDrawerOpen = false
                     else if (isFavoritesConfigOpen) isFavoritesConfigOpen = false
                     else if (isColorConfigOpen) isColorConfigOpen = false
@@ -472,7 +479,25 @@ class MainActivity : ComponentActivity() {
                      ) {
                          Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
                              EditConfigMenu(
+                                 onOpenIconConfig = { isIconConfigOpen = true },
                                  onClose = { isEditConfigOpen = false }
+                             )
+                         }
+                     }
+
+                    AnimatedVisibility(
+                         visible = isIconConfigOpen,
+                         enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                         exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                     ) {
+                         Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
+                             IconConfigMenu(
+                                 apps = allApps,
+                                 customIcons = customIcons,
+                                 onIconSelected = { pkg, iconName ->
+                                     scope.launch { iconManager.setCustomIcon(pkg, iconName) }
+                                 },
+                                 onClose = { isIconConfigOpen = false }
                              )
                          }
                      }

--- a/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
@@ -1,0 +1,40 @@
+package com.example.androidlauncher.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.iconDataStore by preferencesDataStore(name = "icon_mappings")
+
+/**
+ * Manages custom app icons mapping.
+ * packageName -> lucideIconName
+ */
+class IconManager(private val context: Context) {
+
+    /**
+     * Returns a flow of the current icon mappings.
+     */
+    val customIcons: Flow<Map<String, String>> = context.iconDataStore.data
+        .map { preferences ->
+            preferences.asMap().mapKeys { it.key.name }.mapValues { it.value as String }
+        }
+
+    /**
+     * Updates the custom icon for a package.
+     * If iconName is null, the custom icon is removed (reverts to default).
+     */
+    suspend fun setCustomIcon(packageName: String, iconName: String?) {
+        context.iconDataStore.edit { preferences ->
+            val key = stringPreferencesKey(packageName)
+            if (iconName != null) {
+                preferences[key] = iconName
+            } else {
+                preferences.remove(key)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -1,0 +1,54 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+
+@Composable
+fun EditConfigMenu(
+    onClose: () -> Unit
+) {
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Bearbeiten",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = onClose) {
+                Icon(Icons.Default.Close, contentDescription = "Close", tint = mainTextColor)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Platzhalter für zukünftige Funktionen
+        Text(
+            "Hier können bald weitere Bearbeitungsfunktionen hinzugefügt werden.",
+            color = mainTextColor.copy(alpha = 0.7f),
+            fontSize = 16.sp
+        )
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -1,20 +1,28 @@
 package com.example.androidlauncher.ui
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.composables.icons.lucide.Lucide
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.composables.icons.lucide.Settings2
 
 @Composable
 fun EditConfigMenu(
+    onOpenIconConfig: () -> Unit,
     onClose: () -> Unit
 ) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
@@ -44,11 +52,53 @@ fun EditConfigMenu(
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        // Platzhalter für zukünftige Funktionen
-        Text(
-            "Hier können bald weitere Bearbeitungsfunktionen hinzugefügt werden.",
-            color = mainTextColor.copy(alpha = 0.7f),
-            fontSize = 16.sp
+        // Menu Point: App Icons anpassen
+        EditMenuItem(
+            icon = Lucide.Settings2,
+            label = "App-Icons anpassen",
+            onClick = onOpenIconConfig,
+            mainTextColor = mainTextColor
         )
+    }
+}
+
+@Composable
+fun EditMenuItem(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+    mainTextColor: Color
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { onClick() },
+        color = Color.Transparent
+    ) {
+        Row(
+            modifier = Modifier
+                .padding(vertical = 16.dp, horizontal = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = mainTextColor,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = label,
+                color = mainTextColor,
+                fontSize = 18.sp,
+                modifier = Modifier.weight(1f)
+            )
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowRight,
+                contentDescription = null,
+                tint = mainTextColor.copy(alpha = 0.5f)
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -1,24 +1,30 @@
 package com.example.androidlauncher.ui
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.composables.icons.lucide.Lucide
-import androidx.compose.ui.graphics.vector.ImageVector
 import com.composables.icons.lucide.Settings2
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 
 @Composable
 fun EditConfigMenu(
@@ -26,6 +32,7 @@ fun EditConfigMenu(
     onClose: () -> Unit
 ) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
 
     Column(
@@ -57,7 +64,9 @@ fun EditConfigMenu(
             icon = Lucide.Settings2,
             label = "App-Icons anpassen",
             onClick = onOpenIconConfig,
-            mainTextColor = mainTextColor
+            mainTextColor = mainTextColor,
+            isLiquidGlassEnabled = isLiquidGlassEnabled,
+            isDarkTextEnabled = isDarkTextEnabled
         )
     }
 }
@@ -67,18 +76,63 @@ fun EditMenuItem(
     icon: ImageVector,
     label: String,
     onClick: () -> Unit,
-    mainTextColor: Color
+    mainTextColor: Color,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean
 ) {
+    val backgroundModifier = if (isLiquidGlassEnabled) {
+        val glassBrush = if (isDarkTextEnabled) {
+            Brush.linearGradient(
+                colors = listOf(
+                    Color.Black.copy(alpha = 0.10f),
+                    Color.Black.copy(alpha = 0.03f)
+                ),
+                start = Offset(0f, 0f),
+                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+            )
+        } else {
+            Brush.linearGradient(
+                colors = listOf(
+                    Color.White.copy(alpha = 0.12f),
+                    Color.White.copy(alpha = 0.04f)
+                ),
+                start = Offset(0f, 0f),
+                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+            )
+        }
+        val borderBrush = if (isDarkTextEnabled) {
+            Brush.linearGradient(
+                colors = listOf(
+                    Color.Black.copy(alpha = 0.2f),
+                    Color.Black.copy(alpha = 0.05f)
+                )
+            )
+        } else {
+            Brush.linearGradient(
+                colors = listOf(
+                    Color.White.copy(alpha = 0.25f),
+                    Color.White.copy(alpha = 0.05f)
+                )
+            )
+        }
+        Modifier
+            .background(glassBrush, RoundedCornerShape(16.dp))
+            .border(BorderStroke(1.dp, borderBrush), RoundedCornerShape(16.dp))
+    } else {
+        Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
+    }
+
     Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(RoundedCornerShape(16.dp))
+            .then(backgroundModifier)
             .clickable { onClick() },
         color = Color.Transparent
     ) {
         Row(
             modifier = Modifier
-                .padding(vertical = 16.dp, horizontal = 8.dp),
+                .padding(vertical = 20.dp, horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
@@ -92,12 +146,13 @@ fun EditMenuItem(
                 text = label,
                 color = mainTextColor,
                 fontSize = 18.sp,
+                fontWeight = FontWeight.Normal,
                 modifier = Modifier.weight(1f)
             )
             Icon(
-                imageVector = Icons.Default.KeyboardArrowRight,
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = null,
-                tint = mainTextColor.copy(alpha = 0.5f)
+                tint = mainTextColor.copy(alpha = 0.4f)
             )
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -1,0 +1,376 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.composables.icons.lucide.*
+import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
+import com.example.androidlauncher.LauncherLogic
+import java.lang.reflect.Method
+
+@Composable
+fun IconConfigMenu(
+    apps: List<AppInfo>,
+    customIcons: Map<String, String>,
+    onIconSelected: (String, String?) -> Unit,
+    onClose: () -> Unit
+) {
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    
+    var searchQuery by remember { mutableStateOf("") }
+    val filteredApps = remember(apps, searchQuery) {
+        if (searchQuery.isBlank()) apps else apps.filter { it.label.contains(searchQuery, ignoreCase = true) }
+    }
+
+    var selectedAppForIcon by remember { mutableStateOf<AppInfo?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "App-Icons anpassen",
+                fontSize = 24.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = onClose) {
+                Icon(Icons.Default.Close, contentDescription = "Close", tint = mainTextColor)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Search Bar with Liquid Glass Optic
+        val searchBarModifier = if (isLiquidGlassEnabled) {
+            val glassBrush = if (isDarkTextEnabled) {
+                Brush.linearGradient(
+                    colors = listOf(Color.Black.copy(alpha = 0.10f), Color.Black.copy(alpha = 0.03f)),
+                    start = Offset(0f, 0f),
+                    end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                )
+            } else {
+                Brush.linearGradient(
+                    colors = listOf(Color.White.copy(alpha = 0.12f), Color.White.copy(alpha = 0.04f)),
+                    start = Offset(0f, 0f),
+                    end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                )
+            }
+            val borderBrush = if (isDarkTextEnabled) {
+                Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.2f), Color.Black.copy(alpha = 0.05f)))
+            } else {
+                Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.25f), Color.White.copy(alpha = 0.05f)))
+            }
+            Modifier
+                .background(glassBrush, RoundedCornerShape(12.dp))
+                .border(BorderStroke(1.dp, borderBrush), RoundedCornerShape(12.dp))
+        } else {
+            Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+        }
+
+        Box(modifier = Modifier.fillMaxWidth().then(searchBarModifier).padding(horizontal = 16.dp, vertical = 12.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Search, contentDescription = null, tint = mainTextColor.copy(alpha = 0.4f), modifier = Modifier.size(20.dp))
+                Spacer(modifier = Modifier.width(12.dp))
+                BasicTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 16.sp),
+                    cursorBrush = SolidColor(mainTextColor),
+                    singleLine = true,
+                    decorationBox = { if (searchQuery.isEmpty()) Text("Apps durchsuchen...", color = mainTextColor.copy(alpha = 0.4f), fontSize = 16.sp); it() }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 32.dp)
+        ) {
+            items(filteredApps) { app ->
+                val customIconName = customIcons[app.packageName]
+                val customIcon = if (customIconName != null) getLucideIconByName(customIconName) else null
+                
+                val itemBackgroundModifier = if (isLiquidGlassEnabled) {
+                    val glassBrush = if (isDarkTextEnabled) {
+                        Brush.linearGradient(
+                            colors = listOf(Color.Black.copy(alpha = 0.06f), Color.Black.copy(alpha = 0.02f)),
+                            start = Offset(0f, 0f),
+                            end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                        )
+                    } else {
+                        Brush.linearGradient(
+                            colors = listOf(Color.White.copy(alpha = 0.08f), Color.White.copy(alpha = 0.02f)),
+                            start = Offset(0f, 0f),
+                            end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                        )
+                    }
+                    val borderBrush = if (isDarkTextEnabled) {
+                        Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.15f), Color.Black.copy(alpha = 0.03f)))
+                    } else {
+                        Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.18f), Color.White.copy(alpha = 0.03f)))
+                    }
+                    Modifier
+                        .background(glassBrush, RoundedCornerShape(16.dp))
+                        .border(BorderStroke(1.dp, borderBrush), RoundedCornerShape(16.dp))
+                } else {
+                    Modifier.background(mainTextColor.copy(alpha = 0.03f), RoundedCornerShape(16.dp))
+                }
+
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .then(itemBackgroundModifier)
+                        .clickable { selectedAppForIcon = app },
+                    color = Color.Transparent
+                ) {
+                    Row(
+                        modifier = Modifier.padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        if (customIcon != null) {
+                            Box(modifier = Modifier.size(40.dp), contentAlignment = Alignment.Center) {
+                                Icon(customIcon, contentDescription = null, tint = mainTextColor, modifier = Modifier.size(24.dp))
+                            }
+                        } else {
+                            AppIconView(app, modifier = Modifier.size(40.dp))
+                        }
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(app.label, color = mainTextColor, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+                            if (customIconName != null) {
+                                Text(customIconName, color = mainTextColor.copy(alpha = 0.5f), fontSize = 12.sp)
+                            }
+                        }
+                        if (customIconName != null) {
+                            TextButton(onClick = { onIconSelected(app.packageName, null) }) {
+                                Text("Reset", color = Color.Red.copy(alpha = 0.7f))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (selectedAppForIcon != null) {
+        LucideIconPicker(
+            onIconSelected = { iconName ->
+                onIconSelected(selectedAppForIcon!!.packageName, iconName)
+                selectedAppForIcon = null
+            },
+            onDismiss = { selectedAppForIcon = null },
+            isLiquidGlassEnabled = isLiquidGlassEnabled,
+            isDarkTextEnabled = isDarkTextEnabled
+        )
+    }
+}
+
+@Composable
+fun LucideIconPicker(
+    onIconSelected: (String) -> Unit,
+    onDismiss: () -> Unit,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean
+) {
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    var searchQuery by remember { mutableStateOf("") }
+    
+    // Comprehensive list of Lucide icons
+    val commonIconNames = remember {
+        listOf(
+            "Airplay", "AlarmCheck", "AlarmClock", "AlarmClockOff", "Album", "Anchor", "Aperture", "AppWindow", "Apple", "AreaChart", "Armchair", "Asterisk", "Axis3d", "BaggageClaim", "Ban", "Banknote", "BarChart", "BarChart2", "BarChart3", "BarChart4", "BarChartBig", "BarChartHorizontal", "BarChartHorizontalBig", "Barrier", "Baseline", "Bath", "Battery", "BatteryCharging", "BatteryFull", "BatteryLow", "BatteryMedium", "BatteryWarning", "Beaker", "Bean", "BeanOff", "Bed", "BedDouble", "BedSingle", "Beef", "Beer", "Bell", "BellMinus", "BellOff", "BellPlus", "BellRing", "Bike", "Binary", "Biohazard", "Bird", "Bitcoin", "Blinds", "Bluetooth", "BluetoothConnected", "BluetoothOff", "BluetoothSearching", "Bold", "Bomb", "Bone", "Book", "BookCopy", "BookDown", "BookKey", "BookLock", "BookOpen", "BookOpenCheck", "BookPlus", "BookTemplate", "BookType", "BookUp", "Bookmark", "BookmarkMinus", "BookmarkPlus", "Bot", "BoxSelect", "Boxes", "Brackets", "Brain", "BrainCircuit", "BrainCog", "BrickWall", "Briefcase", "Brush", "Bug", "Building", "Building2", "Bus", "Cake", "Calculator", "Calendar", "CalendarCheck", "CalendarCheck2", "CalendarClock", "CalendarDays", "CalendarHeart", "CalendarMinus", "CalendarOff", "CalendarPlus", "CalendarRange", "CalendarSearch", "CalendarX", "CalendarX2", "Camera", "CameraOff", "CandlestickChart", "Car", "Cast", "Castle", "Cat", "Check", "CheckCircle", "CheckCircle2", "CheckSquare", "ChefHat", "Cherry", "ChevronDown", "ChevronFirst", "ChevronLast", "ChevronLeft", "ChevronRight", "ChevronUp", "ChevronsDown", "ChevronsDownUp", "ChevronsLeft", "ChevronsLeftRight", "ChevronsRight", "ChevronsRightLeft", "ChevronsUp", "ChevronsUpDown", "Chrome", "Church", "Cigarette", "CigaretteOff", "Circle", "CircleDashed", "CircleDollarSign", "CircleDot", "CircleDotLab", "CircleEllipsis", "CircleEqual", "CircleOff", "CircleSlash", "CircleSlash2", "CircleUser", "CircleUserRound", "CircuitBoard", "Clipboard", "ClipboardCheck", "ClipboardCopy", "ClipboardEdit", "ClipboardList", "ClipboardPaste", "ClipboardSignature", "ClipboardType", "ClipboardX", "Clock", "Clock1", "Clock10", "Clock11", "Clock12", "Clock2", "Clock3", "Clock4", "Clock5", "Clock6", "Clock7", "Clock8", "Clock9", "Cloud", "CloudDrizzle", "CloudFog", "CloudLightning", "CloudMoon", "CloudMoonRain", "CloudOff", "CloudRain", "CloudRainWind", "CloudSnow", "CloudSun", "CloudSunRain", "Clapperboard", "Code", "Component", "ConciergeBell", "Contact", "Contact2", "Contrast", "Cookie", "Copy", "CopyCheck", "CopyMinus", "CopyPlus", "CopySlash", "CopyX", "Copyleft", "Copyright", "CornerDownLeft", "CornerDownRight", "CornerLeftDown", "CornerLeftUp", "CornerRightDown", "CornerRightUp", "CornerUpLeft", "CornerUpRight", "Cpu", "CreativeCommons", "CreditCard", "Croissant", "Crop", "Cross", "Crosshair", "Crown", "CupSoap", "Currency", "Database", "DatabaseBackup", "DatabaseZap", "Delete", "Diamond", "Dice1", "Dice2", "Dice3", "Dice4", "Dice5", "Dice6", "Dices", "Diff", "Disc", "Disc2", "Disc3", "Divide", "DivideCircle", "DivideSquare", "Dna", "DnaOff", "Dog", "DollarSign", "DoorClosed", "DoorOpen", "Dot", "Download", "DownloadCloud", "Dribbble", "Droplet", "Droplets", "Drumstick", "Dumbbell", "Ear", "EarOff", "Edit", "Edit2", "Edit3", "Egg", "EggFried", "EggOff", "Equal", "EqualNot", "Eraser", "Euro", "Expand", "ExternalLink", "Eye", "EyeOff", "Facebook", "Factory", "Fan", "FastForward", "Feather", "FerrisWheel", "Figma", "File", "FileArchive", "FileAudio", "FileAudio2", "FileBadge", "FileBadge2", "FileBarChart", "FileBarChart2", "FileBox", "FileCheck", "FileCheck2", "FileCode", "FileCode2", "FileCog", "FileCog2", "FileDiff", "FileDigit", "FileDown", "FileEdit", "FileHeart", "FileImage", "FileJson", "FileJson2", "FileKey", "FileKey2", "FileLineChart", "FileLock", "FileLock2", "FileMinus", "FileMinus2", "FileMusic", "FileOutput", "FilePlus", "FilePlus2", "FileQuestion", "FileScan", "FileSearch", "FileSearch2", "FileSignature", "FileSpreadsheet", "FileStack", "FileSymlink", "FileTerminal", "FileText", "FileType", "FileType2", "FileUp", "FileVideo", "FileVideo2", "FileWarning", "FileX", "FileX2", "Files", "Film", "Filter", "FilterX", "Fingerprint", "Fish", "FishOff", "Flag", "FlagOff", "FlagTriangleLeft", "FlagTriangleRight", "Flame", "Flashlight", "FlashlightOff", "FlaskConical", "FlaskConicalOff", "FlaskRound", "FlipHorizontal", "FlipHorizontal2", "FlipVertical", "FlipVertical2", "Flower", "Flower2", "Focus", "Folder", "FolderArchive", "FolderCheck", "FolderCog", "FolderCog2", "FolderDown", "FolderEdit", "FolderHeart", "FolderInput", "FolderKey", "FolderLock", "FolderMinus", "FolderOpen", "FolderOutput", "FolderPlus", "FolderSearch", "FolderSearch2", "FolderSymlink", "FolderUp", "FolderX", "Folders", "Footprints", "Forklift", "FormInput", "Forward", "Frame", "Framer", "Frown", "Fuel", "FunctionSquare", "Gamepad", "Gamepad2", "Gavel", "Gem", "Ghost", "Gift", "GitBranch", "GitBranchPlus", "GitCommit", "GitCompare", "GitFork", "GitMerge", "GitPullRequest", "GitPullRequestClosed", "GitPullRequestDraft", "GitPullRequestCreate", "GitPullRequestCreateArrow", "Github", "Gitlab", "GlassWater", "Globe", "Grid", "Grip", "GripHorizontal", "GripVertical", "GroupBox", "Hammer", "Hand", "HandMetal", "HardDrive", "HardDriveDownload", "HardDriveUpload", "HardHat", "Hash", "Haze", "HdmiPort", "Heading", "Heading1", "Heading2", "Heading3", "Heading4", "Heading5", "Heading6", "Headphones", "Heart", "HeartHandshake", "HeartOff", "HeartPulse", "HelpCircle", "HelpingHand", "Hexagon", "Highlighter", "History", "Home", "Hop", "HopOff", "Hotel", "Hourglass", "IceCream", "IceCream2", "Image", "ImageMinus", "ImageOff", "ImagePlus", "Import", "Inbox", "Indented", "Infinity", "Info", "Inspect", "Instagram", "Italic", "IterationCcw", "IterationCw", "JapaneseYen", "Joystick", "Kanban", "KanbanSquare", "Key", "Keyboard", "Lamp", "LampCeiling", "LampDesk", "LampFloor", "LampWallDown", "LampWallUp", "Landmark", "Languages", "Laptop", "Layers", "Layout", "LayoutDashboard", "LayoutList", "LayoutPanelLeft", "LayoutPanelTop", "LayoutTemplate", "Leaf", "Library", "LifeBuoy", "Lightbulb", "LightbulbOff", "LineChart", "Link", "Link2", "Link2Off", "Linkedin", "List", "ListCheck", "ListChecks", "ListEnd", "ListFilter", "ListMinus", "ListMusic", "ListOrdered", "ListPlus", "ListRestart", "ListStart", "ListTodo", "ListVideo", "ListX", "Loader", "Loader2", "Locate", "LocateFixed", "LocateOff", "Lock", "LogOut", "LogIn", "Luggage", "Magnet", "Mail", "MailOpen", "MailWarning", "Mailbox", "Mails", "Map", "MapPin", "MapPinOff", "Martini", "Maximize", "Maximize2", "Medal", "Megaphone", "MegaphoneOff", "Menu", "MessageCircle", "MessageSquare", "Mic", "Mic2", "MicOff", "Microscope", "Microwave", "Milestone", "Milk", "MilkOff", "Minimize", "Minimize2", "Mission", "Monitor", "MonitorCheck", "MonitorDot", "MonitorOff", "MonitorSpeaker", "MonitorX", "Moon", "Mountain", "MountainSnow", "Mouse", "MousePointer", "MousePointer2", "MousePointerClick", "Move", "Move3d", "MoveDiagonal", "MoveDiagonal2", "MoveHorizontal", "MoveVertical", "Music", "Music2", "Music3", "Music4", "Navigation", "Navigation2", "Navigation2Off", "NavigationOff", "Network", "Newspaper", "Nfc", "Nut", "NutOff", "Octagon", "Option", "Outdent", "Package", "Package2", "PackageCheck", "PackageMinus", "PackageOpen", "PackagePlus", "PackageSearch", "PackageX", "PaintBucket", "Paintbrush", "Paintbrush2", "Palette", "PanelBottom", "PanelBottomClose", "PanelBottomInactive", "PanelBottomOpen", "PanelLeft", "PanelLeftClose", "PanelLeftInactive", "PanelLeftOpen", "PanelRight", "PanelRightClose", "PanelRightInactive", "PanelRightOpen", "PanelTop", "PanelTopClose", "PanelTopInactive", "PanelTopOpen", "Paperclip", "Parentheses", "ParkingCircle", "ParkingCircleOff", "ParkingSquare", "ParkingSquareOff", "PartyPopper", "Pause", "PauseCircle", "PauseOctagon", "PcCase", "Pencil", "Percent", "PersonStanding", "Phone", "PhoneCall", "PhoneForwarded", "PhoneIncoming", "PhoneMissed", "PhoneOff", "PhoneOutgoing", "PieChart", "PiggyBank", "Pilate", "Pill", "Pin", "PinOff", "Pipette", "Pizza", "Plane", "PlaneLanding", "PlaneTakeoff", "Play", "PlayCircle", "PlaySquare", "Plug", "Plug2", "Plus", "PlusCircle", "PlusSquare", "Pocket", "PocketKnife", "Podcast", "Pointer", "PoundSterling", "Power", "PowerOff", "Presentation", "Printer", "Projector", "Puzzle", "Pyramid", "QrCode", "Quote", "Rabbit", "Radar", "Radiation", "Radio", "RadioReceiver", "RadioTower", "Railcar", "Rat", "Ratio", "Receipt", "RectangleHorizontal", "RectangleVertical", "Recycle", "Redo", "Redo2", "RedoDot", "RefreshCcw", "RefreshCcwDot", "RefreshCw", "RefreshCwDot", "Refrigerator", "Regex", "Repeat", "Repeat1", "Repeat2", "Replace", "ReplaceAll", "Reply", "ReplyAll", "Rewind", "Rocket", "RockingChair", "RotateCcw", "RotateCw", "Route", "Router", "Rows", "Rss", "Ruler", "RussianRuble", "Sailboat", "Salad", "Sandwich", "Save", "Satellite", "SatelliteDish", "Scale", "Scale3d", "Scan", "ScanFace", "ScanLine", "Scissors", "ScreenShare", "ScreenShareOff", "Scroll", "ScrollText", "Search", "Send", "SeparatorHorizontal", "SeparatorVertical", "Server", "ServerCog", "ServerCrash", "ServerOff", "Settings", "Settings2", "Shapes", "Share", "Share2", "Sheet", "Shield", "ShieldAlert", "ShieldCheck", "ShieldClose", "ShieldOff", "ShieldQuestion", "Ship", "Shirt", "ShoppingBag", "ShoppingCart", "Shovel", "ShowerHead", "Shrink", "Shrub", "Shuffle", "Sigma", "Signal", "SignalHigh", "SignalLow", "SignalMedium", "SignalZero", "Siren", "SkipBack", "SkipForward", "Skull", "Slack", "Slice", "Sliders", "SlidersHorizontal", "Smartphone", "SmartphoneCharging", "SmartphoneNfc", "Smile", "SmilePlus", "Snail", "Snowflake", "Sofa", "Soup", "Space", "Sprout", "Speaker", "Spline", "Split", "Smartphone", "Square", "SquareAsterisk", "SquareCode", "SquareDollarSign", "SquareDot", "SquareEqual", "SquareSlash", "Squirrel", "Stamp", "Star", "StarHalf", "StarOff", "StepBack", "StepForward", "Stethoscope", "Sticker", "StickyNote", "StopCircle", "StretchHorizontal", "StretchVertical", "Strikethrough", "Smartphone", "Subscript", "Subtitles", "Sun", "SunDim", "SunMedium", "SunMoon", "SunRain", "SunSnow", "Sunrise", "Sunset", "Superscript", "SwissFranc", "SwitchCamera", "Sword", "Swords", "Syringe", "Table", "Table2", "TableProperties", "Tablet", "Tag", "Tags", "Tally1", "Tally2", "Tally3", "Tally4", "Tally5", "Target", "Tent", "Terminal", "TerminalSquare", "Text", "TextCursor", "TextCursorInput", "TextQuote", "TextSelect", "Thermometer", "ThermometerSnowflake", "ThermometerSun", "ThumbsDown", "ThumbsUp", "Ticket", "Timer", "TimerOff", "TimerReset", "ToggleLeft", "ToggleRight", "Tornado", "TowerControl", "ToyBrick", "Train", "Trash", "Trash2", "TreePine", "TreePalm", "Trees", "Trello", "TrendingDown", "TrendingUp", "Triangle", "Trophy", "Truck", "Tv", "Tv2", "Twitch", "Twitter", "Type", "Umbrella", "Underline", "Undo", "Undo2", "UndoDot", "UnfoldHorizontal", "UnfoldVertical", "Ungroup", "Unlink", "Unlink2", "Unlock", "Upload", "UploadCloud", "Usb", "User", "UserCheck", "UserMinus", "UserPlus", "UserX", "Users", "Utensils", "UtensilsCrossed", "Variable", "VenetianMask", "Vibrate", "Video", "VideoOff", "View", "Voicemail", "Volume", "Volume1", "Volume2", "VolumeX", "Vote", "Wallet", "Wand", "Wand2", "Watch", "Waves", "Webcam", "Webhook", "Wheat", "WheatOff", "WholeWord", "Wifi", "WifiOff", "Wind", "Wine", "WineOff", "WrapText", "X", "XCircle", "XOctagon", "XSquare", "Youtube", "Zap", "ZapOff", "ZoomIn", "ZoomOut"
+        ).distinct().sorted()
+    }
+
+    val allIcons = remember { 
+        commonIconNames.mapNotNull { name ->
+            val icon = getLucideIconByName(name)
+            if (icon != null) name to icon else null
+        }
+    }
+
+    val filteredIcons = remember(searchQuery, allIcons) {
+        if (searchQuery.isBlank()) allIcons else allIcons.filter { it.first.contains(searchQuery, ignoreCase = true) }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+                // Header
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    IconButton(onClick = onDismiss) {
+                        Icon(Icons.Default.Close, contentDescription = "Close", tint = mainTextColor)
+                    }
+                    Text("Icon wählen", fontSize = 20.sp, fontWeight = FontWeight.SemiBold, color = mainTextColor)
+                    Spacer(modifier = Modifier.width(48.dp)) // Placeholder for balance
+                }
+
+                // Search Bar - FULL WIDTH with Liquid Glass style
+                val searchBarModifier = if (isLiquidGlassEnabled) {
+                    val glassBrush = if (isDarkTextEnabled) {
+                        Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.10f), Color.Black.copy(alpha = 0.03f)))
+                    } else {
+                        Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.12f), Color.White.copy(alpha = 0.04f)))
+                    }
+                    val borderBrush = if (isDarkTextEnabled) {
+                        Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.2f), Color.Black.copy(alpha = 0.05f)))
+                    } else {
+                        Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.25f), Color.White.copy(alpha = 0.05f)))
+                    }
+                    Modifier
+                        .background(glassBrush, RoundedCornerShape(12.dp))
+                        .border(BorderStroke(1.dp, borderBrush), RoundedCornerShape(12.dp))
+                } else {
+                    Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+                }
+
+                Box(modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp).then(searchBarModifier)) {
+                    OutlinedTextField(
+                        value = searchQuery,
+                        onValueChange = { searchQuery = it },
+                        modifier = Modifier.fillMaxWidth(),
+                        placeholder = { Text("Icons suchen...", color = mainTextColor.copy(alpha = 0.4f)) },
+                        singleLine = true,
+                        leadingIcon = { Icon(Icons.Default.Search, contentDescription = null, tint = mainTextColor.copy(alpha = 0.4f)) },
+                        shape = RoundedCornerShape(12.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = mainTextColor,
+                            unfocusedTextColor = mainTextColor,
+                            cursorColor = mainTextColor,
+                            focusedBorderColor = Color.Transparent,
+                            unfocusedBorderColor = Color.Transparent
+                        )
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(72.dp),
+                    modifier = Modifier.weight(1f),
+                    contentPadding = PaddingValues(bottom = 32.dp, start = 8.dp, end = 8.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    items(filteredIcons) { (name, icon) ->
+                        val iconBoxModifier = if (isLiquidGlassEnabled) {
+                            val glassBrush = if (isDarkTextEnabled) {
+                                Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.08f), Color.Black.copy(alpha = 0.02f)))
+                            } else {
+                                Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.10f), Color.White.copy(alpha = 0.03f)))
+                            }
+                            Modifier.background(glassBrush, RoundedCornerShape(12.dp))
+                                .border(BorderStroke(0.5.dp, mainTextColor.copy(alpha = 0.1f)), RoundedCornerShape(12.dp))
+                        } else {
+                            Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+                        }
+
+                        Box(
+                            modifier = Modifier
+                                .aspectRatio(1f)
+                                .clip(RoundedCornerShape(12.dp))
+                                .then(iconBoxModifier)
+                                .clickable { onIconSelected(name) }
+                                .padding(4.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Icon(icon, contentDescription = name, tint = mainTextColor, modifier = Modifier.size(28.dp))
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(name, fontSize = 9.sp, color = mainTextColor.copy(alpha = 0.6f), maxLines = 1)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Retrieves a Lucide icon by name.
+ * Handles both direct members and extension properties (which are compiled to <Name>Kt classes).
+ */
+fun getLucideIconByName(name: String): ImageVector? {
+    val lucideClass = Lucide::class.java
+    
+    // 1. Try as a direct static member (Field or Method)
+    try {
+        val field = lucideClass.getField(name)
+        return field.get(null) as? ImageVector
+    } catch (e: Exception) {}
+    
+    try {
+        val methodName = if (name.startsWith("get")) name else "get$name"
+        val method = lucideClass.getMethod(methodName)
+        return method.invoke(null) as? ImageVector
+    } catch (e: Exception) {}
+
+    // 2. Try as a Kotlin extension property (compiled to com.composables.icons.lucide.<Name>Kt)
+    try {
+        // The naming convention for extension properties is usually IconNameKt
+        val className = "com.composables.icons.lucide.${name}Kt"
+        val clazz = Class.forName(className)
+        // Extension property "val Lucide.IconName" becomes "public static final ImageVector getIconName(Lucide receiver)"
+        val getterName = "get$name"
+        val method = clazz.getMethod(getterName, Lucide::class.java)
+        return method.invoke(null, Lucide) as? ImageVector
+    } catch (e: Exception) {}
+
+    return null
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import com.composables.icons.lucide.ALargeSmall
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Palette
+import com.composables.icons.lucide.Pencil
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import kotlinx.coroutines.delay
@@ -46,7 +47,7 @@ data class PaletteMenuItem(
  * - Favorites configuration
  * - Color theme configuration
  * - Size configuration
- * - System Settings
+ * - System Settings / Editing mode
  * - App Info
  */
 @Composable
@@ -69,7 +70,7 @@ fun SettingsPaletteMenu(
             PaletteMenuItem("themes", Lucide.Palette, "Themes", onOpenColorConfig),
             PaletteMenuItem("size", Lucide.ALargeSmall, "Größe", onOpenSizeConfig),
             PaletteMenuItem("favorites", Icons.Default.Star, "Favorites", onOpenFavoritesConfig),
-            PaletteMenuItem("system", Icons.Default.Settings, "System", onOpenSystemSettings),
+            PaletteMenuItem("edit", Lucide.Pencil, "Bearbeiten", onOpenSystemSettings),
             PaletteMenuItem("info", Icons.Default.Info, "Info", onOpenInfo),
         )
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
@@ -100,20 +101,27 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
     val customIconName = customIcons[app.packageName]
     val customLucideIcon = if (customIconName != null) getLucideIconByName(customIconName) else null
 
-    when {
-        customLucideIcon != null -> {
-            // Skalierung der Lucide Icons auf ca. 85% der Originalgröße für ein harmonischeres Bild
-            Icon(
-                imageVector = customLucideIcon, 
-                contentDescription = null, 
-                modifier = modifier.size(iconSize * 0.85f), 
-                tint = tintColor
-            )
+    Box(
+        modifier = modifier.size(iconSize),
+        contentAlignment = Alignment.Center
+    ) {
+        when {
+            customLucideIcon != null -> {
+                // Skalierung der Lucide Icons auf ca. 60% der Originalgröße.
+                // Wir halten den Container (Box) auf iconSize und zentrieren das Icon darin,
+                // damit die Positionierung symmetrisch zu den anderen Icons bleibt.
+                Icon(
+                    imageVector = customLucideIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(iconSize * 0.55f),
+                    tint = tintColor
+                )
+            }
+            app.lucideIcon != null -> Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = Modifier.size(iconSize), tint = tintColor)
+            app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = Modifier.size(iconSize), tint = tintColor)
+            app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = Modifier.size(iconSize), colorFilter = ColorFilter.tint(tintColor))
+            else -> Box(modifier = Modifier.size(iconSize).background(tintColor.copy(alpha = 0.05f), CircleShape))
         }
-        app.lucideIcon != null -> Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
-        app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
-        app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = modifier.size(iconSize), colorFilter = ColorFilter.tint(tintColor))
-        else -> Box(modifier = modifier.size(iconSize).background(tintColor.copy(alpha = 0.05f), CircleShape))
     }
 }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -101,7 +101,15 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
     val customLucideIcon = if (customIconName != null) getLucideIconByName(customIconName) else null
 
     when {
-        customLucideIcon != null -> Icon(imageVector = customLucideIcon, contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
+        customLucideIcon != null -> {
+            // Skalierung der Lucide Icons auf ca. 85% der Originalgröße für ein harmonischeres Bild
+            Icon(
+                imageVector = customLucideIcon, 
+                contentDescription = null, 
+                modifier = modifier.size(iconSize * 0.85f), 
+                tint = tintColor
+            )
+        }
         app.lucideIcon != null -> Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
         app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
         app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = modifier.size(iconSize), colorFilter = ColorFilter.tint(tintColor))

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -36,6 +37,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
@@ -43,6 +45,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalIconSize
 import kotlin.math.max
@@ -86,11 +89,19 @@ fun Modifier.bounceClick(interactionSource: MutableInteractionSource, enabled: B
  */
 @Composable
 fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val iconManager = remember { IconManager(context) }
+    val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
+    
     val iconSize = LocalIconSize.current.size
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val tintColor = if (isDarkTextEnabled) Color.Black else Color.White
 
+    val customIconName = customIcons[app.packageName]
+    val customLucideIcon = if (customIconName != null) getLucideIconByName(customIconName) else null
+
     when {
+        customLucideIcon != null -> Icon(imageVector = customLucideIcon, contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
         app.lucideIcon != null -> Icon(imageVector = app.lucideIcon, contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
         app.customIconResId != null -> Icon(painter = painterResource(id = app.customIconResId), contentDescription = null, modifier = modifier.size(iconSize), tint = tintColor)
         app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = modifier.size(iconSize), colorFilter = ColorFilter.tint(tintColor))


### PR DESCRIPTION
# Custom App Icons mit Lucide Icons auswählbar machen

## Beschreibung

Der Launcher soll die Möglichkeit bieten, App-Icons individuell anzupassen.

Dafür sollen Lucide Icons verwendet werden.  
Der Nutzer soll über das bestehende Einstellungsmenü einen Bereich öffnen können, in dem er für jede App ein individuelles Icon auswählen kann.

---

## Ziel

Nutzer sollen Apps visuell personalisieren können, indem sie ein Lucide Icon als Ersatz für das Standard-App-Icon festlegen.

---

## Integration ins Einstellungsmenü

- [x] Neuer Menüpunkt im bestehenden Einstellungsmenü hinzufügen
- [x] Klick öffnet den Bereich „App-Icons anpassen“

---

## Icon-Zuweisungsbereich

- [x] Liste aller installierten Apps anzeigen
- [x] Aktuell gesetztes Icon anzeigen (Standard oder Custom)
- [x] Klick auf App öffnet Icon-Auswahl
- [x] Übersicht aller verfügbaren Lucide Icons anzeigen
- [x] Auswahl eines Icons weist dieses der App zu
- [x] Möglichkeit, auf Standard-App-Icon zurückzusetzen

---

## Verhalten im Launcher

- [x] Custom Icons werden auf Startseite angezeigt
- [x] Custom Icons werden im AppDrawer angezeigt
- [x] Änderung wird sofort visuell übernommen
- [x] Keine Duplikate oder Inkonsistenzen

---

## Persistenz

- [x] Icon-Zuweisung wird persistent gespeichert (z.B. DataStore / Room)
- [x] Zuordnung bleibt nach App-Neustart erhalten

---

## Technische Hinweise (optional)

- Mapping: packageName → lucideIconName
- Fallback: Wenn kein Custom Icon gesetzt ist → Standard-App-Icon verwenden
- Performance beachten (Icon-Rendering im Grid)

---

## Akzeptanzkriterien

- Nutzer kann für jede App ein Lucide Icon auswählen
- Custom Icons werden korrekt gespeichert
- Launcher zeigt konsistente Icons in allen Bereichen
- Projekt buildet ohne Fehler
