### PR TITLE
#18 Notification-Badge (Benachrichtigungspunkt) auf Favoriten-Apps anzeigen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission" />
     <uses-permission android:name="android.permission.REQUEST_DELETE_PACKAGES" />
+    <uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" tools:ignore="ProtectedPermissions" />
 
     <queries>
         <intent>
@@ -31,6 +32,17 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AndroidLauncher">
+
+        <service
+            android:name=".NotificationService"
+            android:label="@string/app_name"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -700,12 +700,6 @@ fun HomeScreen(
         animationSpec = tween(300, easing = EaseInOutCubic), label = ""
     )
 
-    val settingsButtonSize by animateDpAsState(
-        targetValue = if (isSettingsOpen) 72.dp else 56.dp,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
-        label = ""
-    )
-
     LaunchedEffect(launchRequest) {
         val request = launchRequest ?: return@LaunchedEffect
         delay(280)
@@ -843,7 +837,7 @@ fun HomeScreen(
                                         scaleX = bounceScale
                                         scaleY = bounceScale
                                     }) {
-                                        AppIconView(app)
+                                        AppIconView(app, showBadge = true)
                                     }
                                     if (showLabels) {
                                         Text(

--- a/app/src/main/java/com/example/androidlauncher/NotificationService.kt
+++ b/app/src/main/java/com/example/androidlauncher/NotificationService.kt
@@ -1,0 +1,47 @@
+package com.example.androidlauncher
+
+import android.service.notification.NotificationListenerService
+import android.service.notification.StatusBarNotification
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Service that listens for notification events.
+ * Provides a real-time set of package names that have active notifications.
+ */
+class NotificationService : NotificationListenerService() {
+
+    companion object {
+        private val _activeNotificationPackages = MutableStateFlow<Set<String>>(emptySet())
+        val activeNotificationPackages = _activeNotificationPackages.asStateFlow()
+    }
+
+    override fun onListenerConnected() {
+        super.onListenerConnected()
+        updateNotifications()
+    }
+
+    override fun onNotificationPosted(sbn: StatusBarNotification?) {
+        super.onNotificationPosted(sbn)
+        updateNotifications()
+    }
+
+    override fun onNotificationRemoved(sbn: StatusBarNotification?) {
+        super.onNotificationRemoved(sbn)
+        updateNotifications()
+    }
+
+    /**
+     * Updates the flow with the current set of package names that have active notifications.
+     */
+    private fun updateNotifications() {
+        try {
+            // activeNotifications is a property of NotificationListenerService returning StatusBarNotification[]
+            val notifications = activeNotifications ?: return
+            val activePkgs = notifications.mapNotNull { it.packageName }.toSet()
+            _activeNotificationPackages.value = activePkgs
+        } catch (e: Exception) {
+            // In some cases (e.g. during binding) activeNotifications might not be available yet
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -17,23 +17,35 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Settings2
+import com.composables.icons.lucide.Bell
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 
 @Composable
 fun EditConfigMenu(
     onOpenIconConfig: () -> Unit,
     onClose: () -> Unit
 ) {
+    val context = LocalContext.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    var isNotificationEnabled by remember { mutableStateOf(isNotificationServiceEnabled(context)) }
+
+    // Re-check permission when returning to the app
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        isNotificationEnabled = isNotificationServiceEnabled(context)
+    }
 
     Column(
         modifier = Modifier
@@ -69,6 +81,27 @@ fun EditConfigMenu(
             isLiquidGlassEnabled = isLiquidGlassEnabled,
             isDarkTextEnabled = isDarkTextEnabled
         )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // Menu Point: Notification Dots
+        EditMenuItem(
+            icon = Lucide.Bell,
+            label = "Benachrichtigungs-Punkte",
+            onClick = {
+                if (!isNotificationEnabled) {
+                    openNotificationSettings(context)
+                } else {
+                    // If already enabled, maybe show a toast or just do nothing for now
+                    // as disabling requires system settings too.
+                    openNotificationSettings(context)
+                }
+            },
+            statusLabel = if (isNotificationEnabled) "An" else "Aus",
+            mainTextColor = mainTextColor,
+            isLiquidGlassEnabled = isLiquidGlassEnabled,
+            isDarkTextEnabled = isDarkTextEnabled
+        )
     }
 }
 
@@ -79,7 +112,8 @@ fun EditMenuItem(
     onClick: () -> Unit,
     mainTextColor: Color,
     isLiquidGlassEnabled: Boolean,
-    isDarkTextEnabled: Boolean
+    isDarkTextEnabled: Boolean,
+    statusLabel: String? = null
 ) {
     val backgroundModifier = if (isLiquidGlassEnabled) {
         val glassBrush = if (isDarkTextEnabled) {
@@ -150,6 +184,14 @@ fun EditMenuItem(
                 fontWeight = FontWeight.Normal,
                 modifier = Modifier.weight(1f)
             )
+            if (statusLabel != null) {
+                Text(
+                    text = statusLabel,
+                    color = mainTextColor.copy(alpha = 0.5f),
+                    fontSize = 14.sp,
+                    modifier = Modifier.padding(horizontal = 8.dp)
+                )
+            }
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                 contentDescription = null,

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -2,6 +2,7 @@ package com.example.androidlauncher.ui
 
 import android.app.Activity
 import android.app.ActivityOptions
+import android.content.ComponentName
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
@@ -58,7 +59,7 @@ import com.example.androidlauncher.ui.theme.LocalIconSize
 
 /**
  * Default system-side mapping for app icons to Lucide icons.
- * packageName -> lucideIconName
+ * Maps package names to Lucide icon names.
  */
 val DEFAULT_ICON_MAPPINGS: Map<String, String> = mapOf(
     "com.android.chrome" to "Chrome",
@@ -208,10 +209,21 @@ fun isNotificationServiceEnabled(context: Context): Boolean {
 
 /**
  * Opens the system settings to enable notification access.
+ * On Android 11+ (API 30), it attempts to open the specific detail settings for this app
+ * so the user doesn't have to find the launcher in a list.
  */
 fun openNotificationSettings(context: Context) {
-    val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
-    context.startActivity(intent)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        // Direct link to this app's notification listener settings (available from Android 11)
+        val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_DETAIL_SETTINGS)
+        val componentName = ComponentName(context, NotificationService::class.java)
+        intent.putExtra(Settings.EXTRA_NOTIFICATION_LISTENER_COMPONENT_NAME, componentName.flattenToString())
+        context.startActivity(intent)
+    } else {
+        // Fallback to the general list of notification listeners for older Android versions
+        val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
+        context.startActivity(intent)
+    }
 }
 
 /**

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.os.Build
+import android.provider.Settings
 import android.widget.Toast
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.FastOutSlowInEasing
@@ -15,11 +16,13 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Icon
@@ -46,6 +49,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.composables.icons.lucide.Lucide
+import com.example.androidlauncher.NotificationService
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
@@ -132,6 +136,7 @@ fun Modifier.bounceClick(interactionSource: MutableInteractionSource, enabled: B
  * Composable that renders an app icon.
  * Supports Vector icons (Lucide) and Bitmaps.
  * Adjusts tint based on dark text mode.
+ * Shows a notification dot if the app has active notifications.
  */
 @Composable
 fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
@@ -143,6 +148,10 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val tintColor = if (isDarkTextEnabled) Color.Black else Color.White
 
+    // Observe notifications
+    val activeNotifications by NotificationService.activeNotificationPackages.collectAsState()
+    val hasNotification = app.packageName in activeNotifications
+
     // Priority: 1. User choice, 2. System default mapping, 3. App's own lucideIcon (if any)
     val customIconName = customIcons[app.packageName] ?: DEFAULT_ICON_MAPPINGS[app.packageName]
     val lucideIcon = if (customIconName != null) getLucideIconByName(customIconName) else app.lucideIcon
@@ -153,9 +162,6 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
     ) {
         when {
             lucideIcon != null -> {
-                // Skalierung der Lucide Icons auf ca. 55% der Originalgröße.
-                // Wir halten den Container (Box) auf iconSize und zentrieren das Icon darin,
-                // damit die Positionierung symmetrisch zu den anderen Icons bleibt.
                 Icon(
                     imageVector = lucideIcon,
                     contentDescription = null,
@@ -166,7 +172,37 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
             app.iconBitmap != null -> Image(bitmap = app.iconBitmap, contentDescription = null, modifier = Modifier.size(iconSize), colorFilter = ColorFilter.tint(tintColor))
             else -> Box(modifier = Modifier.size(iconSize).background(tintColor.copy(alpha = 0.05f), CircleShape))
         }
+
+        // Notification Badge (Small Dot top right)
+        if (hasNotification) {
+            val dotSize = iconSize * 0.2f
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = iconSize * 0.05f, end = iconSize * 0.05f)
+                    .size(dotSize)
+                    .background(tintColor, CircleShape)
+                    .border(1.dp, Color.Black.copy(alpha = 0.1f), CircleShape) // Subtle border for visibility
+            )
+        }
     }
+}
+
+/**
+ * Checks if the notification listener service is enabled for this app.
+ */
+fun isNotificationServiceEnabled(context: Context): Boolean {
+    val pkgName = context.packageName
+    val flat = Settings.Secure.getString(context.contentResolver, "enabled_notification_listeners")
+    return flat != null && flat.contains(pkgName)
+}
+
+/**
+ * Opens the system settings to enable notification access.
+ */
+fun openNotificationSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS)
+    context.startActivity(intent)
 }
 
 /**

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -136,10 +137,14 @@ fun Modifier.bounceClick(interactionSource: MutableInteractionSource, enabled: B
  * Composable that renders an app icon.
  * Supports Vector icons (Lucide) and Bitmaps.
  * Adjusts tint based on dark text mode.
- * Shows a notification dot if the app has active notifications.
+ * Shows a notification dot if the app has active notifications and showBadge is true.
  */
 @Composable
-fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
+fun AppIconView(
+    app: AppInfo, 
+    modifier: Modifier = Modifier,
+    showBadge: Boolean = false
+) {
     val context = LocalContext.current
     val iconManager = remember { IconManager(context) }
     val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
@@ -148,9 +153,13 @@ fun AppIconView(app: AppInfo, modifier: Modifier = Modifier) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val tintColor = if (isDarkTextEnabled) Color.Black else Color.White
 
-    // Observe notifications
-    val activeNotifications by NotificationService.activeNotificationPackages.collectAsState()
-    val hasNotification = app.packageName in activeNotifications
+    // Observe notifications only if badge display is requested
+    val activeNotifications by if (showBadge) {
+        NotificationService.activeNotificationPackages.collectAsState()
+    } else {
+        remember { mutableStateOf(emptySet<String>()) }
+    }
+    val hasNotification = showBadge && app.packageName in activeNotifications
 
     // Priority: 1. User choice, 2. System default mapping, 3. App's own lucideIcon (if any)
     val customIconName = customIcons[app.packageName] ?: DEFAULT_ICON_MAPPINGS[app.packageName]


### PR DESCRIPTION
# Notification-Badge (Benachrichtigungspunkt) auf Favoriten-Apps anzeigen

## Beschreibung

Auf der Startseite sollen Favoriten-Apps ein kleines Benachrichtigungssymbol (z.B. kleiner Kreis / Dot) anzeigen, wenn für diese App aktive Benachrichtigungen vorhanden sind.

Das Badge soll als kleiner Kreis oben rechts auf dem App-Icon angezeigt werden.

---

## Ziel

Nutzer sollen direkt auf der Startseite erkennen können, welche Favoriten-Apps ungelesene Benachrichtigungen haben.

---

## Anforderungen

### Anzeige

- [x] Kleiner Kreis (Notification Dot) oben rechts auf dem App-Icon
- [x] Nur sichtbar, wenn aktive Benachrichtigungen vorhanden sind
- [x] Verschwindet automatisch, wenn keine Benachrichtigungen mehr vorhanden sind
- [x] Größe des Dots passt sich der Icon-Größe an (bei Größen-Presets)

---

### Verhalten

- [x] Badge aktualisiert sich in Echtzeit
- [x] Funktioniert für alle Favoriten-Apps
- [x] Kein Einfluss auf Layout oder Grid
- [x] Keine Überlagerung wichtiger UI-Elemente

---

## Technische Anforderungen

- [x] NotificationListenerService implementieren
- [x] Berechtigung für Benachrichtigungszugriff einholen
- [x] Mapping von packageName → aktive Benachrichtigungen
- [x] Reaktive UI-Aktualisierung bei Statusänderung
- [x] Performance beachten (keine unnötigen Recomposition-Schleifen)

---

## Optional (Nice-to-have)

- [ ] Anzeige der Anzahl (z.B. kleine Zahl im Badge)
- [ ] Badge-Farbe an Theme angepasst
- [x] Aktivier-/Deaktivierbar in Einstellungen

---

## Akzeptanzkriterien

- Badge erscheint bei aktiven Benachrichtigungen
- Badge verschwindet bei keiner Benachrichtigung
- Keine Performance-Einbußen
- Funktioniert mit allen Theme- und Größen-Presets
- Projekt buildet ohne Fehler
