### PR TITLE
#54

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/LauncherLogic.kt
+++ b/app/src/main/java/com/example/androidlauncher/LauncherLogic.kt
@@ -11,7 +11,7 @@ import java.util.UUID
  * This object is stateless and operates on immutable lists/objects passed to it.
  */
 object LauncherLogic {
-    const val MAX_FAVORITES = 8
+    const val MAX_FAVORITES = 6
 
     /**
      * Filters the list of apps based on a search query.

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -734,7 +734,7 @@ fun HomeScreen(
                 .padding(24.dp)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                Spacer(modifier = Modifier.height(64.dp))
+                Spacer(modifier = Modifier.height(60.dp))
                 ClockHeader(onAppLaunchForReturn = onAppLaunchForReturn, onLaunchRequest = { launchRequest = it }, returnIconPackage = returnIconPackage)
 
                 Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -734,7 +734,7 @@ fun HomeScreen(
                 .padding(24.dp)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
-                Spacer(modifier = Modifier.height(60.dp))
+                Spacer(modifier = Modifier.height(64.dp))
                 ClockHeader(onAppLaunchForReturn = onAppLaunchForReturn, onLaunchRequest = { launchRequest = it }, returnIconPackage = returnIconPackage)
 
                 Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -105,7 +105,12 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        
+        // Full Edge-to-Edge with transparent bars even in button navigation mode
+        enableEdgeToEdge(
+            statusBarStyle = androidx.activity.SystemBarStyle.auto(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT),
+            navigationBarStyle = androidx.activity.SystemBarStyle.auto(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT)
+        )
 
         // Exclude the launcher itself from the "Recent Apps" list
         intent?.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
@@ -725,6 +730,7 @@ fun HomeScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(24.dp)
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
@@ -1248,7 +1254,11 @@ fun FavoritesConfigMenu(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp), contentPadding = PaddingValues(bottom = 150.dp)) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 120.dp)
+        ) {
             if (selectedPackages.isNotEmpty()) {
                 item { Text(stringResource(R.string.order_label), color = grayTone, fontSize = 12.sp) }
                 itemsIndexed(selectedPackages) { index, pkg ->
@@ -1391,7 +1401,7 @@ fun FavoritesConfigMenu(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.BottomEnd) {
+    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding().padding(32.dp), contentAlignment = Alignment.BottomEnd) {
         val intSrc = remember { MutableInteractionSource() }
         val checkmarkColor = if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)
 

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -141,7 +141,7 @@ fun AppDrawer(
     // Fokus-Requester für das Suchfeld.
     val focusRequester = remember { FocusRequester() }
 
-    // Zustand für den aktuell geöffneten Ordner.
+    // Zustand für die aktuell geöffneten Ordner.
     var activeFolderId by remember { mutableStateOf<String?>(null) }
     val activeFolder = remember(activeFolderId, folders) {
         if (activeFolderId != null) folders.find { it.id == activeFolderId } else null
@@ -216,6 +216,7 @@ fun AppDrawer(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
+                .navigationBarsPadding()
                 .padding(horizontal = 24.dp, vertical = 16.dp)
         ) {
             // Kopfzeile mit Titel und Schließen-Button.

--- a/app/src/main/java/com/example/androidlauncher/ui/BottomSearch.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/BottomSearch.kt
@@ -140,7 +140,8 @@ fun BottomSearch(
             .clickable(interactionSource = remember { MutableInteractionSource() }, indication = null) {
                  onClose()
             }
-            .windowInsetsPadding(WindowInsets.statusBars)
+            .statusBarsPadding()
+            .navigationBarsPadding()
     ) {
         Box(
             modifier = Modifier
@@ -194,7 +195,7 @@ fun BottomSearch(
                                      .padding(vertical = 4.dp)
                                      .height(1.dp)
                                      .background(
-                                         color = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.1f) else Color.White.copy(alpha = 0.1f)
+                                         color = mainTextColor.copy(alpha = 0.1f)
                                      )
                              )
                         }

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -58,7 +58,13 @@ fun ColorConfigMenu(
         SystemWallpaperView()
         Box(modifier = Modifier.fillMaxSize().background(backgroundColor.copy(alpha = 0.95f)))
 
-        Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(horizontal = 24.dp, vertical = 16.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .statusBarsPadding()
+                .navigationBarsPadding()
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+        ) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
                 Text("Farben", fontSize = 24.sp, fontWeight = FontWeight.Light, color = mainTextColor)
                 IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = mainTextColor) }
@@ -72,7 +78,7 @@ fun ColorConfigMenu(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 // Bleibt grau (weiß mit alpha), da es eine sekundäre Info ist
-                Text("Vorschau", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp)
+                Text("Vorschau", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
 
                 val darkTextSwitchColors = if (isLiquidGlassEnabled) {
                     if (isDarkTextEnabled) {
@@ -161,7 +167,7 @@ fun ColorConfigMenu(
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 // Bleibt grau
-                Text("Themen", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp)
+                Text("Themen", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
 
                 val liquidGlassSwitchColors = if (isLiquidGlassEnabled) {
                     if (isDarkTextEnabled) {
@@ -291,7 +297,7 @@ fun PreviewCard(
             .background(glassBrush, RoundedCornerShape(16.dp))
             .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(16.dp))
     } else {
-        Modifier.background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
+        Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
     }
 
     Box(
@@ -299,7 +305,7 @@ fun PreviewCard(
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             // Karten-Titel bleibt grau
-            Text(title, color = Color.White.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
             Spacer(modifier = Modifier.height(8.dp))
             Box(
                 modifier = Modifier
@@ -416,8 +422,8 @@ fun ThemeOptionItem(
         }
     } else {
         // Standard style
-        val bgColor = if (isSelected) Color.White.copy(alpha = 0.15f) else Color.White.copy(alpha = 0.05f)
-        val border = if (isSelected) BorderStroke(1.dp, Color.White.copy(alpha = 0.3f)) else null
+        val bgColor = if (isSelected) mainTextColor.copy(alpha = 0.15f) else mainTextColor.copy(alpha = 0.05f)
+        val border = if (isSelected) BorderStroke(1.dp, mainTextColor.copy(alpha = 0.3f)) else null
 
         Modifier
             .background(bgColor, RoundedCornerShape(16.dp))

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -39,6 +39,7 @@ fun EditConfigMenu(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
+            .navigationBarsPadding()
             .padding(horizontal = 24.dp, vertical = 16.dp)
     ) {
         Row(

--- a/app/src/main/java/com/example/androidlauncher/ui/FolderConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FolderConfigMenu.kt
@@ -93,12 +93,12 @@ fun FolderConfigMenu(
                     cursorBrush = SolidColor(mainTextColor),
                     decorationBox = { 
                         if (folderName.isEmpty()) {
-                            Text("Ordnername", color = Color.White.copy(alpha = 0.4f), fontSize = 24.sp)
+                            Text("Ordnername", color = mainTextColor.copy(alpha = 0.4f), fontSize = 24.sp)
                         }
                         it() 
                     }
                 )
-                Text("${selectedPackages.size} Apps ausgewählt", fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
+                Text("${selectedPackages.size} Apps ausgewählt", fontSize = 14.sp, color = mainTextColor.copy(alpha = 0.6f))
             }
             Row {
                 IconButton(onClick = { showDeleteConfirm = true }) { 
@@ -152,7 +152,7 @@ fun FolderConfigMenu(
                 .background(glassBrush, RoundedCornerShape(12.dp))
                 .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
         } else {
-            Modifier.background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+            Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
         }
 
         Box(modifier = Modifier.fillMaxWidth().then(searchBarModifier).padding(horizontal = 16.dp, vertical = 12.dp).clickable(
@@ -160,7 +160,7 @@ fun FolderConfigMenu(
             indication = null
         ) { focusRequester.requestFocus() }) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Search, contentDescription = null, tint = Color.White.copy(alpha = 0.4f), modifier = Modifier.size(18.dp))
+                Icon(Icons.Default.Search, contentDescription = null, tint = mainTextColor.copy(alpha = 0.4f), modifier = Modifier.size(18.dp))
                 Spacer(modifier = Modifier.width(12.dp))
                 BasicTextField(
                     value = searchQuery,
@@ -171,7 +171,7 @@ fun FolderConfigMenu(
                     singleLine = true,
                     decorationBox = { 
                         if (searchQuery.isEmpty()) {
-                            Text("Apps suchen...", color = Color.White.copy(alpha = 0.4f), fontSize = 15.sp)
+                            Text("Apps suchen...", color = mainTextColor.copy(alpha = 0.4f), fontSize = 15.sp)
                         }
                         it() 
                     }
@@ -181,8 +181,12 @@ fun FolderConfigMenu(
         
         Spacer(modifier = Modifier.height(16.dp))
         
-        LazyColumn(modifier = Modifier.fillMaxSize(), verticalArrangement = Arrangement.spacedBy(8.dp), contentPadding = PaddingValues(bottom = 150.dp)) {
-            item { Text("Apps verwalten", color = Color.White.copy(alpha = 0.5f), fontSize = 12.sp) }
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 120.dp)
+        ) {
+            item { Text("Apps verwalten", color = mainTextColor.copy(alpha = 0.5f), fontSize = 12.sp) }
             items(filteredApps) { app ->
                 val isSelected = app.packageName in selectedPackages
                 // Requirement 2: Disable app if it's already in another folder
@@ -230,7 +234,7 @@ fun FolderConfigMenu(
                         .background(glassBrush, RoundedCornerShape(12.dp))
                         .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
                 } else if (isSelected) {
-                    Modifier.background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
+                    Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(12.dp))
                 } else {
                     Modifier.background(Color.Transparent, RoundedCornerShape(12.dp))
                 }
@@ -305,7 +309,7 @@ fun FolderConfigMenu(
         )
     }
 
-    Box(modifier = Modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.BottomEnd) {
+    Box(modifier = Modifier.fillMaxSize().navigationBarsPadding().padding(32.dp), contentAlignment = Alignment.BottomEnd) {
         val intSrc = remember { MutableInteractionSource() }
         val checkmarkColor = if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)
         

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -60,6 +60,7 @@ fun IconConfigMenu(
         modifier = Modifier
             .fillMaxSize()
             .statusBarsPadding()
+            .navigationBarsPadding()
             .padding(horizontal = 24.dp, vertical = 16.dp)
     ) {
         Row(
@@ -239,7 +240,7 @@ fun LucideIconPicker(
             modifier = Modifier.fillMaxSize(),
             color = MaterialTheme.colorScheme.surface
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize().navigationBarsPadding()) {
                 // Header
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),

--- a/app/src/main/java/com/example/androidlauncher/ui/InfoDialog.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/InfoDialog.kt
@@ -45,6 +45,7 @@ fun InfoDialog(
             modifier = Modifier
                 .fillMaxSize()
                 .statusBarsPadding()
+                .navigationBarsPadding()
                 .padding(horizontal = 24.dp, vertical = 16.dp)
         ) {
             Row(
@@ -166,6 +167,3 @@ fun InfoSection(
         HorizontalDivider(color = secondaryTextColor.copy(alpha = 0.2f), thickness = 0.5.dp)
     }
 }
-
-
-

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -84,7 +84,7 @@ fun SizeConfigMenu(
             Spacer(modifier = Modifier.height(24.dp))
             
             // Bleibt grau
-            Text("Vorschau", color = Color.White.copy(alpha = 0.5f), fontSize = 14.sp)
+            Text("Vorschau", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
             Spacer(modifier = Modifier.height(12.dp))
             
             // Preview Area
@@ -116,7 +116,7 @@ fun SizeConfigMenu(
             // Bleibt grau
             Text(
                 text = "Schriftgröße",
-                color = Color.White.copy(alpha = 0.5f),
+                color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
@@ -171,8 +171,8 @@ fun SizeConfigMenu(
                             .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
                     } else {
                         // Standard Style or Selected Button (which is solid)
-                        val bgColor = if (isSelected) mainTextColor else Color.White.copy(alpha = 0.1f)
-                        val border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                        val bgColor = if (isSelected) mainTextColor else mainTextColor.copy(alpha = 0.1f)
+                        val border = if (isSelected) null else BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f))
                         Modifier
                             .background(bgColor, RoundedCornerShape(12.dp))
                             .then(if (border != null) Modifier.border(border, RoundedCornerShape(12.dp)) else Modifier)
@@ -203,7 +203,7 @@ fun SizeConfigMenu(
             // Bleibt grau
             Text(
                 text = "Icon-Größe",
-                color = Color.White.copy(alpha = 0.5f),
+                color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
                 modifier = Modifier.padding(bottom = 16.dp)
             )
@@ -258,8 +258,8 @@ fun SizeConfigMenu(
                             .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
                     } else {
                         // Standard Style or Selected Button (which is solid)
-                        val bgColor = if (isSelected) mainTextColor else Color.White.copy(alpha = 0.1f)
-                        val border = if (isSelected) null else BorderStroke(1.dp, Color.White.copy(alpha = 0.2f))
+                        val bgColor = if (isSelected) mainTextColor else mainTextColor.copy(alpha = 0.1f)
+                        val border = if (isSelected) null else BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f))
                         Modifier
                             .background(bgColor, RoundedCornerShape(12.dp))
                             .then(if (border != null) Modifier.border(border, RoundedCornerShape(12.dp)) else Modifier)
@@ -290,6 +290,7 @@ fun SizeConfigMenu(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .navigationBarsPadding()
                 .padding(bottom = 32.dp, end = 24.dp, start = 24.dp),
             contentAlignment = Alignment.BottomCenter
         ) {
@@ -299,14 +300,14 @@ fun SizeConfigMenu(
                     onIconSizeSelected(IconSize.STANDARD)
                 },
                 // Bleibt grau
-                colors = ButtonDefaults.textButtonColors(contentColor = Color.White.copy(alpha = 0.6f))
+                colors = ButtonDefaults.textButtonColors(contentColor = mainTextColor.copy(alpha = 0.6f))
             ) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Icon(
                         imageVector = Icons.Default.Refresh,
                         contentDescription = null,
                         modifier = Modifier.size(16.dp),
-                        tint = Color.White.copy(alpha = 0.6f)
+                        tint = mainTextColor.copy(alpha = 0.6f)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     Text("Auf Standardwerte zurücksetzen", fontSize = 14.sp)
@@ -361,7 +362,7 @@ fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, isHom
             .background(glassBrush, RoundedCornerShape(16.dp))
             .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(16.dp))
     } else {
-        Modifier.background(Color.White.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
+        Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
     }
 
     Box(
@@ -369,7 +370,7 @@ fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, isHom
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             // Karten-Titel bleibt grau
-            Text(title, color = Color.White.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
             Spacer(modifier = Modifier.height(8.dp))
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.example.androidlauncher.ui.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -8,8 +9,12 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.IconSize
 
@@ -49,7 +54,7 @@ fun AndroidLauncherTheme(
 ) {
     val colorScheme = when {
         dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
+            val context = LocalView.current.context
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
         else -> {
@@ -62,6 +67,24 @@ fun AndroidLauncherTheme(
                 background = backgroundColor,
                 surface = backgroundColor.copy(alpha = 0.8f)
             )
+        }
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = Color.Transparent.toArgb()
+            window.navigationBarColor = Color.Transparent.toArgb()
+            
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                window.isNavigationBarContrastEnforced = false
+                window.isStatusBarContrastEnforced = false
+            }
+
+            val controller = WindowCompat.getInsetsController(window, view)
+            controller.isAppearanceLightStatusBars = darkTextEnabled
+            controller.isAppearanceLightNavigationBars = darkTextEnabled
         }
     }
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.AndroidLauncher" parent="android:Theme.Material.Light.NoActionBar" />
+    <style name="Theme.AndroidLauncher" parent="android:Theme.Material.Light.NoActionBar">
+        <item name="android:windowTranslucentStatus">false</item>
+        <item name="android:windowTranslucentNavigation">false</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <!-- Disables the automatic background contrast/scrim on API 29+ -->
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="29">false</item>
+        <item name="android:enforceStatusBarContrast" tools:targetApi="29">false</item>
+    </style>
 </resources>


### PR DESCRIPTION
# 📱 Issue: Anpassung der Navigationsleiste & Layout-Korrektur bei aktiver System-Navigationsleiste

## 🎯 Ziel

Die System-Navigationsleiste soll sich korrekt an das System-Theme anpassen und das Launcher-Layout darf bei aktiver Navigationsleiste nicht visuell verschoben oder überdeckt werden.

---

# 1️⃣ Problem: Navigationsleiste passt sich nicht dem System an

## Beschreibung

Im White Mode ist die Navigationsleiste im Launcher dauerhaft weiß  
und passt sich nicht dynamisch an das System-Theme oder den aktuellen Modus (Light/Dark) an.

## Erwartetes Verhalten

- Navigationsleiste übernimmt:
  - unsichtbaren hintergrund
- Dynamische Anpassung bei Wechsel zwischen Light/Dark Mode
- Keine feste, hartcodierte Farbe

## Anforderungen

- [x] Verwendung von WindowInsets / System UI APIs
- [x] Keine feste Hintergrundfarbe für Navigation Bar
- [x] Dynamische Aktualisierung bei Theme-Wechsel
- [x] Kontrast der Navigationsicons korrekt (hell/dunkel)

---

# 2️⃣ Layout-Verschiebung bei aktiver Navigationsleiste

## Beschreibung

Wenn das Gerät mit der klassischen Navigationsleiste (3-Button oder Gestenleiste) genutzt wird:

- Favoriten-Apps
- Uhrzeit
- Kalender-Widget

werden nicht korrekt positioniert und überlappen visuell oder sitzen zu tief.

## Ziel

Das Layout soll unabhängig vom Navigationsmodus konsistent bleiben.

## Erwartetes Verhalten

- Favoritenleiste wird automatisch oberhalb der Navigationsleiste positioniert
- Uhrzeit und Kalender-Widget behalten ihre relative Layout-Struktur
- Kein Überlappen mit der Systemleiste
- Einheitlicher Abstand auf allen Geräten

## Anforderungen

- [ ] Nutzung von WindowInsets zur Berechnung des unteren Abstands
- [ ] Dynamische Padding-Anpassung
- [ ] Kompatibilität mit:
  - 3-Button-Navigation
  - Gesten-Navigation
- [ ] Kein zusätzliches Padding bei reiner Gestensteuerung (wenn nicht nötig)

---

# 🧪 Testfälle

- [x] Navigationsleiste passt sich im Light Mode korrekt an
- [x] Navigationsleiste passt sich im Dark Mode korrekt an
- [x] Favoritenleiste wird korrekt über der Navigationsleiste positioniert
- [x] Keine UI-Überlappungen
- [x] Layout bleibt konsistent auf verschiedenen Displaygrößen
- [x] Wechsel zwischen Navigationsmodi verursacht keine Layout-Fehler

---


Favoriten und Widgets unanhängig von steuerung weil sonst hässlich.
Favoriten apps auf maximal 6 begrenzt.