### PR TITLE
#52 🖼️ Issue: Eigene Wallpaper für die Startseite hinzufügen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,9 @@ dependencies {
     // Lucide Icons
     implementation(libs.lucide.icons)
 
+    // uCrop
+    implementation(libs.ucrop)
+
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,6 +62,11 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.yalantis.ucrop.UCropActivity"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -76,6 +76,7 @@ import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
 import androidx.core.net.toUri
+import androidx.compose.ui.graphics.toArgb
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
@@ -174,9 +175,24 @@ class MainActivity : ComponentActivity() {
             ) { uri: Uri? ->
                 uri?.let { sourceUri ->
                     val destinationUri = Uri.fromFile(File(context.cacheDir, "cropped_wallpaper_${System.currentTimeMillis()}.jpg"))
+
+                    val options = UCrop.Options().apply {
+                        val editorBackgroundColor = if (isDarkTextEnabled) currentTheme.lightBackground.toArgb() else currentTheme.drawerBackground.toArgb()
+                        val widgetColor = if (isDarkTextEnabled) Color.Black.toArgb() else Color.White.toArgb()
+
+                        setToolbarColor(editorBackgroundColor)
+                        setStatusBarColor(editorBackgroundColor)
+                        setToolbarWidgetColor(widgetColor)
+                        setActiveControlsWidgetColor(currentTheme.primary.toArgb())
+                        setToolbarTitle("Hintergrund zuschneiden")
+                        // Hintergrund des eigentlichen Editors (hinter dem Bild) ebenfalls anpassen
+                        setLogoColor(editorBackgroundColor)
+                    }
+
                     val uCrop = UCrop.of(sourceUri, destinationUri)
                         .withAspectRatio(9f, 16f)
                         .withMaxResultSize(1080, 1920)
+                        .withOptions(options)
                         .getIntent(context)
 
                     cropLauncher.launch(uCrop)

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -14,6 +14,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.AdaptiveIconDrawable
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.provider.AlarmClock
 import android.provider.CalendarContract
@@ -566,6 +567,7 @@ class MainActivity : ComponentActivity() {
                                 onDimChange = { scope.launch { themeManager.setWallpaperDim(it) } },
                                 zoomLevel = wallpaperZoom,
                                 onZoomChange = { scope.launch { themeManager.setWallpaperZoom(it) } },
+                                customWallpaperUri = customWallpaperUri,
                                 onClose = { isWallpaperConfigOpen = false }
                             )
                         }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -25,6 +25,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
@@ -155,7 +156,7 @@ class MainActivity : ComponentActivity() {
             val scope = rememberCoroutineScope()
 
             val wallpaperPickerLauncher = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.OpenDocument()
+                contract = ActivityResultContracts.PickVisualMedia()
             ) { uri: Uri? ->
                 uri?.let {
                     try {
@@ -482,6 +483,7 @@ class MainActivity : ComponentActivity() {
                                  onLiquidGlassToggled = { enabled ->
                                     scope.launch { themeManager.setLiquidGlassEnabled(enabled) }
                                  },
+                                 customWallpaperUri = customWallpaperUri,
                                  onClose = { isColorConfigOpen = false }
                              )
                          }
@@ -508,6 +510,7 @@ class MainActivity : ComponentActivity() {
                                  },
                                  currentAppFont = currentAppFont,
                                  onOpenFontSelection = { isFontSelectionOpen = true },
+                                 customWallpaperUri = customWallpaperUri,
                                  onClose = { isSizeConfigOpen = false }
                              )
                          }
@@ -537,7 +540,11 @@ class MainActivity : ComponentActivity() {
                          Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
                              EditConfigMenu(
                                  onOpenIconConfig = { isIconConfigOpen = true },
-                                 onChangeWallpaper = { wallpaperPickerLauncher.launch(arrayOf("image/*")) },
+                                 onChangeWallpaper = { 
+                                     wallpaperPickerLauncher.launch(
+                                         PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                     ) 
+                                 },
                                  onResetWallpaper = { scope.launch { themeManager.setCustomWallpaperUri(null) } },
                                  onClose = { isEditConfigOpen = false }
                              )
@@ -568,6 +575,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
                             InfoDialog(
+                                customWallpaperUri = customWallpaperUri,
                                 onClose = { isInfoOpen = false }
                             )
                         }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -13,6 +13,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.AdaptiveIconDrawable
+import android.net.Uri
 import android.os.Bundle
 import android.provider.AlarmClock
 import android.provider.CalendarContract
@@ -21,8 +22,10 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.*
@@ -67,6 +70,7 @@ import androidx.core.content.edit
 import androidx.core.graphics.applyCanvas
 import androidx.core.graphics.createBitmap
 import androidx.core.graphics.drawable.toBitmap
+import androidx.core.net.toUri
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalColorTheme
@@ -142,12 +146,27 @@ class MainActivity : ComponentActivity() {
             val isDarkTextEnabled by themeManager.isDarkTextEnabled.collectAsState(initial = false)
             val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val isLiquidGlassEnabled by themeManager.isLiquidGlassEnabled.collectAsState(initial = true)
+            val customWallpaperUri by themeManager.customWallpaperUri.collectAsState(initial = null)
             val folders by folderManager.folders.collectAsState(initial = emptyList())
             val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
 
             val menuBackgroundColor = if (isDarkTextEnabled) currentTheme.lightBackground else currentTheme.drawerBackground
 
             val scope = rememberCoroutineScope()
+
+            val wallpaperPickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.OpenDocument()
+            ) { uri: Uri? ->
+                uri?.let {
+                    try {
+                        contentResolver.takePersistableUriPermission(it, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                        scope.launch { themeManager.setCustomWallpaperUri(it.toString()) }
+                    } catch (e: Exception) {
+                        // Fallback if persistable permission fails
+                        scope.launch { themeManager.setCustomWallpaperUri(it.toString()) }
+                    }
+                }
+            }
 
             AndroidLauncherTheme(
                 colorTheme = currentTheme,
@@ -317,7 +336,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize()
                         .onGloballyPositioned { rootSize = it.size }
                 ) {
-                    SystemWallpaperView()
+                    SystemWallpaperView(customWallpaperUri)
 
                     AnimatedContent(
                          targetState = isDrawerOpen,
@@ -518,6 +537,8 @@ class MainActivity : ComponentActivity() {
                          Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
                              EditConfigMenu(
                                  onOpenIconConfig = { isIconConfigOpen = true },
+                                 onChangeWallpaper = { wallpaperPickerLauncher.launch(arrayOf("image/*")) },
+                                 onResetWallpaper = { scope.launch { themeManager.setCustomWallpaperUri(null) } },
                                  onClose = { isEditConfigOpen = false }
                              )
                          }
@@ -678,19 +699,32 @@ private fun expandNotifications(context: Context) {
 
 @SuppressLint("MissingPermission")
 @Composable
-fun SystemWallpaperView() {
+fun SystemWallpaperView(customWallpaperUri: String? = null) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val wallpaperManager = WallpaperManager.getInstance(context)
     var wallpaperBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
 
-    LaunchedEffect(Unit) {
-        delay(300)
+    LaunchedEffect(customWallpaperUri) {
         withContext(Dispatchers.IO) {
             try {
-                val drawable = wallpaperManager.drawable
-                drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
-            } catch (_: Exception) {}
+                if (customWallpaperUri != null) {
+                    val uri = customWallpaperUri.toUri()
+                    context.contentResolver.openInputStream(uri)?.use { stream ->
+                        val b = BitmapFactory.decodeStream(stream)
+                        wallpaperBitmap = b?.asImageBitmap()
+                    }
+                } else {
+                    val drawable = wallpaperManager.drawable
+                    drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
+                }
+            } catch (e: Exception) {
+                // Fallback to system wallpaper if custom fails
+                try {
+                    val drawable = wallpaperManager.drawable
+                    drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
+                } catch (_: Exception) {}
+            }
         }
     }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -114,16 +114,13 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         
-        // Full Edge-to-Edge with transparent bars even in button navigation mode
         enableEdgeToEdge(
             statusBarStyle = androidx.activity.SystemBarStyle.auto(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT),
             navigationBarStyle = androidx.activity.SystemBarStyle.auto(android.graphics.Color.TRANSPARENT, android.graphics.Color.TRANSPARENT)
         )
 
-        // Exclude the launcher itself from the "Recent Apps" list
         intent?.addFlags(Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
 
-        // Handle Back button: Do nothing (default launcher behavior)
         backCallback = object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {}
         }
@@ -133,12 +130,10 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             val context = LocalContext.current
-            // Initialize data managers
             val themeManager = remember { ThemeManager(context) }
             val folderManager = remember { FolderManager(context) }
             val iconManager = remember { IconManager(context) }
 
-            // Observe settings as State
             val currentTheme by themeManager.selectedTheme.collectAsState(initial = ColorTheme.SIGNATURE)
             val currentFontSize by themeManager.selectedFontSize.collectAsState(initial = FontSize.STANDARD)
             val currentFontWeight by themeManager.selectedFontWeight.collectAsState(initial = FontWeightLevel.NORMAL)
@@ -163,7 +158,6 @@ class MainActivity : ComponentActivity() {
                         contentResolver.takePersistableUriPermission(it, Intent.FLAG_GRANT_READ_URI_PERMISSION)
                         scope.launch { themeManager.setCustomWallpaperUri(it.toString()) }
                     } catch (e: Exception) {
-                        // Fallback if persistable permission fails
                         scope.launch { themeManager.setCustomWallpaperUri(it.toString()) }
                     }
                 }
@@ -236,13 +230,9 @@ class MainActivity : ComponentActivity() {
                     LauncherLogic.getFavoriteApps(allApps.toList(), favoritePackages)
                 }
 
-                // Helper to load apps and icons
                 fun refreshAppList(scope: CoroutineScope, context: Context, allApps: MutableList<AppInfo>, favoritePackages: List<String>) {
                     scope.launch {
                         val basicList = withContext(Dispatchers.IO) { getAppListBasic(context) }
-
-                        // We update the list carefully to avoid unnecessary UI jumps if possible,
-                        // but a clear and addAll is simplest for now.
                         allApps.clear()
                         allApps.addAll(basicList)
 
@@ -260,7 +250,6 @@ class MainActivity : ComponentActivity() {
                                 val bitmap = loadSingleIcon(pm, cacheDir, app.packageName)
                                 if (bitmap != null) {
                                     withContext(Dispatchers.Main) {
-                                        // Re-check index after context switch
                                         if (appIdx < allApps.size && allApps[appIdx].packageName == app.packageName) {
                                             allApps[appIdx] = allApps[appIdx].copy(iconBitmap = bitmap)
                                         }
@@ -272,16 +261,13 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                // Initial load
                 LaunchedEffect(Unit) {
                     refreshAppList(scope, context, allApps, favoritePackages)
                 }
 
-                // Listen for app installs/uninstalls
                 DisposableEffect(Unit) {
                     val receiver = object : BroadcastReceiver() {
                         override fun onReceive(context: Context?, intent: Intent?) {
-                            // Delay slightly to give the system time to finalize the uninstall
                             scope.launch {
                                 delay(800)
                                 context?.let { refreshAppList(scope, it, allApps, favoritePackages) }
@@ -430,27 +416,17 @@ class MainActivity : ComponentActivity() {
                                  FolderConfigMenu(
                                      folder = folder,
                                      allApps = allApps,
-                                     allFolders = folders, // Pass all folders for duplicate check
+                                     allFolders = folders,
                                      onConfirm = { updatedFolder ->
-                                         // Check if the folder already exists in our list
                                          val folderExists = folders.any { it.id == updatedFolder.id }
-
-                                         // Determine the new folder list based on whether it's an update or a new folder
                                          val newFolders = if (folderExists) {
-                                             // Update existing folder
                                              folders.map { if (it.id == updatedFolder.id) updatedFolder else it }
                                          } else if (updatedFolder.appPackageNames.isNotEmpty()) {
-                                             // Create new folder only if at least one app is selected
                                              folders + updatedFolder
                                          } else {
-                                             // If it's a new folder but empty, don't add it (Minimalist approach)
                                              folders
                                          }
-
-                                         // Save the updated folder list to persistent storage
                                          scope.launch { folderManager.saveFolders(newFolders) }
-
-                                         // Close the configuration menu
                                          selectedFolderForConfig = null
                                      },
                                      onDelete = { folderId ->
@@ -618,9 +594,6 @@ class MainActivity : ComponentActivity() {
         enforceExcludeFromRecents()
     }
 
-    /**
-     * Ensures the activity is excluded from recents programmatically.
-     */
     private fun enforceExcludeFromRecents() {
         val am = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val tasks = am.appTasks
@@ -629,10 +602,6 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    /**
-     * Gets a simple list of installed apps.
-     * Heavy lifting (icon loading) is done asynchronously later.
-     */
     private suspend fun getAppListBasic(context: Context): List<AppInfo> {
         val pm = context.packageManager
         val intent = Intent(Intent.ACTION_MAIN, null).apply { addCategory(Intent.CATEGORY_LAUNCHER) }
@@ -714,23 +683,27 @@ fun SystemWallpaperView(customWallpaperUri: String? = null) {
     var wallpaperBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
 
     LaunchedEffect(customWallpaperUri) {
+        // Explizit auf null setzen, um einen "Flash" des alten Bildes zu vermeiden
+        wallpaperBitmap = null
         withContext(Dispatchers.IO) {
             try {
-                if (customWallpaperUri != null) {
+                if (!customWallpaperUri.isNullOrEmpty()) {
                     val uri = customWallpaperUri.toUri()
                     context.contentResolver.openInputStream(uri)?.use { stream ->
                         val b = BitmapFactory.decodeStream(stream)
-                        wallpaperBitmap = b?.asImageBitmap()
+                        val ib = b?.asImageBitmap()
+                        withContext(Dispatchers.Main) { wallpaperBitmap = ib }
                     }
                 } else {
                     val drawable = wallpaperManager.drawable
-                    drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
+                    val ib = drawable?.toBitmap()?.asImageBitmap()
+                    withContext(Dispatchers.Main) { wallpaperBitmap = ib }
                 }
             } catch (e: Exception) {
-                // Fallback to system wallpaper if custom fails
                 try {
                     val drawable = wallpaperManager.drawable
-                    drawable?.let { wallpaperBitmap = it.toBitmap().asImageBitmap() }
+                    val ib = drawable?.toBitmap()?.asImageBitmap()
+                    withContext(Dispatchers.Main) { wallpaperBitmap = ib }
                 } catch (_: Exception) {}
             }
         }
@@ -740,7 +713,6 @@ fun SystemWallpaperView(customWallpaperUri: String? = null) {
         wallpaperBitmap?.let {
             Image(bitmap = it, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
         } ?: Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(listOf(colorTheme.primary, colorTheme.secondary))))
-        // Reduzierte Overlay-Deckkraft (von 0.4f auf 0.1f), damit der Hintergrund klarer erscheint
         Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.1f)))
     }
 }
@@ -948,7 +920,6 @@ fun HomeScreen(
                 val searchIntSrc = remember { MutableInteractionSource() }
 
                 val buttonModifier = if (isLiquidGlassEnabled) {
-                    // Liquid/Glass Style für den Button
                     val glassBrush = if (isDarkTextEnabled) {
                         Brush.linearGradient(
                             colors = listOf(
@@ -988,13 +959,11 @@ fun HomeScreen(
                         .background(glassBrush, CircleShape)
                         .border(BorderStroke(1.2.dp, borderBrush), CircleShape)
                 } else {
-                    // Standard Style (Original)
                     Modifier
                         .background(mainTextColor.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f), CircleShape)
                         .then(if (isSettingsOpen) Modifier.border(BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f)), CircleShape) else Modifier)
                 }
 
-                // Spalte für Buttons (Search oben, Settings unten)
                 val settingsBtnScale by animateFloatAsState(
                     targetValue = if (isSettingsOpen) 1.2f else 1f,
                     animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
@@ -1006,7 +975,6 @@ fun HomeScreen(
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    // Search Button (nur sichtbar wenn Settings zu sind)
                     AnimatedVisibility(
                         visible = !isSettingsOpen,
                         enter = scaleIn(
@@ -1018,7 +986,6 @@ fun HomeScreen(
                         ) + fadeIn(animationSpec = tween(150)),
                         exit = scaleOut(animationSpec = tween(150)) + fadeOut(animationSpec = tween(150))
                     ) {
-                        // Animation für den Klick auf den Suchbutton (Rotation + Scale bei Aktivierung)
                         val searchButtonScale by animateFloatAsState(
                             targetValue = if (isSearchOpen) 0.8f else 1f,
                             animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy),
@@ -1056,7 +1023,6 @@ fun HomeScreen(
                         }
                     }
 
-                    // Settings Button
                     Box(
                         modifier = Modifier
                             .graphicsLayer {
@@ -1189,7 +1155,6 @@ fun FavoritesConfigMenu(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Option Toggle
         Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -1258,7 +1223,6 @@ fun FavoritesConfigMenu(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        val searchIntSrc = remember { MutableInteractionSource() }
         val searchBarModifier = if (isLiquidGlassEnabled) {
             val glassBrush = if (isDarkTextEnabled) {
                 Brush.linearGradient(
@@ -1303,10 +1267,7 @@ fun FavoritesConfigMenu(
             Modifier.background(Color.White.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
         }
 
-        Box(modifier = Modifier.fillMaxWidth().then(searchBarModifier).padding(horizontal = 16.dp, vertical = 12.dp).clickable(
-            interactionSource = searchIntSrc,
-            indication = null
-        ) { focusRequester.requestFocus() }) {
+        Box(modifier = Modifier.fillMaxWidth().then(searchBarModifier).padding(horizontal = 16.dp, vertical = 12.dp).clickable { focusRequester.requestFocus() }) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(Icons.Default.Search, contentDescription = null, tint = grayTone, modifier = Modifier.size(18.dp))
                 Spacer(modifier = Modifier.width(12.dp))

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -521,7 +521,11 @@ class MainActivity : ComponentActivity() {
                                          PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                                      ) 
                                  },
-                                 onResetWallpaper = { scope.launch { themeManager.setCustomWallpaperUri(null) } },
+                                 onResetWallpaper = { 
+                                     scope.launch { themeManager.setCustomWallpaperUri(null) }
+                                     Toast.makeText(context, "Hintergrund entfernt", Toast.LENGTH_SHORT).show()
+                                 },
+                                 isCustomWallpaperSet = customWallpaperUri != null,
                                  onClose = { isEditConfigOpen = false }
                              )
                          }
@@ -680,10 +684,9 @@ fun SystemWallpaperView(customWallpaperUri: String? = null) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val wallpaperManager = WallpaperManager.getInstance(context)
-    var wallpaperBitmap by remember { mutableStateOf<ImageBitmap?>(null) }
+    var wallpaperBitmap by remember(customWallpaperUri) { mutableStateOf<ImageBitmap?>(null) }
 
     LaunchedEffect(customWallpaperUri) {
-        // Explizit auf null setzen, um einen "Flash" des alten Bildes zu vermeiden
         wallpaperBitmap = null
         withContext(Dispatchers.IO) {
             try {

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.drawBehind
@@ -142,11 +143,14 @@ class MainActivity : ComponentActivity() {
             val isDarkTextEnabled by themeManager.isDarkTextEnabled.collectAsState(initial = false)
             val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val isLiquidGlassEnabled by themeManager.isLiquidGlassEnabled.collectAsState(initial = true)
+            
             val customWallpaperUri by themeManager.customWallpaperUri.collectAsState(initial = null)
+            val wallpaperBlur by themeManager.wallpaperBlur.collectAsState(initial = 0f)
+            val wallpaperDim by themeManager.wallpaperDim.collectAsState(initial = 0.1f)
+            val wallpaperZoom by themeManager.wallpaperZoom.collectAsState(initial = 1.0f)
+
             val folders by folderManager.folders.collectAsState(initial = emptyList())
             val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
-
-            val menuBackgroundColor = if (isDarkTextEnabled) currentTheme.lightBackground else currentTheme.drawerBackground
 
             val scope = rememberCoroutineScope()
 
@@ -174,6 +178,9 @@ class MainActivity : ComponentActivity() {
                 appFont = currentAppFont
             ) {
                 val lifecycleOwner = LocalLifecycleOwner.current
+                val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+                val menuBackgroundColor = if (isDarkTextEnabled) currentTheme.lightBackground else currentTheme.drawerBackground
+
                 var rootSize by remember { mutableStateOf(IntSize.Zero) }
                 var pendingReturnAnimation by remember { mutableStateOf<ReturnAnimation?>(null) }
                 var activeReturnAnimation by remember { mutableStateOf<ReturnAnimation?>(null) }
@@ -187,6 +194,7 @@ class MainActivity : ComponentActivity() {
                 var isFontSelectionOpen by remember { mutableStateOf(false) }
                 var isEditConfigOpen by remember { mutableStateOf(false) }
                 var isIconConfigOpen by remember { mutableStateOf(false) }
+                var isWallpaperConfigOpen by remember { mutableStateOf(false) }
                 var isInfoOpen by remember { mutableStateOf(false) }
                 var selectedFolderForConfig by remember { mutableStateOf<FolderInfo?>(null) }
 
@@ -203,6 +211,7 @@ class MainActivity : ComponentActivity() {
                                     isFontSelectionOpen = false
                                     isEditConfigOpen = false
                                     isIconConfigOpen = false
+                                    isWallpaperConfigOpen = false
                                     isInfoOpen = false
                                     selectedFolderForConfig = null
                                 }
@@ -296,20 +305,22 @@ class MainActivity : ComponentActivity() {
                         isFontSelectionOpen = false
                         isEditConfigOpen = false
                         isIconConfigOpen = false
+                        isWallpaperConfigOpen = false
                         isInfoOpen = false
                         selectedFolderForConfig = null
                     }
                 }
 
-                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isFontSelectionOpen, isEditConfigOpen, isIconConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
-                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
+                LaunchedEffect(isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen, isSizeConfigOpen, isFontSelectionOpen, isEditConfigOpen, isIconConfigOpen, isWallpaperConfigOpen, isInfoOpen, selectedFolderForConfig, isSearchOpen) {
+                    val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen || isIconConfigOpen || isWallpaperConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen
                     backCallback.isEnabled = !anyModalOpen
                 }
 
-                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen || isIconConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
+                BackHandler(enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen || isIconConfigOpen || isWallpaperConfigOpen || isInfoOpen || selectedFolderForConfig != null || isSearchOpen) {
                     if (selectedFolderForConfig != null) selectedFolderForConfig = null
                     else if (isSearchOpen) isSearchOpen = false
                     else if (isFontSelectionOpen) isFontSelectionOpen = false
+                    else if (isWallpaperConfigOpen) isWallpaperConfigOpen = false
                     else if (isIconConfigOpen) isIconConfigOpen = false
                     else if (isDrawerOpen) isDrawerOpen = false
                     else if (isFavoritesConfigOpen) isFavoritesConfigOpen = false
@@ -323,7 +334,12 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize()
                         .onGloballyPositioned { rootSize = it.size }
                 ) {
-                    SystemWallpaperView(customWallpaperUri)
+                    SystemWallpaperView(
+                        customWallpaperUri = customWallpaperUri,
+                        blurLevel = wallpaperBlur,
+                        dimLevel = wallpaperDim,
+                        zoomLevel = wallpaperZoom
+                    )
 
                     AnimatedContent(
                          targetState = isDrawerOpen,
@@ -522,14 +538,38 @@ class MainActivity : ComponentActivity() {
                                      ) 
                                  },
                                  onResetWallpaper = { 
-                                     scope.launch { themeManager.setCustomWallpaperUri(null) }
+                                     scope.launch { 
+                                         themeManager.setCustomWallpaperUri(null)
+                                         themeManager.setWallpaperBlur(0f)
+                                         themeManager.setWallpaperDim(0.1f)
+                                         themeManager.setWallpaperZoom(1.0f)
+                                     }
                                      Toast.makeText(context, "Hintergrund entfernt", Toast.LENGTH_SHORT).show()
                                  },
+                                 onOpenWallpaperAdjust = { isWallpaperConfigOpen = true },
                                  isCustomWallpaperSet = customWallpaperUri != null,
                                  onClose = { isEditConfigOpen = false }
                              )
                          }
                      }
+
+                    AnimatedVisibility(
+                        visible = isWallpaperConfigOpen,
+                        enter = slideInVertically(initialOffsetY = { it }, animationSpec = tween(300, easing = EaseOutCubic)) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { it }, animationSpec = tween(300, easing = EaseInCubic)) + fadeOut()
+                    ) {
+                        Box(modifier = Modifier.fillMaxSize().background(menuBackgroundColor)) {
+                            WallpaperConfigMenu(
+                                blurLevel = wallpaperBlur,
+                                onBlurChange = { scope.launch { themeManager.setWallpaperBlur(it) } },
+                                dimLevel = wallpaperDim,
+                                onDimChange = { scope.launch { themeManager.setWallpaperDim(it) } },
+                                zoomLevel = wallpaperZoom,
+                                onZoomChange = { scope.launch { themeManager.setWallpaperZoom(it) } },
+                                onClose = { isWallpaperConfigOpen = false }
+                            )
+                        }
+                    }
 
                     AnimatedVisibility(
                          visible = isIconConfigOpen,
@@ -680,7 +720,12 @@ private fun expandNotifications(context: Context) {
 
 @SuppressLint("MissingPermission")
 @Composable
-fun SystemWallpaperView(customWallpaperUri: String? = null) {
+fun SystemWallpaperView(
+    customWallpaperUri: String? = null,
+    blurLevel: Float = 0f,
+    dimLevel: Float = 0.1f,
+    zoomLevel: Float = 1.0f
+) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
     val wallpaperManager = WallpaperManager.getInstance(context)
@@ -714,9 +759,21 @@ fun SystemWallpaperView(customWallpaperUri: String? = null) {
 
     Box(modifier = Modifier.fillMaxSize()) {
         wallpaperBitmap?.let {
-            Image(bitmap = it, contentDescription = null, modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Crop)
+            Image(
+                bitmap = it, 
+                contentDescription = null, 
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = zoomLevel
+                        scaleY = zoomLevel
+                    }
+                    .blur(blurLevel.dp),
+                contentScale = ContentScale.Crop
+            )
         } ?: Box(modifier = Modifier.fillMaxSize().background(Brush.verticalGradient(listOf(colorTheme.primary, colorTheme.secondary))))
-        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.1f)))
+
+        Box(modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = dimLevel)))
     }
 }
 
@@ -1409,10 +1466,7 @@ fun FavoritesConfigMenu(
                     Modifier.background(Color.Transparent, RoundedCornerShape(12.dp))
                 }
 
-                Box(modifier = Modifier.fillMaxWidth().then(itemModifier).bounceClick(intSrc).clickable(
-                    interactionSource = intSrc,
-                    indication = null
-                ) {
+                Box(modifier = Modifier.fillMaxWidth().then(itemModifier).bounceClick(intSrc).clickable {
                     val newFavs = LauncherLogic.toggleFavorite(selectedPackages, app.packageName)
                     if (newFavs.size <= LauncherLogic.MAX_FAVORITES) selectedPackages = newFavs else Toast.makeText(context, context.getString(R.string.max_favorites_reached), Toast.LENGTH_SHORT).show()
                 }) {

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -16,6 +16,8 @@ import android.graphics.drawable.AdaptiveIconDrawable
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import java.io.File
+import com.yalantis.ucrop.UCrop
 import android.provider.AlarmClock
 import android.provider.CalendarContract
 import android.provider.Settings
@@ -102,7 +104,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import java.io.File
 import java.io.FileOutputStream
 import kotlin.math.max
 
@@ -155,16 +156,30 @@ class MainActivity : ComponentActivity() {
 
             val scope = rememberCoroutineScope()
 
+            val cropLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.StartActivityForResult()
+            ) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    result.data?.let { intent ->
+                        val resultUri = UCrop.getOutput(intent)
+                        resultUri?.let { uri ->
+                            scope.launch { themeManager.setCustomWallpaperUri(uri.toString()) }
+                        }
+                    }
+                }
+            }
+
             val wallpaperPickerLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.PickVisualMedia()
             ) { uri: Uri? ->
-                uri?.let {
-                    try {
-                        contentResolver.takePersistableUriPermission(it, Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                        scope.launch { themeManager.setCustomWallpaperUri(it.toString()) }
-                    } catch (e: Exception) {
-                        scope.launch { themeManager.setCustomWallpaperUri(it.toString()) }
-                    }
+                uri?.let { sourceUri ->
+                    val destinationUri = Uri.fromFile(File(context.cacheDir, "cropped_wallpaper_${System.currentTimeMillis()}.jpg"))
+                    val uCrop = UCrop.of(sourceUri, destinationUri)
+                        .withAspectRatio(9f, 16f)
+                        .withMaxResultSize(1080, 1920)
+                        .getIntent(context)
+
+                    cropLauncher.launch(uCrop)
                 }
             }
 

--- a/app/src/main/java/com/example/androidlauncher/data/IconSize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IconSize.kt
@@ -7,9 +7,10 @@ import androidx.compose.ui.unit.dp
  * Enum representing available icon size options.
  * @property label Display name of the size option.
  * @property size The Dp size of the app icon.
+ * @property scale Relative scale factor for previews.
  */
-enum class IconSize(val label: String, val size: Dp) {
-    SMALL("Klein", 40.dp),
-    STANDARD("Standard", 48.dp),
-    LARGE("Groß", 56.dp)
+enum class IconSize(val label: String, val size: Dp, val scale: Float) {
+    SMALL("Klein", 40.dp, 0.83f),
+    STANDARD("Standard", 48.dp, 1.0f),
+    LARGE("Groß", 56.dp, 1.17f)
 }

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -3,6 +3,7 @@ package com.example.androidlauncher.data
 import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.example.androidlauncher.ui.theme.ColorTheme
@@ -23,6 +24,7 @@ private val Context.dataStore by preferencesDataStore(name = "settings")
  * - Liquid Glass Effect
  * - App Font
  * - Custom Wallpaper URI
+ * - Wallpaper Blur and Dim
  */
 class ThemeManager(private val context: Context) {
     companion object {
@@ -36,6 +38,9 @@ class ThemeManager(private val context: Context) {
         private val LIQUID_GLASS_KEY = booleanPreferencesKey("liquid_glass_enabled")
         private val APP_FONT_KEY = stringPreferencesKey("app_font")
         private val CUSTOM_WALLPAPER_KEY = stringPreferencesKey("custom_wallpaper_uri")
+        private val WALLPAPER_BLUR_KEY = floatPreferencesKey("wallpaper_blur")
+        private val WALLPAPER_DIM_KEY = floatPreferencesKey("wallpaper_dim")
+        private val WALLPAPER_ZOOM_KEY = floatPreferencesKey("wallpaper_zoom")
     }
 
     /**
@@ -137,6 +142,30 @@ class ThemeManager(private val context: Context) {
         }
 
     /**
+     * Observable flow for wallpaper blur (0.0 to 25.0)
+     */
+    val wallpaperBlur: Flow<Float> = context.dataStore.data
+        .map { preferences ->
+            preferences[WALLPAPER_BLUR_KEY] ?: 0f
+        }
+
+    /**
+     * Observable flow for wallpaper dim (0.0 to 1.0)
+     */
+    val wallpaperDim: Flow<Float> = context.dataStore.data
+        .map { preferences ->
+            preferences[WALLPAPER_DIM_KEY] ?: 0.1f
+        }
+
+    /**
+     * Observable flow for wallpaper zoom (1.0 to 2.0)
+     */
+    val wallpaperZoom: Flow<Float> = context.dataStore.data
+        .map { preferences ->
+            preferences[WALLPAPER_ZOOM_KEY] ?: 1.0f
+        }
+
+    /**
      * Updates the selected theme.
      */
     suspend fun setTheme(theme: ColorTheme) {
@@ -218,6 +247,33 @@ class ThemeManager(private val context: Context) {
             } else {
                 preferences[CUSTOM_WALLPAPER_KEY] = uri
             }
+        }
+    }
+
+    /**
+     * Updates the wallpaper blur level.
+     */
+    suspend fun setWallpaperBlur(blur: Float) {
+        context.dataStore.edit { preferences ->
+            preferences[WALLPAPER_BLUR_KEY] = blur
+        }
+    }
+
+    /**
+     * Updates the wallpaper dim level.
+     */
+    suspend fun setWallpaperDim(dim: Float) {
+        context.dataStore.edit { preferences ->
+            preferences[WALLPAPER_DIM_KEY] = dim
+        }
+    }
+
+    /**
+     * Updates the wallpaper zoom level.
+     */
+    suspend fun setWallpaperZoom(zoom: Float) {
+        context.dataStore.edit { preferences ->
+            preferences[WALLPAPER_ZOOM_KEY] = zoom
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -22,6 +22,7 @@ private val Context.dataStore by preferencesDataStore(name = "settings")
  * - Favorite Labels Visibility
  * - Liquid Glass Effect
  * - App Font
+ * - Custom Wallpaper URI
  */
 class ThemeManager(private val context: Context) {
     companion object {
@@ -34,6 +35,7 @@ class ThemeManager(private val context: Context) {
         private val SHOW_FAVORITE_LABELS_KEY = booleanPreferencesKey("show_favorite_labels")
         private val LIQUID_GLASS_KEY = booleanPreferencesKey("liquid_glass_enabled")
         private val APP_FONT_KEY = stringPreferencesKey("app_font")
+        private val CUSTOM_WALLPAPER_KEY = stringPreferencesKey("custom_wallpaper_uri")
     }
 
     /**
@@ -127,6 +129,14 @@ class ThemeManager(private val context: Context) {
         }
 
     /**
+     * Observable flow for custom wallpaper URI.
+     */
+    val customWallpaperUri: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[CUSTOM_WALLPAPER_KEY]
+        }
+
+    /**
      * Updates the selected theme.
      */
     suspend fun setTheme(theme: ColorTheme) {
@@ -195,6 +205,19 @@ class ThemeManager(private val context: Context) {
     suspend fun setAppFont(font: AppFont) {
         context.dataStore.edit { preferences ->
             preferences[APP_FONT_KEY] = font.name
+        }
+    }
+
+    /**
+     * Updates the custom wallpaper URI.
+     */
+    suspend fun setCustomWallpaperUri(uri: String?) {
+        context.dataStore.edit { preferences ->
+            if (uri == null) {
+                preferences.remove(CUSTOM_WALLPAPER_KEY)
+            } else {
+                preferences[CUSTOM_WALLPAPER_KEY] = uri
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -49,6 +49,7 @@ fun ColorConfigMenu(
     onDarkTextToggled: (Boolean) -> Unit,
     isLiquidGlassEnabled: Boolean,
     onLiquidGlassToggled: (Boolean) -> Unit,
+    customWallpaperUri: String? = null,
     onClose: () -> Unit
 ) {
     val fontWeight = LocalFontWeight.current
@@ -57,7 +58,7 @@ fun ColorConfigMenu(
 
     val backgroundColor = if (isDarkTextEnabled) selectedTheme.lightBackground else selectedTheme.drawerBackground
     Box(modifier = Modifier.fillMaxSize().testTag("color_config_menu")) {
-        SystemWallpaperView()
+        SystemWallpaperView(customWallpaperUri)
         Box(modifier = Modifier.fillMaxSize().background(backgroundColor.copy(alpha = 0.95f)))
 
         Column(

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -24,6 +25,7 @@ import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Settings2
 import com.composables.icons.lucide.Bell
+import com.composables.icons.lucide.Image
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -33,6 +35,8 @@ import androidx.lifecycle.compose.LifecycleEventEffect
 @Composable
 fun EditConfigMenu(
     onOpenIconConfig: () -> Unit,
+    onChangeWallpaper: () -> Unit,
+    onResetWallpaper: () -> Unit,
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
@@ -84,6 +88,28 @@ fun EditConfigMenu(
 
         Spacer(modifier = Modifier.height(12.dp))
 
+        // Menu Point: Wallpaper ändern
+        EditMenuItem(
+            icon = Lucide.Image,
+            label = "Wallpaper ändern",
+            onClick = onChangeWallpaper,
+            mainTextColor = mainTextColor,
+            isLiquidGlassEnabled = isLiquidGlassEnabled,
+            isDarkTextEnabled = isDarkTextEnabled,
+            trailingContent = {
+                IconButton(onClick = onResetWallpaper) {
+                    Icon(
+                        imageVector = Icons.Default.Refresh,
+                        contentDescription = "Reset",
+                        tint = mainTextColor.copy(alpha = 0.4f),
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+            }
+        )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
         // Menu Point: Notification Dots
         EditMenuItem(
             icon = Lucide.Bell,
@@ -92,8 +118,6 @@ fun EditConfigMenu(
                 if (!isNotificationEnabled) {
                     openNotificationSettings(context)
                 } else {
-                    // If already enabled, maybe show a toast or just do nothing for now
-                    // as disabling requires system settings too.
                     openNotificationSettings(context)
                 }
             },
@@ -113,7 +137,8 @@ fun EditMenuItem(
     mainTextColor: Color,
     isLiquidGlassEnabled: Boolean,
     isDarkTextEnabled: Boolean,
-    statusLabel: String? = null
+    statusLabel: String? = null,
+    trailingContent: @Composable (() -> Unit)? = null
 ) {
     val backgroundModifier = if (isLiquidGlassEnabled) {
         val glassBrush = if (isDarkTextEnabled) {
@@ -192,11 +217,15 @@ fun EditMenuItem(
                     modifier = Modifier.padding(horizontal = 8.dp)
                 )
             }
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                contentDescription = null,
-                tint = mainTextColor.copy(alpha = 0.4f)
-            )
+            if (trailingContent != null) {
+                trailingContent()
+            } else {
+                Icon(
+                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    contentDescription = null,
+                    tint = mainTextColor.copy(alpha = 0.4f)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -97,7 +97,9 @@ fun EditConfigMenu(
             isLiquidGlassEnabled = isLiquidGlassEnabled,
             isDarkTextEnabled = isDarkTextEnabled,
             trailingContent = {
-                IconButton(onClick = onResetWallpaper) {
+                IconButton(onClick = { 
+                    onResetWallpaper()
+                }) {
                     Icon(
                         imageVector = Icons.Default.Refresh,
                         contentDescription = "Reset",
@@ -186,44 +188,56 @@ fun EditMenuItem(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
-            .then(backgroundModifier)
-            .clickable { onClick() },
+            .then(backgroundModifier),
         color = Color.Transparent
     ) {
         Row(
-            modifier = Modifier
-                .padding(vertical = 20.dp, horizontal = 16.dp),
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = mainTextColor,
-                modifier = Modifier.size(24.dp)
-            )
-            Spacer(modifier = Modifier.width(16.dp))
-            Text(
-                text = label,
-                color = mainTextColor,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Normal,
-                modifier = Modifier.weight(1f)
-            )
-            if (statusLabel != null) {
-                Text(
-                    text = statusLabel,
-                    color = mainTextColor.copy(alpha = 0.5f),
-                    fontSize = 14.sp,
-                    modifier = Modifier.padding(horizontal = 8.dp)
+            // Main clickable area
+            Row(
+                modifier = Modifier
+                    .weight(1f)
+                    .clickable { onClick() }
+                    .padding(vertical = 20.dp, horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = mainTextColor,
+                    modifier = Modifier.size(24.dp)
                 )
+                Spacer(modifier = Modifier.width(16.dp))
+                Text(
+                    text = label,
+                    color = mainTextColor,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Normal,
+                    modifier = Modifier.weight(1f)
+                )
+                if (statusLabel != null) {
+                    Text(
+                        text = statusLabel,
+                        color = mainTextColor.copy(alpha = 0.5f),
+                        fontSize = 14.sp,
+                        modifier = Modifier.padding(horizontal = 8.dp)
+                    )
+                }
             }
+
+            // Trailing content area (separate from main click)
             if (trailingContent != null) {
-                trailingContent()
+                Box(modifier = Modifier.padding(end = 8.dp)) {
+                    trailingContent()
+                }
             } else {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                     contentDescription = null,
-                    tint = mainTextColor.copy(alpha = 0.4f)
+                    tint = mainTextColor.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(end = 16.dp)
                 )
             }
         }

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -37,6 +36,7 @@ fun EditConfigMenu(
     onOpenIconConfig: () -> Unit,
     onChangeWallpaper: () -> Unit,
     onResetWallpaper: () -> Unit,
+    isCustomWallpaperSet: Boolean,
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
@@ -97,14 +97,21 @@ fun EditConfigMenu(
             isLiquidGlassEnabled = isLiquidGlassEnabled,
             isDarkTextEnabled = isDarkTextEnabled,
             trailingContent = {
-                IconButton(onClick = { 
-                    onResetWallpaper()
-                }) {
+                if (isCustomWallpaperSet) {
+                    IconButton(onClick = onResetWallpaper) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Remove Wallpaper",
+                            tint = mainTextColor.copy(alpha = 0.6f),
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                } else {
                     Icon(
-                        imageVector = Icons.Default.Refresh,
-                        contentDescription = "Reset",
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = null,
                         tint = mainTextColor.copy(alpha = 0.4f),
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.padding(end = 16.dp)
                     )
                 }
             }

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -36,6 +37,7 @@ fun EditConfigMenu(
     onOpenIconConfig: () -> Unit,
     onChangeWallpaper: () -> Unit,
     onResetWallpaper: () -> Unit,
+    onOpenWallpaperAdjust: () -> Unit,
     isCustomWallpaperSet: Boolean,
     onClose: () -> Unit
 ) {
@@ -46,7 +48,6 @@ fun EditConfigMenu(
 
     var isNotificationEnabled by remember { mutableStateOf(isNotificationServiceEnabled(context)) }
 
-    // Re-check permission when returning to the app
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         isNotificationEnabled = isNotificationServiceEnabled(context)
     }
@@ -76,7 +77,6 @@ fun EditConfigMenu(
 
         Spacer(modifier = Modifier.height(32.dp))
 
-        // Menu Point: App Icons anpassen
         EditMenuItem(
             icon = Lucide.Settings2,
             label = "App-Icons anpassen",
@@ -88,7 +88,6 @@ fun EditConfigMenu(
 
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Menu Point: Wallpaper ändern
         EditMenuItem(
             icon = Lucide.Image,
             label = "Wallpaper ändern",
@@ -110,25 +109,31 @@ fun EditConfigMenu(
                     Icon(
                         imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = null,
-                        tint = mainTextColor.copy(alpha = 0.4f),
-                        modifier = Modifier.padding(end = 16.dp)
+                        tint = mainTextColor.copy(alpha = 0.4f)
                     )
                 }
             }
         )
 
+        if (isCustomWallpaperSet) {
+            Spacer(modifier = Modifier.height(12.dp))
+            EditMenuItem(
+                icon = Lucide.Settings2,
+                label = "Hintergrund anpassen",
+                onClick = onOpenWallpaperAdjust,
+                mainTextColor = mainTextColor,
+                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                isDarkTextEnabled = isDarkTextEnabled
+            )
+        }
+
         Spacer(modifier = Modifier.height(12.dp))
 
-        // Menu Point: Notification Dots
         EditMenuItem(
             icon = Lucide.Bell,
             label = "Benachrichtigungs-Punkte",
             onClick = {
-                if (!isNotificationEnabled) {
-                    openNotificationSettings(context)
-                } else {
-                    openNotificationSettings(context)
-                }
+                openNotificationSettings(context)
             },
             statusLabel = if (isNotificationEnabled) "An" else "Aus",
             mainTextColor = mainTextColor,
@@ -195,56 +200,44 @@ fun EditMenuItem(
         modifier = Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(16.dp))
-            .then(backgroundModifier),
+            .then(backgroundModifier)
+            .clickable { onClick() },
         color = Color.Transparent
     ) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .padding(vertical = 20.dp, horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Main clickable area
-            Row(
-                modifier = Modifier
-                    .weight(1f)
-                    .clickable { onClick() }
-                    .padding(vertical = 20.dp, horizontal = 16.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Icon(
-                    imageVector = icon,
-                    contentDescription = null,
-                    tint = mainTextColor,
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(modifier = Modifier.width(16.dp))
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = mainTextColor,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = label,
+                color = mainTextColor,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Normal,
+                modifier = Modifier.weight(1f)
+            )
+            if (statusLabel != null) {
                 Text(
-                    text = label,
-                    color = mainTextColor,
-                    fontSize = 18.sp,
-                    fontWeight = FontWeight.Normal,
-                    modifier = Modifier.weight(1f)
+                    text = statusLabel,
+                    color = mainTextColor.copy(alpha = 0.5f),
+                    fontSize = 14.sp,
+                    modifier = Modifier.padding(horizontal = 8.dp)
                 )
-                if (statusLabel != null) {
-                    Text(
-                        text = statusLabel,
-                        color = mainTextColor.copy(alpha = 0.5f),
-                        fontSize = 14.sp,
-                        modifier = Modifier.padding(horizontal = 8.dp)
-                    )
-                }
             }
-
-            // Trailing content area (separate from main click)
             if (trailingContent != null) {
-                Box(modifier = Modifier.padding(end = 8.dp)) {
-                    trailingContent()
-                }
+                trailingContent()
             } else {
                 Icon(
                     imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                     contentDescription = null,
-                    tint = mainTextColor.copy(alpha = 0.4f),
-                    modifier = Modifier.padding(end = 16.dp)
+                    tint = mainTextColor.copy(alpha = 0.4f)
                 )
             }
         }

--- a/app/src/main/java/com/example/androidlauncher/ui/InfoDialog.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/InfoDialog.kt
@@ -29,6 +29,7 @@ import com.example.androidlauncher.ui.theme.LocalFontWeight
 
 @Composable
 fun InfoDialog(
+    customWallpaperUri: String? = null,
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
@@ -40,7 +41,7 @@ fun InfoDialog(
     val scrollState = rememberScrollState()
 
     Box(modifier = Modifier.fillMaxSize()) {
-        SystemWallpaperView()
+        SystemWallpaperView(customWallpaperUri)
         Box(modifier = Modifier.fillMaxSize().background(backgroundColor.copy(alpha = 0.95f)))
 
         Column(

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
@@ -48,6 +48,7 @@ fun SizeConfigMenu(
     onIconSizeSelected: (IconSize) -> Unit,
     currentAppFont: AppFont,
     onOpenFontSelection: () -> Unit,
+    customWallpaperUri: String? = null,
     onClose: () -> Unit
 ) {
     val colorTheme = LocalColorTheme.current
@@ -58,7 +59,7 @@ fun SizeConfigMenu(
 
     val backgroundColor = if (isDarkTextEnabled) colorTheme.lightBackground else colorTheme.drawerBackground
     Box(modifier = Modifier.fillMaxSize()) {
-        SystemWallpaperView()
+        SystemWallpaperView(customWallpaperUri)
         Box(modifier = Modifier.fillMaxSize().background(backgroundColor.copy(alpha = 0.95f)))
 
         Column(
@@ -181,7 +182,7 @@ fun SizeConfigMenu(
                         )
                     }
                     Icon(
-                        imageVector = Icons.Default.KeyboardArrowRight,
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
                         contentDescription = null,
                         tint = mainTextColor.copy(alpha = 0.6f)
                     )
@@ -300,7 +301,7 @@ fun SizeConfigMenu(
                                 ),
                                 start = Offset(0f, 0f),
                                 end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                            )
+                                )
                         } else {
                             Brush.linearGradient(
                                 colors = listOf(
@@ -446,43 +447,21 @@ fun SizeConfigMenu(
                 }
             }
         }
-
-        // Zurücksetzen Button am unteren Rand
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .navigationBarsPadding()
-                .padding(bottom = 32.dp, end = 24.dp, start = 24.dp),
-            contentAlignment = Alignment.BottomCenter
-        ) {
-            TextButton(
-                onClick = {
-                    onFontSizeSelected(FontSize.STANDARD)
-                    onFontWeightSelected(FontWeightLevel.NORMAL)
-                    onIconSizeSelected(IconSize.STANDARD)
-                },
-                // Bleibt grau
-                colors = ButtonDefaults.textButtonColors(contentColor = mainTextColor.copy(alpha = 0.6f))
-            ) {
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Icon(
-                        imageVector = Icons.Default.Refresh,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                        tint = mainTextColor.copy(alpha = 0.6f)
-                    )
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Text("Auf Standardwerte zurücksetzen", fontSize = 14.sp)
-                }
-            }
-        }
     }
 }
 
 @Composable
-fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, fontWeight: FontWeight, isHome: Boolean, mainTextColor: Color, isLiquidGlassEnabled: Boolean, isDarkTextEnabled: Boolean, modifier: Modifier = Modifier) {
-    val colorTheme = LocalColorTheme.current
-
+fun SizePreviewCard(
+    title: String, 
+    fontSize: FontSize, 
+    iconSize: IconSize,
+    fontWeight: FontWeight,
+    isHome: Boolean, 
+    mainTextColor: Color,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean,
+    modifier: Modifier = Modifier
+) {
     val cardModifier = if (isLiquidGlassEnabled) {
         val glassBrush = if (isDarkTextEnabled) {
             Brush.linearGradient(
@@ -531,56 +510,31 @@ fun SizePreviewCard(title: String, fontSize: FontSize, iconSize: IconSize, fontW
         modifier = modifier.then(cardModifier)
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
-            // Karten-Titel bleibt grau
-            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = fontWeight)
+            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
             Spacer(modifier = Modifier.height(8.dp))
             Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .clip(RoundedCornerShape(8.dp))
-                    .background(
-                        if (isHome) {
-                            Brush.verticalGradient(listOf(colorTheme.primary.copy(alpha = 0.6f), colorTheme.secondary.copy(alpha = 0.6f)))
-                        } else {
-                            if (mainTextColor == Color(0xFF010101)) {
-                                SolidColor(colorTheme.lightBackground)
-                            } else {
-                                SolidColor(colorTheme.drawerBackground)
-                            }
-                        }
-                    )
+                    .background(if (isHome) mainTextColor.copy(alpha = 0.05f) else mainTextColor.copy(alpha = 0.1f))
             ) {
                 if (isHome) {
                     Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Box(modifier = Modifier.width(40.dp * fontSize.scale).height(8.dp * fontSize.scale).background(mainTextColor.copy(alpha = 0.8f), CircleShape))
-                        Box(modifier = Modifier.width(30.dp * fontSize.scale).height(4.dp * fontSize.scale).background(mainTextColor.copy(alpha = 0.4f), CircleShape))
-                        Spacer(modifier = Modifier.height(12.dp))
-                        repeat(3) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                val dotSize = 12.dp * (iconSize.size / 48.dp)
-                                Box(modifier = Modifier.size(dotSize).border(1.dp, mainTextColor.copy(alpha = 0.5f), CircleShape))
-                                Spacer(modifier = Modifier.width(8.dp))
-                                Box(modifier = Modifier.width(40.dp * fontSize.scale).height(4.dp * fontSize.scale).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
-                            }
+                        Text("12:00", fontSize = (24.sp * fontSize.scale), fontWeight = fontWeight, color = mainTextColor)
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Box(modifier = Modifier.size(16.dp * iconSize.scale).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Box(modifier = Modifier.width(40.dp).height(4.dp).background(mainTextColor.copy(alpha = 0.1f), CircleShape))
                         }
                     }
                 } else {
                     Box(modifier = Modifier.fillMaxSize()) {
                         Column(modifier = Modifier.padding(8.dp)) {
-                            Box(modifier = Modifier.fillMaxWidth().height(16.dp * fontSize.scale).background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(4.dp)))
-                            Spacer(modifier = Modifier.height(12.dp))
-                            
-                            val columns = when (iconSize) {
-                                IconSize.SMALL -> 5
-                                IconSize.STANDARD -> 4
-                                IconSize.LARGE -> 3
-                            }
-                            val dotSize = 10.dp * (iconSize.size / 48.dp)
-                            
                             repeat(3) {
                                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-                                    repeat(columns) {
-                                        Box(modifier = Modifier.size(dotSize).border(1.dp, mainTextColor.copy(alpha = 0.7f), CircleShape))
+                                    repeat(4) {
+                                        Box(modifier = Modifier.size(12.dp * iconSize.scale).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
                                     }
                                 }
                                 Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -1,26 +1,18 @@
 package com.example.androidlauncher.ui
 
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -32,12 +24,12 @@ import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.geometry.Offset
 
-/**
- * Menu for configuring the size of icons and text.
- * Allows the user to select from Small, Standard, and Large sizes.
- * Now also includes a button to open the font selection menu.
- */
 @Composable
 fun SizeConfigMenu(
     currentFontSize: FontSize,
@@ -54,8 +46,8 @@ fun SizeConfigMenu(
     val colorTheme = LocalColorTheme.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
-    // Nur für primäre Schriften und Symbole
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    val secondaryTextColor = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.6f)
 
     val backgroundColor = if (isDarkTextEnabled) colorTheme.lightBackground else colorTheme.drawerBackground
     Box(modifier = Modifier.fillMaxSize()) {
@@ -73,14 +65,12 @@ fun SizeConfigMenu(
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Column {
-                    Text(
-                        text = "Design & Schriftart",
-                        fontSize = 24.sp,
-                        fontWeight = currentFontWeight.weight,
-                        color = mainTextColor
-                    )
-                }
+                Text(
+                    text = "Design & Schriftart",
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Light,
+                    color = mainTextColor
+                )
                 IconButton(onClick = onClose) {
                     Icon(
                         imageVector = Icons.Default.Close,
@@ -92,45 +82,61 @@ fun SizeConfigMenu(
             
             Spacer(modifier = Modifier.height(16.dp))
             
-            Text("Vorschau", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
+            Text("Vorschau", color = secondaryTextColor, fontSize = 14.sp)
             Spacer(modifier = Modifier.height(8.dp))
             
-            // Preview Area
-            Row(modifier = Modifier.fillMaxWidth().height(150.dp), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
-                SizePreviewCard(
-                    title = "Startseite", 
-                    fontSize = currentFontSize, 
-                    iconSize = currentIconSize,
-                    fontWeight = currentFontWeight.weight,
-                    isHome = true,
-                    mainTextColor = mainTextColor,
-                    isLiquidGlassEnabled = isLiquidGlassEnabled,
-                    isDarkTextEnabled = isDarkTextEnabled,
-                    modifier = Modifier.weight(1f)
-                )
-                SizePreviewCard(
-                    title = "App Drawer", 
-                    fontSize = currentFontSize, 
-                    iconSize = currentIconSize,
-                    fontWeight = currentFontWeight.weight,
-                    isHome = false,
-                    mainTextColor = mainTextColor,
-                    isLiquidGlassEnabled = isLiquidGlassEnabled,
-                    isDarkTextEnabled = isDarkTextEnabled,
-                    modifier = Modifier.weight(1f)
-                )
+            // Large Centered Preview (similar to WallpaperConfig)
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(240.dp)
+                    .clip(RoundedCornerShape(24.dp))
+                    .border(BorderStroke(1.5.dp, mainTextColor.copy(alpha = 0.2f)), RoundedCornerShape(24.dp)),
+                contentAlignment = Alignment.Center
+            ) {
+                SystemWallpaperView(customWallpaperUri)
+                
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(20.dp),
+                    horizontalAlignment = Alignment.Start
+                ) {
+                    Text(
+                        "12:00", 
+                        color = mainTextColor, 
+                        fontSize = (40.sp * currentFontSize.scale), 
+                        fontWeight = currentFontWeight.weight,
+                        letterSpacing = (-1).sp
+                    )
+                    Spacer(modifier = Modifier.height(20.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(32.dp * currentIconSize.scale)
+                                .background(mainTextColor.copy(alpha = 0.3f), CircleShape)
+                        )
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(
+                            "Favorit", 
+                            color = mainTextColor, 
+                            fontSize = (16.sp * currentFontSize.scale),
+                            fontWeight = FontWeight.Normal
+                        )
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(24.dp))
             
+            // Font Selection Button
             Text(
                 text = "Schriftart",
-                color = mainTextColor.copy(alpha = 0.5f),
+                color = secondaryTextColor,
                 fontSize = 12.sp,
                 modifier = Modifier.padding(bottom = 8.dp)
             )
 
-            // Font Selection Button
             val fontButtonModifier = if (isLiquidGlassEnabled) {
                 val glassBrush = if (isDarkTextEnabled) {
                     Brush.linearGradient(
@@ -189,360 +195,56 @@ fun SizeConfigMenu(
                 }
             }
 
-            Spacer(modifier = Modifier.height(16.dp))
+            Spacer(modifier = Modifier.height(24.dp))
             
-            Text(
-                text = "Schriftgröße",
-                color = mainTextColor.copy(alpha = 0.5f),
-                fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 8.dp)
+            // Slider for Font Size
+            Text("Schriftgröße", color = secondaryTextColor, fontSize = 12.sp)
+            val fontSizeOptions = FontSize.entries
+            Slider(
+                value = fontSizeOptions.indexOf(currentFontSize).toFloat(),
+                onValueChange = { onFontSizeSelected(fontSizeOptions[it.toInt()]) },
+                valueRange = 0f..(fontSizeOptions.size - 1).toFloat(),
+                steps = fontSizeOptions.size - 2,
+                colors = SliderDefaults.colors(
+                    thumbColor = mainTextColor,
+                    activeTrackColor = mainTextColor,
+                    inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
+                )
             )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                FontSize.entries.forEach { size ->
-                    val isSelected = size == currentFontSize
-
-                    val buttonModifier = if (isLiquidGlassEnabled && !isSelected) {
-                        // Liquid Glass Style for inactive buttons
-                        val glassBrush = if (isDarkTextEnabled) {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.Black.copy(alpha = 0.15f),
-                                    Color.Black.copy(alpha = 0.05f)
-                                ),
-                                start = Offset(0f, 0f),
-                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                            )
-                        } else {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.White.copy(alpha = 0.15f),
-                                    Color.White.copy(alpha = 0.05f)
-                                ),
-                                start = Offset(0f, 0f),
-                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                            )
-                        }
-
-                        val borderBrush = if (isDarkTextEnabled) {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.Black.copy(alpha = 0.8f),
-                                    Color.Black.copy(alpha = 0.3f)
-                                )
-                            )
-                        } else {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.White.copy(alpha = 0.6f),
-                                    Color.White.copy(alpha = 0.1f)
-                                )
-                            )
-                        }
-
-                        Modifier
-                            .background(glassBrush, RoundedCornerShape(12.dp))
-                            .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
-                    } else {
-                        // Standard Style or Selected Button (which is solid)
-                        val bgColor = if (isSelected) mainTextColor else mainTextColor.copy(alpha = 0.1f)
-                        val border = if (isSelected) null else BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f))
-                        Modifier
-                            .background(bgColor, RoundedCornerShape(12.dp))
-                            .then(if (border != null) Modifier.border(border, RoundedCornerShape(12.dp)) else Modifier)
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(48.dp)
-                            .then(buttonModifier)
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { onFontSizeSelected(size) },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        val contentColor = if (isSelected) (if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)) else mainTextColor
-                        Text(
-                            text = size.label,
-                            fontSize = 14.sp,
-                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
-                            color = contentColor
-                        )
-                    }
-                }
-            }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Text(
-                text = "Schriftstärke",
-                color = mainTextColor.copy(alpha = 0.5f),
-                fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 8.dp)
+            // Slider for Font Weight
+            Text("Schriftstärke", color = secondaryTextColor, fontSize = 12.sp)
+            val fontWeightOptions = FontWeightLevel.entries
+            Slider(
+                value = fontWeightOptions.indexOf(currentFontWeight).toFloat(),
+                onValueChange = { onFontWeightSelected(fontWeightOptions[it.toInt()]) },
+                valueRange = 0f..(fontWeightOptions.size - 1).toFloat(),
+                steps = fontWeightOptions.size - 2,
+                colors = SliderDefaults.colors(
+                    thumbColor = mainTextColor,
+                    activeTrackColor = mainTextColor,
+                    inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
+                )
             )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                FontWeightLevel.entries.forEach { weight ->
-                    val isSelected = weight == currentFontWeight
-
-                    val buttonModifier = if (isLiquidGlassEnabled && !isSelected) {
-                        // Liquid Glass Style for inactive buttons
-                        val glassBrush = if (isDarkTextEnabled) {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.Black.copy(alpha = 0.15f),
-                                    Color.Black.copy(alpha = 0.05f)
-                                ),
-                                start = Offset(0f, 0f),
-                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                                )
-                        } else {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.White.copy(alpha = 0.15f),
-                                    Color.White.copy(alpha = 0.05f)
-                                ),
-                                start = Offset(0f, 0f),
-                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                            )
-                        }
-
-                        val borderBrush = if (isDarkTextEnabled) {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.Black.copy(alpha = 0.8f),
-                                    Color.Black.copy(alpha = 0.3f)
-                                )
-                            )
-                        } else {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.White.copy(alpha = 0.6f),
-                                    Color.White.copy(alpha = 0.1f)
-                                )
-                            )
-                        }
-
-                        Modifier
-                            .background(glassBrush, RoundedCornerShape(12.dp))
-                            .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
-                    } else {
-                        // Standard Style or Selected Button (which is solid)
-                        val bgColor = if (isSelected) mainTextColor else mainTextColor.copy(alpha = 0.1f)
-                        val border = if (isSelected) null else BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f))
-                        Modifier
-                            .background(bgColor, RoundedCornerShape(12.dp))
-                            .then(if (border != null) Modifier.border(border, RoundedCornerShape(12.dp)) else Modifier)
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(48.dp)
-                            .then(buttonModifier)
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { onFontWeightSelected(weight) },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        val contentColor = if (isSelected) (if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)) else mainTextColor
-                        Text(
-                            text = weight.label,
-                            fontSize = 14.sp,
-                            fontWeight = weight.weight,
-                            color = contentColor
-                        )
-                    }
-                }
-            }
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            Text(
-                text = "Icon-Größe",
-                color = mainTextColor.copy(alpha = 0.5f),
-                fontSize = 12.sp,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
-
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                IconSize.entries.forEach { size ->
-                    val isSelected = size == currentIconSize
-
-                    val buttonModifier = if (isLiquidGlassEnabled && !isSelected) {
-                        // Liquid Glass Style for inactive buttons
-                        val glassBrush = if (isDarkTextEnabled) {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.Black.copy(alpha = 0.15f),
-                                    Color.Black.copy(alpha = 0.05f)
-                                ),
-                                start = Offset(0f, 0f),
-                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                            )
-                        } else {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.White.copy(alpha = 0.15f),
-                                    Color.White.copy(alpha = 0.05f)
-                                ),
-                                start = Offset(0f, 0f),
-                                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-                            )
-                        }
-
-                        val borderBrush = if (isDarkTextEnabled) {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.Black.copy(alpha = 0.8f),
-                                    Color.Black.copy(alpha = 0.3f)
-                                )
-                            )
-                        } else {
-                            Brush.linearGradient(
-                                colors = listOf(
-                                    Color.White.copy(alpha = 0.6f),
-                                    Color.White.copy(alpha = 0.1f)
-                                )
-                            )
-                        }
-
-                        Modifier
-                            .background(glassBrush, RoundedCornerShape(12.dp))
-                            .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(12.dp))
-                    } else {
-                        // Standard Style or Selected Button (which is solid)
-                        val bgColor = if (isSelected) mainTextColor else mainTextColor.copy(alpha = 0.1f)
-                        val border = if (isSelected) null else BorderStroke(1.dp, mainTextColor.copy(alpha = 0.2f))
-                        Modifier
-                            .background(bgColor, RoundedCornerShape(12.dp))
-                            .then(if (border != null) Modifier.border(border, RoundedCornerShape(12.dp)) else Modifier)
-                    }
-
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .height(48.dp)
-                            .then(buttonModifier)
-                            .clip(RoundedCornerShape(12.dp))
-                            .clickable { onIconSizeSelected(size) },
-                        contentAlignment = Alignment.Center
-                    ) {
-                        val contentColor = if (isSelected) (if (isDarkTextEnabled) Color.White else Color(0xFF0F172A)) else mainTextColor
-                        Text(
-                            text = size.label,
-                            fontSize = 14.sp,
-                            fontWeight = if (isSelected) FontWeight.Medium else FontWeight.Normal,
-                            color = contentColor
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun SizePreviewCard(
-    title: String, 
-    fontSize: FontSize, 
-    iconSize: IconSize,
-    fontWeight: FontWeight,
-    isHome: Boolean, 
-    mainTextColor: Color,
-    isLiquidGlassEnabled: Boolean,
-    isDarkTextEnabled: Boolean,
-    modifier: Modifier = Modifier
-) {
-    val cardModifier = if (isLiquidGlassEnabled) {
-        val glassBrush = if (isDarkTextEnabled) {
-            Brush.linearGradient(
-                colors = listOf(
-                    Color.Black.copy(alpha = 0.15f),
-                    Color.Black.copy(alpha = 0.05f)
-                ),
-                start = Offset(0f, 0f),
-                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-            )
-        } else {
-            Brush.linearGradient(
-                colors = listOf(
-                    Color.White.copy(alpha = 0.15f),
-                    Color.White.copy(alpha = 0.05f)
-                ),
-                start = Offset(0f, 0f),
-                end = Offset(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY)
-            )
-        }
-
-        val borderBrush = if (isDarkTextEnabled) {
-            Brush.linearGradient(
-                colors = listOf(
-                    Color.Black.copy(alpha = 0.8f),
-                    Color.Black.copy(alpha = 0.3f)
+            // Slider for Icon Size
+            Text("Icon-Größe", color = secondaryTextColor, fontSize = 12.sp)
+            val iconSizeOptions = IconSize.entries
+            Slider(
+                value = iconSizeOptions.indexOf(currentIconSize).toFloat(),
+                onValueChange = { onIconSizeSelected(iconSizeOptions[it.toInt()]) },
+                valueRange = 0f..(iconSizeOptions.size - 1).toFloat(),
+                steps = iconSizeOptions.size - 2,
+                colors = SliderDefaults.colors(
+                    thumbColor = mainTextColor,
+                    activeTrackColor = mainTextColor,
+                    inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
                 )
             )
-        } else {
-            Brush.linearGradient(
-                colors = listOf(
-                    Color.White.copy(alpha = 0.6f),
-                    Color.White.copy(alpha = 0.1f)
-                )
-            )
-        }
-
-        Modifier
-            .background(glassBrush, RoundedCornerShape(16.dp))
-            .border(BorderStroke(1.2.dp, borderBrush), RoundedCornerShape(16.dp))
-    } else {
-        Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
-    }
-
-    Box(
-        modifier = modifier.then(cardModifier)
-    ) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            Text(title, color = mainTextColor.copy(alpha = 0.7f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
-            Spacer(modifier = Modifier.height(8.dp))
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(if (isHome) mainTextColor.copy(alpha = 0.05f) else mainTextColor.copy(alpha = 0.1f))
-            ) {
-                if (isHome) {
-                    Column(modifier = Modifier.padding(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                        Text("12:00", fontSize = (24.sp * fontSize.scale), fontWeight = fontWeight, color = mainTextColor)
-                        Spacer(modifier = Modifier.height(4.dp))
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Box(modifier = Modifier.size(16.dp * iconSize.scale).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
-                            Spacer(modifier = Modifier.width(8.dp))
-                            Box(modifier = Modifier.width(40.dp).height(4.dp).background(mainTextColor.copy(alpha = 0.1f), CircleShape))
-                        }
-                    }
-                } else {
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        Column(modifier = Modifier.padding(8.dp)) {
-                            repeat(3) {
-                                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-                                    repeat(4) {
-                                        Box(modifier = Modifier.size(12.dp * iconSize.scale).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
-                                    }
-                                }
-                                Spacer(modifier = Modifier.height(8.dp))
-                            }
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/WallpaperConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/WallpaperConfigMenu.kt
@@ -1,0 +1,165 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.SystemWallpaperView
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalFontWeight
+
+@Composable
+fun WallpaperConfigMenu(
+    blurLevel: Float,
+    onBlurChange: (Float) -> Unit,
+    dimLevel: Float,
+    onDimChange: (Float) -> Unit,
+    zoomLevel: Float,
+    onZoomChange: (Float) -> Unit,
+    customWallpaperUri: String? = null,
+    onClose: () -> Unit
+) {
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val fontWeight = LocalFontWeight.current
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    val secondaryTextColor = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.6f)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Hintergrund anpassen",
+                fontSize = 24.sp,
+                fontWeight = fontWeight.weight,
+                color = mainTextColor
+            )
+            IconButton(onClick = onClose) {
+                Icon(Icons.Default.Close, contentDescription = "Schließen", tint = mainTextColor)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Preview Section
+        Text("Vorschau", color = secondaryTextColor, fontSize = 14.sp)
+        Spacer(modifier = Modifier.height(8.dp))
+        
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(200.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(Color.Black.copy(alpha = 0.2f))
+        ) {
+            // Mini Wallpaper Preview
+            SystemWallpaperView(
+                customWallpaperUri = customWallpaperUri,
+                blurLevel = blurLevel,
+                dimLevel = dimLevel,
+                zoomLevel = zoomLevel
+            )
+            
+            // UI Overlay Mockup
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                horizontalAlignment = Alignment.Start
+            ) {
+                Text(
+                    "12:00", 
+                    color = mainTextColor, 
+                    fontSize = 32.sp, 
+                    fontWeight = FontWeight.Bold,
+                    letterSpacing = (-1).sp
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                repeat(3) {
+                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 4.dp)) {
+                        Box(modifier = Modifier.size(24.dp).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Box(modifier = Modifier.width(60.dp).height(4.dp).background(mainTextColor.copy(alpha = 0.15f), CircleShape))
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(32.dp))
+
+        // Blur Control
+        Text("Unschärfe", color = secondaryTextColor, fontSize = 14.sp)
+        Slider(
+            value = blurLevel,
+            onValueChange = onBlurChange,
+            valueRange = 0f..25f,
+            colors = SliderDefaults.colors(
+                thumbColor = mainTextColor,
+                activeTrackColor = mainTextColor,
+                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
+            )
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Dim Control
+        Text("Abdunkelung", color = secondaryTextColor, fontSize = 14.sp)
+        Slider(
+            value = dimLevel,
+            onValueChange = onDimChange,
+            valueRange = 0f..0.8f,
+            colors = SliderDefaults.colors(
+                thumbColor = mainTextColor,
+                activeTrackColor = mainTextColor,
+                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
+            )
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Zoom Control
+        Text("Zoom", color = secondaryTextColor, fontSize = 14.sp)
+        Slider(
+            value = zoomLevel,
+            onValueChange = onZoomChange,
+            valueRange = 1.0f..2.0f,
+            colors = SliderDefaults.colors(
+                thumbColor = mainTextColor,
+                activeTrackColor = mainTextColor,
+                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
+            )
+        )
+        
+        Spacer(modifier = Modifier.weight(1f))
+        
+        Button(
+            onClick = {
+                onBlurChange(0f)
+                onDimChange(0.1f)
+                onZoomChange(1.0f)
+            },
+            modifier = Modifier.fillMaxWidth(),
+            colors = ButtonDefaults.buttonColors(containerColor = mainTextColor.copy(alpha = 0.1f)),
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Text("Zurücksetzen", color = mainTextColor)
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/WallpaperConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/WallpaperConfigMenu.kt
@@ -1,6 +1,8 @@
 package com.example.androidlauncher.ui
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -60,94 +62,65 @@ fun WallpaperConfigMenu(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Preview Section
-        Text("Vorschau", color = secondaryTextColor, fontSize = 14.sp)
-        Spacer(modifier = Modifier.height(8.dp))
-        
+        // Large Centered Preview
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(200.dp)
-                .clip(RoundedCornerShape(16.dp))
-                .background(Color.Black.copy(alpha = 0.2f))
+                .weight(1f),
+            contentAlignment = Alignment.Center
         ) {
-            // Mini Wallpaper Preview
-            SystemWallpaperView(
-                customWallpaperUri = customWallpaperUri,
-                blurLevel = blurLevel,
-                dimLevel = dimLevel,
-                zoomLevel = zoomLevel
-            )
-            
-            // UI Overlay Mockup
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp),
-                horizontalAlignment = Alignment.Start
-            ) {
-                Text(
-                    "12:00", 
-                    color = mainTextColor, 
-                    fontSize = 32.sp, 
-                    fontWeight = FontWeight.Bold,
-                    letterSpacing = (-1).sp
-                )
-                Spacer(modifier = Modifier.height(20.dp))
-                repeat(3) {
-                    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 4.dp)) {
-                        Box(modifier = Modifier.size(24.dp).background(mainTextColor.copy(alpha = 0.2f), CircleShape))
-                        Spacer(modifier = Modifier.width(12.dp))
-                        Box(modifier = Modifier.width(60.dp).height(4.dp).background(mainTextColor.copy(alpha = 0.15f), CircleShape))
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxHeight(0.85f)
+                        .aspectRatio(9f / 19f)
+                        .clip(RoundedCornerShape(24.dp))
+                        .border(BorderStroke(1.5.dp, mainTextColor.copy(alpha = 0.2f)), RoundedCornerShape(24.dp))
+                ) {
+                    SystemWallpaperView(
+                        customWallpaperUri = customWallpaperUri,
+                        blurLevel = blurLevel,
+                        dimLevel = dimLevel,
+                        zoomLevel = zoomLevel
+                    )
+                    
+                    // Home Screen Mockup
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(20.dp),
+                        horizontalAlignment = Alignment.Start
+                    ) {
+                        Text(
+                            "12:00", 
+                            color = mainTextColor, 
+                            fontSize = 40.sp, 
+                            fontWeight = FontWeight.Bold,
+                            letterSpacing = (-1).sp
+                        )
+                        Spacer(modifier = Modifier.height(24.dp))
+                        repeat(4) {
+                            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 6.dp)) {
+                                Box(modifier = Modifier.size(28.dp).background(mainTextColor.copy(alpha = 0.3f), CircleShape))
+                                Spacer(modifier = Modifier.width(12.dp))
+                                Box(modifier = Modifier.width(70.dp).height(5.dp).background(mainTextColor.copy(alpha = 0.15f), CircleShape))
+                            }
+                        }
                     }
                 }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text("Vorschau Startseite", fontSize = 12.sp, color = secondaryTextColor)
             }
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height(24.dp))
 
-        // Blur Control
-        Text("Unschärfe", color = secondaryTextColor, fontSize = 14.sp)
-        Slider(
-            value = blurLevel,
-            onValueChange = onBlurChange,
-            valueRange = 0f..25f,
-            colors = SliderDefaults.colors(
-                thumbColor = mainTextColor,
-                activeTrackColor = mainTextColor,
-                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
-            )
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Dim Control
-        Text("Abdunkelung", color = secondaryTextColor, fontSize = 14.sp)
-        Slider(
-            value = dimLevel,
-            onValueChange = onDimChange,
-            valueRange = 0f..0.8f,
-            colors = SliderDefaults.colors(
-                thumbColor = mainTextColor,
-                activeTrackColor = mainTextColor,
-                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
-            )
-        )
-        Spacer(modifier = Modifier.height(16.dp))
-
-        // Zoom Control
-        Text("Zoom", color = secondaryTextColor, fontSize = 14.sp)
-        Slider(
-            value = zoomLevel,
-            onValueChange = onZoomChange,
-            valueRange = 1.0f..2.0f,
-            colors = SliderDefaults.colors(
-                thumbColor = mainTextColor,
-                activeTrackColor = mainTextColor,
-                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
-            )
-        )
+        // Controls
+        ControlSlider(label = "Unschärfe", value = blurLevel, onValueChange = onBlurChange, range = 0f..25f, mainTextColor = mainTextColor, secondaryTextColor = secondaryTextColor)
+        ControlSlider(label = "Abdunkelung", value = dimLevel, onValueChange = onDimChange, range = 0f..0.8f, mainTextColor = mainTextColor, secondaryTextColor = secondaryTextColor)
+        ControlSlider(label = "Zoom", value = zoomLevel, onValueChange = onZoomChange, range = 1.0f..2.0f, mainTextColor = mainTextColor, secondaryTextColor = secondaryTextColor)
         
-        Spacer(modifier = Modifier.weight(1f))
+        Spacer(modifier = Modifier.height(16.dp))
         
         Button(
             onClick = {
@@ -159,7 +132,31 @@ fun WallpaperConfigMenu(
             colors = ButtonDefaults.buttonColors(containerColor = mainTextColor.copy(alpha = 0.1f)),
             shape = RoundedCornerShape(12.dp)
         ) {
-            Text("Zurücksetzen", color = mainTextColor)
+            Text("Effekte zurücksetzen", color = mainTextColor)
         }
+    }
+}
+
+@Composable
+fun ControlSlider(
+    label: String,
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    range: ClosedFloatingPointRange<Float>,
+    mainTextColor: Color,
+    secondaryTextColor: Color
+) {
+    Column(modifier = Modifier.padding(vertical = 4.dp)) {
+        Text(label, color = secondaryTextColor, fontSize = 12.sp)
+        Slider(
+            value = value,
+            onValueChange = onValueChange,
+            valueRange = range,
+            colors = SliderDefaults.colors(
+                thumbColor = mainTextColor,
+                activeTrackColor = mainTextColor,
+                inactiveTrackColor = mainTextColor.copy(alpha = 0.2f)
+            )
+        )
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ mockk = "1.13.12"
 kotlinxCoroutines = "1.7.3"
 datastore = "1.1.1"
 kover = "0.9.0"
+ucrop = "2.2.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +35,7 @@ lucide-icons = { group = "com.composables", name = "icons-lucide", version.ref =
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
+ucrop = { group = "com.github.yalantis", name = "ucrop", version.ref = "ucrop" }
 
 [plugins]
 androidApp = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://jitpack.io") }
     }
 }
 


### PR DESCRIPTION
# 🖼️ Issue: Eigene Wallpaper für die Startseite hinzufügen

## 🎯 Ziel

Nutzer sollen über das Bearbeitungsmenü die Möglichkeit erhalten, ein eigenes Wallpaper für die Startseite festzulegen.

Das Wallpaper soll unabhängig vom System-Wallpaper gesetzt werden können.

---

## 🧩 User Story

Als Nutzer  
möchte ich ein eigenes Hintergrundbild für meinen Launcher auswählen können,  
damit ich meine Startseite individuell gestalten kann.

---

## 📍 Zugriff

- Funktion erreichbar über das Bearbeitungsmenü der Startseite
- Neuer Menüpunkt: „Wallpaper ändern“ oder „Eigenes Wallpaper auswählen“

---

## ⚙️ Funktionales Verhalten

- Öffnen des System-Dateipickers (Galerie / Dateien)
- Auswahl eines Bildes durch den Nutzer
- Vorschau vor Bestätigung
- Nach Bestätigung:
  - Wallpaper wird als Hintergrund der Startseite gesetzt
  - Einstellung wird persistent gespeichert
- Optional: Zurücksetzen auf Standard möglich

---

## 🛠️ Technische Anforderungen

- [x] Integration eines Image-Pickers (System-Intent)
- [x] Skalierung & Anpassung an Bildschirmgröße
- [x] Optionales Zuschneiden (Crop)
- [x] Performance-optimierte Speicherung (keine riesigen Bitmap-Leaks)
- [x] Persistente Speicherung (URI oder komprimierte Version lokal)
- [x] Funktioniert mit Light/Dark & Custom Themes

---

## 🧪 Testfälle

- [x] Bild kann ausgewählt werden
- [x] Bild wird korrekt skaliert angezeigt
- [x] Kein Qualitätsverlust durch falsche Skalierung
- [x] Kein Memory-Leak bei großen Bildern
- [x] Einstellung bleibt nach Neustart erhalten
- [x] Rücksetzen auf Standard funktioniert

---

## 🚀 Erweiterung (Optional)

- Blur-Option für Wallpaper