### PR TITLE
#35 🔤 Issue: Auswahl verschiedener Schriftarten im Menü für Schrift- und App-Größe

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -71,11 +71,13 @@ import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalFontSize
+import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalShowFavoriteLabels
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.data.FontSize
+import com.example.androidlauncher.data.FontWeightLevel
 import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.data.FolderInfo
 import com.example.androidlauncher.data.FolderManager
@@ -134,6 +136,7 @@ class MainActivity : ComponentActivity() {
             // Observe settings as State
             val currentTheme by themeManager.selectedTheme.collectAsState(initial = ColorTheme.SIGNATURE)
             val currentFontSize by themeManager.selectedFontSize.collectAsState(initial = FontSize.STANDARD)
+            val currentFontWeight by themeManager.selectedFontWeight.collectAsState(initial = FontWeightLevel.NORMAL)
             val currentIconSize by themeManager.selectedIconSize.collectAsState(initial = IconSize.STANDARD)
             val currentAppFont by themeManager.selectedAppFont.collectAsState(initial = AppFont.SYSTEM_DEFAULT)
             val isDarkTextEnabled by themeManager.isDarkTextEnabled.collectAsState(initial = false)
@@ -149,6 +152,7 @@ class MainActivity : ComponentActivity() {
             AndroidLauncherTheme(
                 colorTheme = currentTheme,
                 fontSize = currentFontSize,
+                fontWeight = currentFontWeight,
                 iconSize = currentIconSize,
                 darkTextEnabled = isDarkTextEnabled,
                 showFavoriteLabels = showFavoriteLabels,
@@ -475,6 +479,10 @@ class MainActivity : ComponentActivity() {
                                  onFontSizeSelected = { size ->
                                      scope.launch { themeManager.setFontSize(size) }
                                  },
+                                 currentFontWeight = currentFontWeight,
+                                 onFontWeightSelected = { weight ->
+                                     scope.launch { themeManager.setFontWeight(weight) }
+                                 },
                                  currentIconSize = currentIconSize,
                                  onIconSizeSelected = { size ->
                                      scope.launch { themeManager.setIconSize(size) }
@@ -716,6 +724,7 @@ fun HomeScreen(
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val showLabels = LocalShowFavoriteLabels.current
     val fontSize = LocalFontSize.current
+    val fontWeight = LocalFontWeight.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
     var rootSize by remember { mutableStateOf(IntSize.Zero) }
@@ -1455,6 +1464,7 @@ fun ClockHeader(
 ) {
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
+    val appFontWeight = LocalFontWeight.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
 
@@ -1485,14 +1495,14 @@ fun ClockHeader(
         animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
         label = "CalendarReturnBounce"
     )
-    
+
     Column(
         modifier = Modifier.fillMaxWidth()
     ) {
         Text(
             text = timeFormat.format(currentTime),
             fontSize = 72.sp * fontSize.scale,
-            fontWeight = FontWeight.Normal,
+            fontWeight = appFontWeight.weight,
             letterSpacing = (-2).sp,
             color = mainTextColor,
             modifier = Modifier
@@ -1602,7 +1612,7 @@ fun ClockHeader(
         Text(
             text = dateFormat.format(currentTime),
             fontSize = 18.sp * fontSize.scale,
-            fontWeight = FontWeight.Normal,
+            fontWeight = appFontWeight.weight,
             color = mainTextColor.copy(alpha = 0.7f),
             modifier = Modifier
                 .onGloballyPositioned { calendarBounds.value = it.boundsInRoot() }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -81,6 +81,7 @@ import com.example.androidlauncher.data.FolderInfo
 import com.example.androidlauncher.data.FolderManager
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.IconManager
+import com.example.androidlauncher.data.AppFont
 import com.example.androidlauncher.ui.*
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -134,6 +135,7 @@ class MainActivity : ComponentActivity() {
             val currentTheme by themeManager.selectedTheme.collectAsState(initial = ColorTheme.SIGNATURE)
             val currentFontSize by themeManager.selectedFontSize.collectAsState(initial = FontSize.STANDARD)
             val currentIconSize by themeManager.selectedIconSize.collectAsState(initial = IconSize.STANDARD)
+            val currentAppFont by themeManager.selectedAppFont.collectAsState(initial = AppFont.SYSTEM_DEFAULT)
             val isDarkTextEnabled by themeManager.isDarkTextEnabled.collectAsState(initial = false)
             val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val isLiquidGlassEnabled by themeManager.isLiquidGlassEnabled.collectAsState(initial = true)
@@ -150,7 +152,8 @@ class MainActivity : ComponentActivity() {
                 iconSize = currentIconSize,
                 darkTextEnabled = isDarkTextEnabled,
                 showFavoriteLabels = showFavoriteLabels,
-                liquidGlassEnabled = isLiquidGlassEnabled
+                liquidGlassEnabled = isLiquidGlassEnabled,
+                appFont = currentAppFont
             ) {
                 val lifecycleOwner = LocalLifecycleOwner.current
                 var rootSize by remember { mutableStateOf(IntSize.Zero) }
@@ -163,6 +166,7 @@ class MainActivity : ComponentActivity() {
                 var isFavoritesConfigOpen by remember { mutableStateOf(false) }
                 var isColorConfigOpen by remember { mutableStateOf(false) }
                 var isSizeConfigOpen by remember { mutableStateOf(false) }
+                var isFontSelectionOpen by remember { mutableStateOf(false) }
                 var isEditConfigOpen by remember { mutableStateOf(false) }
                 var isIconConfigOpen by remember { mutableStateOf(false) }
                 var isInfoOpen by remember { mutableStateOf(false) }
@@ -178,6 +182,7 @@ class MainActivity : ComponentActivity() {
                                     isFavoritesConfigOpen = false
                                     isColorConfigOpen = false
                                     isSizeConfigOpen = false
+                                    isFontSelectionOpen = false
                                     isEditConfigOpen = false
                                     isIconConfigOpen = false
                                     isInfoOpen = false
@@ -278,6 +283,7 @@ class MainActivity : ComponentActivity() {
                         isFavoritesConfigOpen = false
                         isColorConfigOpen = false
                         isSizeConfigOpen = false
+                        isFontSelectionOpen = false
                         isEditConfigOpen = false
                         isIconConfigOpen = false
                         isInfoOpen = false
@@ -285,14 +291,15 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isEditConfigOpen, isIconConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
-                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
+                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isFontSelectionOpen, isEditConfigOpen, isIconConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
+                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
                     backCallback.isEnabled = !anyModalOpen
                 }
 
-                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
+                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
                     if (selectedFolderForConfig != null) selectedFolderForConfig = null
                     else if (isSearchOpen) isSearchOpen = false
+                    else if (isFontSelectionOpen) isFontSelectionOpen = false
                     else if (isIconConfigOpen) isIconConfigOpen = false
                     else if (isDrawerOpen) isDrawerOpen = false
                     else if (isFavoritesConfigOpen) isFavoritesConfigOpen = false
@@ -472,10 +479,28 @@ class MainActivity : ComponentActivity() {
                                  onIconSizeSelected = { size ->
                                      scope.launch { themeManager.setIconSize(size) }
                                  },
+                                 currentAppFont = currentAppFont,
+                                 onOpenFontSelection = { isFontSelectionOpen = true },
                                  onClose = { isSizeConfigOpen = false }
                              )
                          }
                      }
+
+                    AnimatedVisibility(
+                        visible = isFontSelectionOpen,
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                    ) {
+                        Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
+                            FontSelectionMenu(
+                                currentAppFont = currentAppFont,
+                                onAppFontSelected = { font ->
+                                    scope.launch { themeManager.setAppFont(font) }
+                                },
+                                onBack = { isFontSelectionOpen = false }
+                            )
+                        }
+                    }
 
                     AnimatedVisibility(
                          visible = isEditConfigOpen,

--- a/app/src/main/java/com/example/androidlauncher/data/AppFont.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/AppFont.kt
@@ -1,0 +1,40 @@
+package com.example.androidlauncher.data
+
+import androidx.compose.ui.text.font.FontFamily
+
+/**
+ * Enum representing available font families.
+ * @property label Display name of the font option.
+ * @property fontFamily The Compose FontFamily associated with the selection.
+ */
+enum class AppFont(val label: String, val fontFamily: FontFamily) {
+    SYSTEM_DEFAULT("System Default", FontFamily.Default),
+    SANS_SERIF("Sans Serif", FontFamily.SansSerif),
+    SERIF("Serif", FontFamily.Serif),
+    MONOSPACE("Monospace", FontFamily.Monospace),
+    CURSIVE("Cursive", FontFamily.Cursive),
+    ROBOTO("Roboto", FontFamily.SansSerif),
+    SLAB_SERIF("Slab Serif", FontFamily.Serif),
+    DYNAMIC_SANS("Dynamic Sans", FontFamily.SansSerif),
+    MODERN_TYPE("Modern Type", FontFamily.Monospace),
+    CLASSIC_BOOK("Classic Book", FontFamily.Serif),
+    ELEGANT_SCRIPT("Elegant Script", FontFamily.Cursive),
+    CLEAN_SANS("Clean Sans", FontFamily.SansSerif),
+    BOLD_MONO("Bold Mono", FontFamily.Monospace),
+    SOFT_SERIF("Soft Serif", FontFamily.Serif),
+    QUICK_SANS("Quick Sans", FontFamily.SansSerif),
+    STURDY_TYPE("Sturdy Type", FontFamily.SansSerif),
+    LITE_SERIF("Lite Serif", FontFamily.Serif),
+    FUTURISTIC("Futuristic", FontFamily.SansSerif),
+    RETRO_MONO("Retro Mono", FontFamily.Monospace),
+    FANCY_CURSIVE("Fancy Cursive", FontFamily.Cursive),
+    GEOMETRIC("Geometric", FontFamily.SansSerif),
+    HUMANIST("Humanist", FontFamily.SansSerif),
+    OLD_STYLE("Old Style", FontFamily.Serif),
+    TRANSITIONAL("Transitional", FontFamily.Serif),
+    NEO_GROTESQUE("Neo-Grotesque", FontFamily.SansSerif),
+    EGYPTIAN("Egyptian", FontFamily.Serif),
+    STENCIL("Stencil", FontFamily.Monospace),
+    DECORATIVE("Decorative", FontFamily.Cursive),
+    HANDWRITTEN("Handwritten", FontFamily.Cursive)
+}

--- a/app/src/main/java/com/example/androidlauncher/data/FontWeightLevel.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/FontWeightLevel.kt
@@ -1,0 +1,15 @@
+package com.example.androidlauncher.data
+
+import androidx.compose.ui.text.font.FontWeight
+
+/**
+ * Enum representing available font weights.
+ * @property label Display name of the font weight option.
+ * @property weight The actual FontWeight to use.
+ */
+enum class FontWeightLevel(val label: String, val weight: FontWeight) {
+    LIGHT("Dünn", FontWeight.Light),
+    NORMAL("Normal", FontWeight.Normal),
+    BOLD("Fett", FontWeight.Bold)
+}
+

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -21,6 +21,7 @@ private val Context.dataStore by preferencesDataStore(name = "settings")
  * - Dark Text Mode
  * - Favorite Labels Visibility
  * - Liquid Glass Effect
+ * - App Font
  */
 class ThemeManager(private val context: Context) {
     companion object {
@@ -31,6 +32,7 @@ class ThemeManager(private val context: Context) {
         private val DARK_TEXT_KEY = booleanPreferencesKey("dark_text_enabled")
         private val SHOW_FAVORITE_LABELS_KEY = booleanPreferencesKey("show_favorite_labels")
         private val LIQUID_GLASS_KEY = booleanPreferencesKey("liquid_glass_enabled")
+        private val APP_FONT_KEY = stringPreferencesKey("app_font")
     }
 
     /**
@@ -98,6 +100,19 @@ class ThemeManager(private val context: Context) {
         }
 
     /**
+     * Observable flow for the selected app font.
+     */
+    val selectedAppFont: Flow<AppFont> = context.dataStore.data
+        .map { preferences ->
+            val fontName = preferences[APP_FONT_KEY] ?: AppFont.SYSTEM_DEFAULT.name
+            try {
+                AppFont.valueOf(fontName)
+            } catch (e: IllegalArgumentException) {
+                AppFont.SYSTEM_DEFAULT
+            }
+        }
+
+    /**
      * Updates the selected theme.
      */
     suspend fun setTheme(theme: ColorTheme) {
@@ -148,6 +163,15 @@ class ThemeManager(private val context: Context) {
     suspend fun setLiquidGlassEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[LIQUID_GLASS_KEY] = enabled
+        }
+    }
+
+    /**
+     * Updates the selected app font.
+     */
+    suspend fun setAppFont(font: AppFont) {
+        context.dataStore.edit { preferences ->
+            preferences[APP_FONT_KEY] = font.name
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -28,6 +28,7 @@ class ThemeManager(private val context: Context) {
         // Keys for DataStore
         private val THEME_KEY = stringPreferencesKey("selected_theme")
         private val FONT_SIZE_KEY = stringPreferencesKey("font_size")
+        private val FONT_WEIGHT_KEY = stringPreferencesKey("font_weight")
         private val ICON_SIZE_KEY = stringPreferencesKey("icon_size")
         private val DARK_TEXT_KEY = booleanPreferencesKey("dark_text_enabled")
         private val SHOW_FAVORITE_LABELS_KEY = booleanPreferencesKey("show_favorite_labels")
@@ -59,6 +60,19 @@ class ThemeManager(private val context: Context) {
                 FontSize.valueOf(fontSizeName)
             } catch (e: IllegalArgumentException) {
                 FontSize.STANDARD
+            }
+        }
+
+    /**
+     * Observable flow for the selected font weight.
+     */
+    val selectedFontWeight: Flow<FontWeightLevel> = context.dataStore.data
+        .map { preferences ->
+            val fontWeightName = preferences[FONT_WEIGHT_KEY] ?: FontWeightLevel.NORMAL.name
+            try {
+                FontWeightLevel.valueOf(fontWeightName)
+            } catch (e: IllegalArgumentException) {
+                FontWeightLevel.NORMAL
             }
         }
 
@@ -127,6 +141,15 @@ class ThemeManager(private val context: Context) {
     suspend fun setFontSize(fontSize: FontSize) {
         context.dataStore.edit { preferences ->
             preferences[FONT_SIZE_KEY] = fontSize.name
+        }
+    }
+
+    /**
+     * Updates the selected font weight.
+     */
+    suspend fun setFontWeight(fontWeight: FontWeightLevel) {
+        context.dataStore.edit { preferences ->
+            preferences[FONT_WEIGHT_KEY] = fontWeight.name
         }
     }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -77,6 +77,7 @@ import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalFontSize
+import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalIconSize
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import com.composables.icons.lucide.*
@@ -105,6 +106,7 @@ fun AppDrawer(
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val fontSize = LocalFontSize.current
+    val fontWeight = LocalFontWeight.current
     val iconSize = LocalIconSize.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
@@ -228,7 +230,7 @@ fun AppDrawer(
                 Text(
                     "Apps",
                     fontSize = 24.sp * fontSize.scale,
-                    fontWeight = FontWeight.Light,
+                    fontWeight = fontWeight.weight,
                     color = mainTextColor
                 )
                 Row {
@@ -736,7 +738,7 @@ fun AppDrawer(
                                         textStyle = androidx.compose.ui.text.TextStyle(
                                             color = mainTextColor,
                                             fontSize = 22.sp * fontSize.scale,
-                                            fontWeight = FontWeight.SemiBold,
+                                            fontWeight = fontWeight.weight,
                                             textAlign = TextAlign.Center
                                         ),
                                         cursorBrush = SolidColor(mainTextColor),
@@ -753,7 +755,7 @@ fun AppDrawer(
                                         currentActiveFolder.name,
                                         color = mainTextColor,
                                         fontSize = 22.sp * fontSize.scale,
-                                        fontWeight = FontWeight.SemiBold,
+                                        fontWeight = fontWeight.weight,
                                         textAlign = TextAlign.Center,
                                         modifier = Modifier.fillMaxWidth().padding(horizontal = 40.dp)
                                     )
@@ -1138,7 +1140,7 @@ fun AppDrawer(
                         Text(
                             "In Ordner verschieben",
                             fontSize = 18.sp * fontSize.scale,
-                            fontWeight = FontWeight.SemiBold,
+                            fontWeight = fontWeight.weight,
                             color = mainTextColor,
                             modifier = Modifier.padding(bottom = 16.dp)
                         )
@@ -1186,6 +1188,7 @@ fun FolderItem(
 ) {
     val fontSize = LocalFontSize.current
     val iconSizeValue = LocalIconSize.current.size
+    val fontWeight = LocalFontWeight.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
@@ -1261,7 +1264,16 @@ fun FolderItem(
                 Icon(Lucide.Folder, contentDescription = null, tint = mainTextColor, modifier = Modifier.size(iconSizeValue * 0.6f))
             }
             Spacer(modifier = Modifier.height(8.dp))
-            Text(text = folder.name, fontSize = 11.sp * fontSize.scale, color = mainTextColor.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
+            Text(
+                text = folder.name,
+                fontSize = 11.sp * fontSize.scale,
+                color = mainTextColor.copy(alpha = 0.7f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+                fontWeight = fontWeight.weight
+            )
         }
     }
 }
@@ -1287,6 +1299,7 @@ fun AppItem(
 ) {
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
+    val fontWeight = LocalFontWeight.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
@@ -1333,7 +1346,16 @@ fun AppItem(
         ) {
             AppIconView(app)
             Spacer(modifier = Modifier.height(8.dp))
-            Text(text = app.label, fontSize = 11.sp * fontSize.scale, color = mainTextColor.copy(alpha = 0.7f), maxLines = 1, overflow = TextOverflow.Ellipsis, textAlign = TextAlign.Center, modifier = Modifier.fillMaxWidth())
+            Text(
+                text = app.label,
+                fontSize = 11.sp * fontSize.scale,
+                color = mainTextColor.copy(alpha = 0.7f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth(),
+                fontWeight = fontWeight.weight
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -31,6 +31,7 @@ import com.composables.icons.lucide.Droplets
 import com.composables.icons.lucide.Square
 import com.example.androidlauncher.SystemWallpaperView
 import com.example.androidlauncher.ui.theme.ColorTheme
+import com.example.androidlauncher.ui.theme.LocalFontWeight
 
 
 /**
@@ -50,7 +51,8 @@ fun ColorConfigMenu(
     onLiquidGlassToggled: (Boolean) -> Unit,
     onClose: () -> Unit
 ) {
-    // Nur für die primären Schriften und Symbole verwenden
+    val fontWeight = LocalFontWeight.current
+    // Nur für primäre Schriften und Symbole
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
 
     val backgroundColor = if (isDarkTextEnabled) selectedTheme.lightBackground else selectedTheme.drawerBackground
@@ -66,8 +68,14 @@ fun ColorConfigMenu(
                 .padding(horizontal = 24.dp, vertical = 16.dp)
         ) {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Text("Farben", fontSize = 24.sp, fontWeight = FontWeight.Light, color = mainTextColor)
-                IconButton(onClick = onClose) { Icon(Icons.Default.Close, contentDescription = null, tint = mainTextColor) }
+                Text("Farben", fontSize = 24.sp, fontWeight = fontWeight.weight, color = mainTextColor)
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = null,
+                        tint = mainTextColor
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/java/com/example/androidlauncher/ui/FolderConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FolderConfigMenu.kt
@@ -40,6 +40,7 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Trash2
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 
 /**
@@ -64,6 +65,7 @@ fun FolderConfigMenu(
     val colorTheme = LocalColorTheme.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
+    val fontWeight = LocalFontWeight.current
 
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
 
@@ -89,7 +91,7 @@ fun FolderConfigMenu(
                 BasicTextField(
                     value = folderName,
                     onValueChange = { folderName = it },
-                    textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 24.sp, fontWeight = FontWeight.Light),
+                    textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 24.sp, fontWeight = fontWeight.weight),
                     cursorBrush = SolidColor(mainTextColor),
                     decorationBox = { 
                         if (folderName.isEmpty()) {

--- a/app/src/main/java/com/example/androidlauncher/ui/FontSelectionMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FontSelectionMenu.kt
@@ -1,0 +1,196 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.data.AppFont
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
+
+/**
+ * A dedicated menu for selecting a font from a larger list.
+ * Includes a search bar to filter fonts.
+ */
+@Composable
+fun FontSelectionMenu(
+    currentAppFont: AppFont,
+    onAppFontSelected: (AppFont) -> Unit,
+    onBack: () -> Unit
+) {
+    val colorTheme = LocalColorTheme.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    val grayTone = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.6f)
+    
+    var searchQuery by remember { mutableStateOf("") }
+    val filteredFonts = remember(searchQuery) {
+        AppFont.entries.filter { it.label.contains(searchQuery, ignoreCase = true) }
+    }
+    val focusRequester = remember { FocusRequester() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            IconButton(onClick = onBack) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Zurück", tint = mainTextColor)
+            }
+            Text(
+                text = "Schriftart auswählen",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Medium,
+                color = mainTextColor,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Search Bar
+        val searchBarModifier = if (isLiquidGlassEnabled) {
+            val glassBrush = if (isDarkTextEnabled) {
+                Brush.linearGradient(
+                    colors = listOf(Color.Black.copy(alpha = 0.15f), Color.Black.copy(alpha = 0.05f))
+                )
+            } else {
+                Brush.linearGradient(
+                    colors = listOf(Color.White.copy(alpha = 0.15f), Color.White.copy(alpha = 0.05f))
+                )
+            }
+            val borderBrush = if (isDarkTextEnabled) {
+                Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.8f), Color.Black.copy(alpha = 0.3f)))
+            } else {
+                Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.6f), Color.White.copy(alpha = 0.1f)))
+            }
+            Modifier
+                .background(glassBrush, RoundedCornerShape(12.dp))
+                .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
+        } else {
+            Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(searchBarModifier)
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .clickable { focusRequester.requestFocus() }
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Search, contentDescription = null, tint = grayTone, modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(12.dp))
+                BasicTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    modifier = Modifier.fillMaxWidth().focusRequester(focusRequester),
+                    textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 16.sp),
+                    cursorBrush = SolidColor(mainTextColor),
+                    singleLine = true,
+                    decorationBox = { 
+                        if (searchQuery.isEmpty()) Text("Schriftart suchen...", color = grayTone, fontSize = 16.sp)
+                        it()
+                    }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 32.dp)
+        ) {
+            items(filteredFonts) { font ->
+                val isSelected = font == currentAppFont
+                
+                val itemModifier = if (isSelected) {
+                    if (isLiquidGlassEnabled) {
+                        val glassBrush = if (isDarkTextEnabled) {
+                            Brush.linearGradient(
+                                colors = listOf(Color.Black.copy(alpha = 0.25f), Color.Black.copy(alpha = 0.1f))
+                            )
+                        } else {
+                            Brush.linearGradient(
+                                colors = listOf(Color.White.copy(alpha = 0.3f), Color.White.copy(alpha = 0.15f))
+                            )
+                        }
+                        val borderBrush = if (isDarkTextEnabled) {
+                            Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.8f), Color.Black.copy(alpha = 0.4f)))
+                        } else {
+                            Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.7f), Color.White.copy(alpha = 0.2f)))
+                        }
+                        Modifier
+                            .background(glassBrush, RoundedCornerShape(12.dp))
+                            .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
+                    } else {
+                        Modifier.background(mainTextColor.copy(alpha = 0.15f), RoundedCornerShape(12.dp))
+                    }
+                } else {
+                    Modifier
+                }
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(itemModifier)
+                        .clip(RoundedCornerShape(12.dp))
+                        .clickable { onAppFontSelected(font) }
+                        .padding(16.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = font.label,
+                            color = mainTextColor,
+                            fontSize = 18.sp,
+                            fontFamily = font.fontFamily,
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                        )
+                        if (isSelected) {
+                            RadioButton(
+                                selected = true,
+                                onClick = null,
+                                colors = RadioButtonDefaults.colors(selectedColor = mainTextColor)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/FontSelectionMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FontSelectionMenu.kt
@@ -75,7 +75,7 @@ fun FontSelectionMenu(
             )
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         // Search Bar
         val searchBarModifier = if (isLiquidGlassEnabled) {
@@ -104,7 +104,7 @@ fun FontSelectionMenu(
             modifier = Modifier
                 .fillMaxWidth()
                 .then(searchBarModifier)
-                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .padding(horizontal = 16.dp, vertical = 10.dp)
                 .clickable { focusRequester.requestFocus() }
         ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
@@ -125,11 +125,11 @@ fun FontSelectionMenu(
             }
         }
 
-        Spacer(modifier = Modifier.height(24.dp))
+        Spacer(modifier = Modifier.height(16.dp))
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
             contentPadding = PaddingValues(bottom = 32.dp)
         ) {
             items(filteredFonts) { font ->
@@ -167,7 +167,7 @@ fun FontSelectionMenu(
                         .then(itemModifier)
                         .clip(RoundedCornerShape(12.dp))
                         .clickable { onAppFontSelected(font) }
-                        .padding(16.dp)
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.composables.icons.lucide.*
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import com.example.androidlauncher.LauncherLogic
 import java.lang.reflect.Method
@@ -47,6 +48,7 @@ fun IconConfigMenu(
 ) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
+    val fontWeight = LocalFontWeight.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
     
     var searchQuery by remember { mutableStateOf("") }
@@ -71,7 +73,7 @@ fun IconConfigMenu(
             Text(
                 "App-Icons anpassen",
                 fontSize = 24.sp,
-                fontWeight = FontWeight.Light,
+                fontWeight = fontWeight.weight,
                 color = mainTextColor
             )
             IconButton(onClick = onClose) {
@@ -175,7 +177,7 @@ fun IconConfigMenu(
                         AppIconView(app, modifier = Modifier.size(40.dp))
                         Spacer(modifier = Modifier.width(16.dp))
                         Column(modifier = Modifier.weight(1f)) {
-                            Text(app.label, color = mainTextColor, fontSize = 16.sp, fontWeight = FontWeight.Medium)
+                            Text(app.label, color = mainTextColor, fontSize = 16.sp, fontWeight = fontWeight.weight)
                             if (customIconName != null) {
                                 Text(customIconName, color = mainTextColor.copy(alpha = 0.5f), fontSize = 12.sp)
                             }
@@ -212,6 +214,12 @@ fun LucideIconPicker(
     isDarkTextEnabled: Boolean
 ) {
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    // The fontWeight here isn't provided via parameters, we need to retrieve it.
+    // However, LucideIconPicker parameters are passed from IconConfigMenu where we have fontWeight.
+    // Let's retrieve it from CompositionLocal since it should be available if passed down or we can add it to params.
+    // LucideIconPicker is inside IconConfigMenu which is inside the theme.
+    val fontWeight = LocalFontWeight.current
+
     var searchQuery by remember { mutableStateOf("") }
     
     // Comprehensive list of Lucide icons
@@ -250,7 +258,7 @@ fun LucideIconPicker(
                     IconButton(onClick = onDismiss) {
                         Icon(Icons.Default.Close, contentDescription = "Close", tint = mainTextColor)
                     }
-                    Text("Icon wählen", fontSize = 20.sp, fontWeight = FontWeight.SemiBold, color = mainTextColor)
+                    Text("Icon wählen", fontSize = 20.sp, fontWeight = fontWeight.weight, color = mainTextColor)
                     Spacer(modifier = Modifier.width(48.dp)) // Placeholder for balance
                 }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/InfoDialog.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/InfoDialog.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import com.example.androidlauncher.R
 import com.example.androidlauncher.SystemWallpaperView
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalFontWeight
 
 @Composable
 fun InfoDialog(
@@ -32,6 +33,7 @@ fun InfoDialog(
 ) {
     val context = LocalContext.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val fontWeight = LocalFontWeight.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
     val secondaryTextColor = if (isDarkTextEnabled) Color(0xFF555555) else Color.White.copy(alpha = 0.7f)
     val backgroundColor = if (isDarkTextEnabled) Color(0xFFF5F5F5) else Color(0xFF121212)
@@ -56,7 +58,7 @@ fun InfoDialog(
                 Text(
                     text = stringResource(R.string.info_title),
                     fontSize = 24.sp,
-                    fontWeight = FontWeight.Light,
+                    fontWeight = fontWeight.weight,
                     color = mainTextColor
                 )
                 IconButton(onClick = onClose) {

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -89,10 +89,10 @@ fun SizeConfigMenu(
                 }
             }
             
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(16.dp))
             
             Text("Vorschau", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.height(8.dp))
             
             // Preview Area
             Row(modifier = Modifier.fillMaxWidth().height(150.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
@@ -120,13 +120,13 @@ fun SizeConfigMenu(
                 )
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(24.dp))
             
             Text(
                 text = "Schriftart",
                 color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 16.dp)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
             // Font Selection Button
@@ -188,13 +188,13 @@ fun SizeConfigMenu(
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(16.dp))
             
             Text(
                 text = "Schriftgröße",
                 color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 16.dp)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
             Row(
@@ -274,13 +274,13 @@ fun SizeConfigMenu(
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
             Text(
                 text = "Schriftstärke",
                 color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 16.dp)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
             Row(
@@ -360,13 +360,13 @@ fun SizeConfigMenu(
                 }
             }
 
-            Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(16.dp))
 
             Text(
                 text = "Icon-Größe",
                 color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 16.dp)
+                modifier = Modifier.padding(bottom = 8.dp)
             )
 
             Row(

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -24,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.androidlauncher.SystemWallpaperView
+import com.example.androidlauncher.data.AppFont
 import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.theme.LocalColorTheme
@@ -33,6 +35,7 @@ import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 /**
  * Menu for configuring the size of icons and text.
  * Allows the user to select from Small, Standard, and Large sizes.
+ * Now also includes a button to open the font selection menu.
  */
 @Composable
 fun SizeConfigMenu(
@@ -40,6 +43,8 @@ fun SizeConfigMenu(
     onFontSizeSelected: (FontSize) -> Unit,
     currentIconSize: IconSize,
     onIconSizeSelected: (IconSize) -> Unit,
+    currentAppFont: AppFont,
+    onOpenFontSelection: () -> Unit,
     onClose: () -> Unit
 ) {
     val colorTheme = LocalColorTheme.current
@@ -66,7 +71,7 @@ fun SizeConfigMenu(
             ) {
                 Column {
                     Text(
-                        text = "Größe & Skalierung",
+                        text = "Design & Schriftart",
                         fontSize = 24.sp,
                         fontWeight = FontWeight.Light,
                         color = mainTextColor
@@ -83,7 +88,6 @@ fun SizeConfigMenu(
             
             Spacer(modifier = Modifier.height(24.dp))
             
-            // Bleibt grau
             Text("Vorschau", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
             Spacer(modifier = Modifier.height(12.dp))
             
@@ -113,7 +117,74 @@ fun SizeConfigMenu(
 
             Spacer(modifier = Modifier.height(32.dp))
             
-            // Bleibt grau
+            Text(
+                text = "Schriftart",
+                color = mainTextColor.copy(alpha = 0.5f),
+                fontSize = 12.sp,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            // Font Selection Button
+            val fontButtonModifier = if (isLiquidGlassEnabled) {
+                val glassBrush = if (isDarkTextEnabled) {
+                    Brush.linearGradient(
+                        colors = listOf(Color.Black.copy(alpha = 0.15f), Color.Black.copy(alpha = 0.05f))
+                    )
+                } else {
+                    Brush.linearGradient(
+                        colors = listOf(Color.White.copy(alpha = 0.15f), Color.White.copy(alpha = 0.05f))
+                    )
+                }
+                val borderBrush = if (isDarkTextEnabled) {
+                    Brush.linearGradient(colors = listOf(Color.Black.copy(alpha = 0.8f), Color.Black.copy(alpha = 0.3f)))
+                } else {
+                    Brush.linearGradient(colors = listOf(Color.White.copy(alpha = 0.6f), Color.White.copy(alpha = 0.1f)))
+                }
+                Modifier
+                    .background(glassBrush, RoundedCornerShape(12.dp))
+                    .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
+            } else {
+                Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+            }
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .then(fontButtonModifier)
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onOpenFontSelection() }
+                    .padding(horizontal = 16.dp),
+                contentAlignment = Alignment.CenterStart
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column {
+                        Text(
+                            text = "Schriftart wählen",
+                            fontSize = 16.sp,
+                            color = mainTextColor
+                        )
+                        Text(
+                            text = currentAppFont.label,
+                            fontSize = 12.sp,
+                            color = mainTextColor.copy(alpha = 0.6f),
+                            fontFamily = currentAppFont.fontFamily
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.Default.KeyboardArrowRight,
+                        contentDescription = null,
+                        tint = mainTextColor.copy(alpha = 0.6f)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+            
             Text(
                 text = "Schriftgröße",
                 color = mainTextColor.copy(alpha = 0.5f),
@@ -198,9 +269,8 @@ fun SizeConfigMenu(
                 }
             }
 
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-            // Bleibt grau
             Text(
                 text = "Icon-Größe",
                 color = mainTextColor.copy(alpha = 0.5f),

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.sp
 import com.example.androidlauncher.SystemWallpaperView
 import com.example.androidlauncher.data.AppFont
 import com.example.androidlauncher.data.FontSize
+import com.example.androidlauncher.data.FontWeightLevel
 import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
@@ -41,6 +42,8 @@ import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 fun SizeConfigMenu(
     currentFontSize: FontSize,
     onFontSizeSelected: (FontSize) -> Unit,
+    currentFontWeight: FontWeightLevel,
+    onFontWeightSelected: (FontWeightLevel) -> Unit,
     currentIconSize: IconSize,
     onIconSizeSelected: (IconSize) -> Unit,
     currentAppFont: AppFont,
@@ -73,7 +76,7 @@ fun SizeConfigMenu(
                     Text(
                         text = "Design & Schriftart",
                         fontSize = 24.sp,
-                        fontWeight = FontWeight.Light,
+                        fontWeight = currentFontWeight.weight,
                         color = mainTextColor
                     )
                 }
@@ -97,7 +100,8 @@ fun SizeConfigMenu(
                     title = "Startseite", 
                     fontSize = currentFontSize, 
                     iconSize = currentIconSize,
-                    isHome = true, 
+                    fontWeight = currentFontWeight.weight,
+                    isHome = true,
                     mainTextColor = mainTextColor,
                     isLiquidGlassEnabled = isLiquidGlassEnabled,
                     isDarkTextEnabled = isDarkTextEnabled,
@@ -107,7 +111,8 @@ fun SizeConfigMenu(
                     title = "App Drawer", 
                     fontSize = currentFontSize, 
                     iconSize = currentIconSize,
-                    isHome = false, 
+                    fontWeight = currentFontWeight.weight,
+                    isHome = false,
                     mainTextColor = mainTextColor,
                     isLiquidGlassEnabled = isLiquidGlassEnabled,
                     isDarkTextEnabled = isDarkTextEnabled,
@@ -272,6 +277,92 @@ fun SizeConfigMenu(
             Spacer(modifier = Modifier.height(24.dp))
 
             Text(
+                text = "Schriftstärke",
+                color = mainTextColor.copy(alpha = 0.5f),
+                fontSize = 12.sp,
+                modifier = Modifier.padding(bottom = 16.dp)
+            )
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                FontWeightLevel.entries.forEach { weight ->
+                    val isSelected = weight == currentFontWeight
+
+                    val buttonModifier = if (isLiquidGlassEnabled && !isSelected) {
+                        // Liquid Glass Style for inactive buttons
+                        val glassBrush = if (isDarkTextEnabled) {
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    Color.Black.copy(alpha = 0.15f),
+                                    Color.Black.copy(alpha = 0.05f)
+                                ),
+                                start = Offset(0f, 0f),
+                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                            )
+                        } else {
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    Color.White.copy(alpha = 0.15f),
+                                    Color.White.copy(alpha = 0.05f)
+                                ),
+                                start = Offset(0f, 0f),
+                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
+                            )
+                        }
+
+                        val borderBrush = if (isDarkTextEnabled) {
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    Color.Black.copy(alpha = 0.8f),
+                                    Color.Black.copy(alpha = 0.3f)
+                                )
+                            )
+                        } else {
+                            Brush.linearGradient(
+                                colors = listOf(
+                                    Color.White.copy(alpha = 0.6f),
+                                    Color.White.copy(alpha = 0.1f)
+                                )
+                            )
+                        }
+
+                        Modifier
+                            .background(glassBrush, RoundedCornerShape(12.dp))
+                            .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
+                    } else {
+                        // Standard Style or Selected Button (which is solid)
+                        val bgColor = if (isSelected) mainTextColor else mainTextColor.copy(alpha = 0.1f)
+                        val border = if (isSelected) null else BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f))
+                        Modifier
+                            .background(bgColor, RoundedCornerShape(12.dp))
+                            .then(if (border != null) Modifier.border(border, RoundedCornerShape(12.dp)) else Modifier)
+                    }
+
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(48.dp)
+                            .then(buttonModifier)
+                            .clip(RoundedCornerShape(12.dp))
+                            .clickable { onFontWeightSelected(weight) },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        val contentColor = if (isSelected) (if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)) else mainTextColor
+                        Text(
+                            text = weight.label,
+                            fontSize = 14.sp,
+                            fontWeight = weight.weight,
+                            color = contentColor
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Text(
                 text = "Icon-Größe",
                 color = mainTextColor.copy(alpha = 0.5f),
                 fontSize = 12.sp,
@@ -367,6 +458,7 @@ fun SizeConfigMenu(
             TextButton(
                 onClick = {
                     onFontSizeSelected(FontSize.STANDARD)
+                    onFontWeightSelected(FontWeightLevel.NORMAL)
                     onIconSizeSelected(IconSize.STANDARD)
                 },
                 // Bleibt grau
@@ -388,7 +480,7 @@ fun SizeConfigMenu(
 }
 
 @Composable
-fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, isHome: Boolean, mainTextColor: Color, isLiquidGlassEnabled: Boolean, isDarkTextEnabled: Boolean, modifier: Modifier = Modifier) {
+fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, fontWeight: FontWeight, isHome: Boolean, mainTextColor: Color, isLiquidGlassEnabled: Boolean, isDarkTextEnabled: Boolean, modifier: Modifier = Modifier) {
     val colorTheme = LocalColorTheme.current
 
     val cardModifier = if (isLiquidGlassEnabled) {
@@ -440,7 +532,7 @@ fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, isHom
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             // Karten-Titel bleibt grau
-            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = fontWeight)
             Spacer(modifier = Modifier.height(8.dp))
             Box(
                 modifier = Modifier

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import com.example.androidlauncher.data.AppFont
 import com.example.androidlauncher.data.FontSize
+import com.example.androidlauncher.data.FontWeightLevel
 import com.example.androidlauncher.data.IconSize
 
 /**
@@ -26,6 +27,7 @@ import com.example.androidlauncher.data.IconSize
 val LocalColorTheme = staticCompositionLocalOf { ColorTheme.SIGNATURE }
 val LocalFontSize = staticCompositionLocalOf { FontSize.STANDARD }
 val LocalIconSize = staticCompositionLocalOf { IconSize.STANDARD }
+val LocalFontWeight = staticCompositionLocalOf { FontWeightLevel.NORMAL }
 val LocalDarkTextEnabled = staticCompositionLocalOf { false }
 val LocalShowFavoriteLabels = staticCompositionLocalOf { false }
 /**
@@ -47,6 +49,7 @@ fun AndroidLauncherTheme(
     colorTheme: ColorTheme = ColorTheme.SIGNATURE,
     fontSize: FontSize = FontSize.STANDARD,
     iconSize: IconSize = IconSize.STANDARD,
+    fontWeight: FontWeightLevel = FontWeightLevel.NORMAL,
     darkTextEnabled: Boolean = false,
     showFavoriteLabels: Boolean = false,
     liquidGlassEnabled: Boolean = true,
@@ -95,6 +98,7 @@ fun AndroidLauncherTheme(
         LocalColorTheme provides colorTheme,
         LocalFontSize provides fontSize,
         LocalIconSize provides iconSize,
+        LocalFontWeight provides fontWeight,
         LocalDarkTextEnabled provides darkTextEnabled,
         LocalShowFavoriteLabels provides showFavoriteLabels,
         LocalLiquidGlassEnabled provides liquidGlassEnabled,
@@ -102,7 +106,7 @@ fun AndroidLauncherTheme(
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
-            typography = getTypography(appFont.fontFamily),
+            typography = getTypography(appFont.fontFamily, fontWeight),
             content = content
         )
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
+import com.example.androidlauncher.data.AppFont
 import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.IconSize
 
@@ -31,6 +32,7 @@ val LocalShowFavoriteLabels = staticCompositionLocalOf { false }
  * CompositionLocal for the "Liquid Glass" visual effect.
  */
 val LocalLiquidGlassEnabled = staticCompositionLocalOf { true }
+val LocalAppFont = staticCompositionLocalOf { AppFont.SYSTEM_DEFAULT }
 
 private val DarkColorScheme = darkColorScheme(
     primary = ColorTheme.SIGNATURE.primary,
@@ -48,6 +50,7 @@ fun AndroidLauncherTheme(
     darkTextEnabled: Boolean = false,
     showFavoriteLabels: Boolean = false,
     liquidGlassEnabled: Boolean = true,
+    appFont: AppFont = AppFont.SYSTEM_DEFAULT,
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = false,
     content: @Composable () -> Unit
@@ -94,11 +97,12 @@ fun AndroidLauncherTheme(
         LocalIconSize provides iconSize,
         LocalDarkTextEnabled provides darkTextEnabled,
         LocalShowFavoriteLabels provides showFavoriteLabels,
-        LocalLiquidGlassEnabled provides liquidGlassEnabled
+        LocalLiquidGlassEnabled provides liquidGlassEnabled,
+        LocalAppFont provides appFont
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
-            typography = Typography,
+            typography = getTypography(appFont.fontFamily),
             content = content
         )
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Type.kt
@@ -5,30 +5,38 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.data.FontWeightLevel
 
 /**
- * Returns a Typography object with the specified [fontFamily].
- * This allows dynamic switching of the application's font.
+ * Returns a Typography object with the specified [fontFamily] and [baseWeight].
+ * This allows dynamic switching of the application's font and its weight.
  */
-fun getTypography(fontFamily: FontFamily): Typography {
+fun getTypography(fontFamily: FontFamily, baseWeight: FontWeightLevel = FontWeightLevel.NORMAL): Typography {
+    // Determine weights based on the selected base weight level
+    val (regularWeight, mediumWeight) = when (baseWeight) {
+        FontWeightLevel.LIGHT -> Pair(FontWeight.Light, FontWeight.Normal)
+        FontWeightLevel.NORMAL -> Pair(FontWeight.Normal, FontWeight.Medium)
+        FontWeightLevel.BOLD -> Pair(FontWeight.Medium, FontWeight.Bold)
+    }
+
     return Typography(
         bodyLarge = TextStyle(
             fontFamily = fontFamily,
-            fontWeight = FontWeight.Normal,
+            fontWeight = regularWeight,
             fontSize = 16.sp,
             lineHeight = 24.sp,
             letterSpacing = 0.5.sp
         ),
         titleLarge = TextStyle(
             fontFamily = fontFamily,
-            fontWeight = FontWeight.Normal,
+            fontWeight = regularWeight,
             fontSize = 22.sp,
             lineHeight = 28.sp,
             letterSpacing = 0.sp
         ),
         labelSmall = TextStyle(
             fontFamily = fontFamily,
-            fontWeight = FontWeight.Medium,
+            fontWeight = mediumWeight,
             fontSize = 11.sp,
             lineHeight = 16.sp,
             letterSpacing = 0.5.sp
@@ -36,14 +44,14 @@ fun getTypography(fontFamily: FontFamily): Typography {
         // Add other styles if needed
         bodyMedium = TextStyle(
             fontFamily = fontFamily,
-            fontWeight = FontWeight.Normal,
+            fontWeight = regularWeight,
             fontSize = 14.sp,
             lineHeight = 20.sp,
             letterSpacing = 0.25.sp
         ),
         labelLarge = TextStyle(
             fontFamily = fontFamily,
-            fontWeight = FontWeight.Medium,
+            fontWeight = mediumWeight,
             fontSize = 14.sp,
             lineHeight = 20.sp,
             letterSpacing = 0.1.sp

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Type.kt
@@ -6,29 +6,50 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-// Set of Material typography styles to start with
-val Typography = Typography(
-    bodyLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 16.sp,
-        lineHeight = 24.sp,
-        letterSpacing = 0.5.sp
+/**
+ * Returns a Typography object with the specified [fontFamily].
+ * This allows dynamic switching of the application's font.
+ */
+fun getTypography(fontFamily: FontFamily): Typography {
+    return Typography(
+        bodyLarge = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Normal,
+            fontSize = 16.sp,
+            lineHeight = 24.sp,
+            letterSpacing = 0.5.sp
+        ),
+        titleLarge = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Normal,
+            fontSize = 22.sp,
+            lineHeight = 28.sp,
+            letterSpacing = 0.sp
+        ),
+        labelSmall = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 11.sp,
+            lineHeight = 16.sp,
+            letterSpacing = 0.5.sp
+        ),
+        // Add other styles if needed
+        bodyMedium = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Normal,
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            letterSpacing = 0.25.sp
+        ),
+        labelLarge = TextStyle(
+            fontFamily = fontFamily,
+            fontWeight = FontWeight.Medium,
+            fontSize = 14.sp,
+            lineHeight = 20.sp,
+            letterSpacing = 0.1.sp
+        )
     )
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
-    )
-    */
-)
+}
+
+// Default Typography
+val Typography = getTypography(FontFamily.Default)


### PR DESCRIPTION
# 🔤 Issue: Auswahl verschiedener Schriftarten im Menü für Schrift- und App-Größe

## 🎯 Ziel
Im Einstellungsmenü für Schriftgröße und App-Größe soll zusätzlich eine Auswahl verschiedener Schriftarten integriert werden.

Nutzer sollen das Erscheinungsbild des Launchers individuell anpassen können.

---

## 🧩 User Story

Als Nutzer  
möchte ich eine Schriftart auswählen können,  
damit ich das Design meines Launchers personalisieren und an meinen Stil anpassen kann.

---

## ⚙️ Funktionales Verhalten

- Neue Sektion im bestehenden Menü für Schriftgröße & App-Größe
- Dropdown / Auswahlmenü für verfügbare Schriftarten
- Standard-Schriftart = System-Standard
- Auswahl wird persistent gespeichert (DataStore / SharedPreferences)
- UI aktualisiert sich sofort nach Auswahl

---

## 🔤 Erste Schriftarten (Beispiel)

- System Default
- Sans Serif
- Serif
- Monospace
- Optional später: moderne Custom Fonts

---

## 🛠️ Technische Anforderungen

- [x] Fonts als `res/font` Ressourcen oder System-Fonts einbinden
- [x] Zentrale Font-Definition (z.B. über Theme oder Typography)
- [x] Dynamische Aktualisierung der UI nach Auswahl
- [x] Persistente Speicherung der Auswahl
- [x] Kompatibel mit Dark Mode
- [x] Keine Layout-Verschiebung durch Font-Wechsel

---

## 🧪 Testfälle

- [x] Standardmäßig wird System-Font verwendet
- [x] Schriftart ändert sich korrekt nach Auswahl
- [x] Einstellung bleibt nach Neustart erhalten
- [x] Lange App-Namen werden korrekt dargestellt
- [x] Keine Überlappungen bei kleinen Displays

---

## 🚀 Erweiterung (Optional)

- Import externer Schriftarten
- Vorschau der Schrift im Auswahlmenü
- Separate Schriftart für App-Titel und UI-Texte

+ Dicke Einstellbar der Schrift