### PR TITLE
#76 🎨 Issue: Einheitlicher Icon-Fallback mit Qualitätsprüfung

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.tasks.testing.Test
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -42,6 +43,12 @@ android {
     }
     testOptions {
         unitTests.isReturnDefaultValues = true
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    doFirst {
+        temporaryDir.mkdirs()
     }
 }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -172,6 +172,7 @@ class MainActivity : ComponentActivity() {
 
             val folders by folderManager.folders.collectAsState(initial = emptyList())
             val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
+            val autoIconFallbacks by iconManager.autoIconFallbacks.collectAsState(initial = emptyMap())
             val favoritePackages by favoritesManager.favorites.collectAsState(initial = emptyList())
 
             var isWallpaperCropOpen by remember { mutableStateOf(false) }
@@ -443,20 +444,41 @@ class MainActivity : ComponentActivity() {
                     scope.launch {
                         appRepository.cleanupLegacyCache()
                         val basicList = appRepository.getInstalledApps()
-                        if (allApps.size != basicList.size || allApps.map { it.packageName } != basicList.map { it.packageName }) {
-                            val currentIcons = allApps.associate { it.packageName to it.iconBitmap }
-                            allApps.clear()
-                            allApps.addAll(basicList.map {
-                                it.copy(iconBitmap = currentIcons[it.packageName])
-                            })
+                        val currentIcons = allApps.associate { it.packageName to it.iconBitmap }
+                        val currentFallbacks = allApps.associate { it.packageName to it.autoIconFallback }
+                        val mergedList = basicList.map {
+                            it.copy(
+                                iconBitmap = currentIcons[it.packageName],
+                                autoIconFallback = autoIconFallbacks[it.packageName] ?: currentFallbacks[it.packageName]
+                            )
                         }
+                        if (allApps.size != mergedList.size || allApps.map { it.packageName } != mergedList.map { it.packageName }) {
+                            allApps.clear()
+                            allApps.addAll(mergedList)
+                        } else {
+                            mergedList.forEachIndexed { index, appInfo ->
+                                if (index < allApps.size && allApps[index] != appInfo) {
+                                    allApps[index] = appInfo
+                                }
+                            }
+                        }
+
+                        val appSnapshot = allApps.toList()
                         appRepository.loadIconsWithPriority(
-                            apps = allApps.toList(),
+                            apps = appSnapshot,
                             favoritePackages = favoritePackages
-                        ) { idx, bitmap ->
+                        ) { idx, resolvedIcon ->
+                            val snapshotApp = appSnapshot.getOrNull(idx) ?: return@loadIconsWithPriority
+                            val fallback = resolvedIcon.autoFallback
+                            if (autoIconFallbacks[snapshotApp.packageName] != fallback) {
+                                iconManager.setAutoIconFallback(snapshotApp.packageName, fallback)
+                            }
                             withContext(Dispatchers.Main) {
-                                if (idx < allApps.size) {
-                                    allApps[idx] = allApps[idx].copy(iconBitmap = bitmap)
+                                if (idx < allApps.size && allApps[idx].packageName == snapshotApp.packageName) {
+                                    allApps[idx] = allApps[idx].copy(
+                                        iconBitmap = resolvedIcon.imageBitmap,
+                                        autoIconFallback = fallback
+                                    )
                                 }
                             }
                         }
@@ -531,7 +553,7 @@ class MainActivity : ComponentActivity() {
                         ?: intent.data?.host
                         ?: "search-launch"
                     Log.d(RETURN_TAG, "requestSearchLaunch resolved=$resolvedPackageName bounds=${bounds != null} searchButton=${homeSearchButtonBounds != null}")
-                     requestLauncherLaunch(
+                    requestLauncherLaunch(
                         packageName = resolvedPackageName,
                         intent = intent,
                         bounds = bounds,
@@ -549,6 +571,15 @@ class MainActivity : ComponentActivity() {
                 }
 
                 LaunchedEffect(Unit) { refreshAppList() }
+                LaunchedEffect(autoIconFallbacks) {
+                    allApps.indices.forEach { index ->
+                        val app = allApps[index]
+                        val storedFallback = autoIconFallbacks[app.packageName]
+                        if (app.autoIconFallback != storedFallback) {
+                            allApps[index] = app.copy(autoIconFallback = storedFallback)
+                        }
+                    }
+                }
 
                 DisposableEffect(Unit) {
                     val receiver = object : BroadcastReceiver() {
@@ -573,7 +604,12 @@ class MainActivity : ComponentActivity() {
                                 Intent.ACTION_PACKAGE_ADDED,
                                 Intent.ACTION_PACKAGE_REMOVED,
                                 Intent.ACTION_PACKAGE_REPLACED -> {
+                                    val packageName = intent.data?.schemeSpecificPart
                                     scope.launch {
+                                        if (!packageName.isNullOrBlank()) {
+                                            appRepository.clearIconCache(packageName)
+                                            iconManager.invalidatePackage(packageName)
+                                        }
                                         delay(800)
                                         refreshAppList()
                                     }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -63,12 +63,14 @@ import androidx.lifecycle.LifecycleEventObserver
 import com.example.androidlauncher.data.AppFont
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.AppRepository
+import com.example.androidlauncher.data.AutoIconRule
 import com.example.androidlauncher.data.FavoritesManager
 import com.example.androidlauncher.data.FolderInfo
 import com.example.androidlauncher.data.FolderManager
 import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.FontWeightLevel
 import com.example.androidlauncher.data.IconManager
+import com.example.androidlauncher.data.IconQualityEvaluator
 import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.data.SearchSuggestionsManager
 import com.example.androidlauncher.data.ThemeManager
@@ -173,6 +175,7 @@ class MainActivity : ComponentActivity() {
             val folders by folderManager.folders.collectAsState(initial = emptyList())
             val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
             val autoIconFallbacks by iconManager.autoIconFallbacks.collectAsState(initial = emptyMap())
+            val autoIconRules by iconManager.autoIconRules.collectAsState(initial = emptyMap())
             val favoritePackages by favoritesManager.favorites.collectAsState(initial = emptyList())
 
             var isWallpaperCropOpen by remember { mutableStateOf(false) }
@@ -440,16 +443,19 @@ class MainActivity : ComponentActivity() {
                     LauncherLogic.getFavoriteApps(allApps.toList(), favoritePackages)
                 }
 
-                fun refreshAppList() {
+                fun refreshAppList(targetPackageName: String? = null) {
                     scope.launch {
                         appRepository.cleanupLegacyCache()
                         val basicList = appRepository.getInstalledApps()
                         val currentIcons = allApps.associate { it.packageName to it.iconBitmap }
                         val currentFallbacks = allApps.associate { it.packageName to it.autoIconFallback }
                         val mergedList = basicList.map {
+                            val resolvedRule = autoIconRules[it.packageName]
+                                ?: IconQualityEvaluator.resolveDefaultRule(it.packageName)
                             it.copy(
                                 iconBitmap = currentIcons[it.packageName],
-                                autoIconFallback = autoIconFallbacks[it.packageName] ?: currentFallbacks[it.packageName]
+                                autoIconFallback = autoIconFallbacks[it.packageName] ?: currentFallbacks[it.packageName],
+                                autoIconRule = resolvedRule
                             )
                         }
                         if (allApps.size != mergedList.size || allApps.map { it.packageName } != mergedList.map { it.packageName }) {
@@ -464,6 +470,28 @@ class MainActivity : ComponentActivity() {
                         }
 
                         val appSnapshot = allApps.toList()
+                        if (targetPackageName != null) {
+                            val targetIndex = appSnapshot.indexOfFirst { it.packageName == targetPackageName }
+                            if (targetIndex >= 0) {
+                                appRepository.loadResolvedIcon(appSnapshot[targetIndex])?.let { resolvedIcon ->
+                                    val snapshotApp = appSnapshot[targetIndex]
+                                    val fallback = resolvedIcon.autoFallback
+                                    if (autoIconFallbacks[snapshotApp.packageName] != fallback) {
+                                        iconManager.setAutoIconFallback(snapshotApp.packageName, fallback)
+                                    }
+                                    withContext(Dispatchers.Main) {
+                                        if (targetIndex < allApps.size && allApps[targetIndex].packageName == snapshotApp.packageName) {
+                                            allApps[targetIndex] = allApps[targetIndex].copy(
+                                                iconBitmap = resolvedIcon.imageBitmap,
+                                                autoIconFallback = fallback
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                            return@launch
+                        }
+
                         appRepository.loadIconsWithPriority(
                             apps = appSnapshot,
                             favoritePackages = favoritePackages
@@ -571,12 +599,17 @@ class MainActivity : ComponentActivity() {
                 }
 
                 LaunchedEffect(Unit) { refreshAppList() }
-                LaunchedEffect(autoIconFallbacks) {
+                LaunchedEffect(autoIconFallbacks, autoIconRules) {
                     allApps.indices.forEach { index ->
                         val app = allApps[index]
                         val storedFallback = autoIconFallbacks[app.packageName]
-                        if (app.autoIconFallback != storedFallback) {
-                            allApps[index] = app.copy(autoIconFallback = storedFallback)
+                        val resolvedRule = autoIconRules[app.packageName]
+                            ?: IconQualityEvaluator.resolveDefaultRule(app.packageName)
+                        if (app.autoIconFallback != storedFallback || app.autoIconRule != resolvedRule) {
+                            allApps[index] = app.copy(
+                                autoIconFallback = storedFallback,
+                                autoIconRule = resolvedRule
+                            )
                         }
                     }
                 }
@@ -611,7 +644,7 @@ class MainActivity : ComponentActivity() {
                                             iconManager.invalidatePackage(packageName)
                                         }
                                         delay(800)
-                                        refreshAppList()
+                                        refreshAppList(packageName)
                                     }
                                 }
                             }
@@ -911,8 +944,23 @@ class MainActivity : ComponentActivity() {
                         IconConfigMenu(
                             apps = allApps,
                             customIcons = customIcons,
+                            iconRules = autoIconRules,
                             onIconSelected = { pkg, iconName ->
                                 scope.launch { iconManager.setCustomIcon(pkg, iconName) }
+                            },
+                            onAutoRuleSelected = { pkg, mode ->
+                                scope.launch {
+                                    val rule = mode?.let { AutoIconRule(mode = it, reason = "user_config") }
+                                    iconManager.setAutoIconRule(pkg, rule)
+                                    iconManager.invalidatePackage(pkg)
+                                    refreshAppList(pkg)
+                                }
+                            },
+                            onReanalyzeRequested = { pkg ->
+                                scope.launch {
+                                    iconManager.invalidatePackage(pkg)
+                                    refreshAppList(pkg)
+                                }
                             },
                             onClose = { isIconConfigOpen = false }
                         )

--- a/app/src/main/java/com/example/androidlauncher/data/AppInfo.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/AppInfo.kt
@@ -13,5 +13,6 @@ data class AppInfo(
     val label: String, // The display name of the app
     val packageName: String, // The unique package identifier (e.g., com.example.app)
     val iconBitmap: ImageBitmap? = null, // The actual app icon as a bitmap
-    val lucideIcon: ImageVector? = null // Optional vector icon (if used)
+    val lucideIcon: ImageVector? = null, // Optional vector icon (if used)
+    val autoIconFallback: AutoIconFallback? = null // Optional auto icon fallback status
 )

--- a/app/src/main/java/com/example/androidlauncher/data/AppInfo.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/AppInfo.kt
@@ -14,5 +14,6 @@ data class AppInfo(
     val packageName: String, // The unique package identifier (e.g., com.example.app)
     val iconBitmap: ImageBitmap? = null, // The actual app icon as a bitmap
     val lucideIcon: ImageVector? = null, // Optional vector icon (if used)
-    val autoIconFallback: AutoIconFallback? = null // Optional auto icon fallback status
+    val autoIconFallback: AutoIconFallback? = null, // Optional auto icon fallback status
+    val autoIconRule: AutoIconRule? = null // Optional auto icon rule status
 )

--- a/app/src/main/java/com/example/androidlauncher/data/AppRepository.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/AppRepository.kt
@@ -83,7 +83,12 @@ class AppRepository(private val context: Context) {
         val bitmap = loadBitmap(app.packageName) ?: return null
         return LoadedAppIcon(
             imageBitmap = bitmap.toPreparedImageBitmap(),
-            autoFallback = IconQualityEvaluator.evaluate(bitmap, app.packageName, app.label)
+            autoFallback = IconQualityEvaluator.evaluate(
+                bitmap = bitmap,
+                packageName = app.packageName,
+                label = app.label,
+                explicitRule = app.autoIconRule
+            )
         )
     }
 

--- a/app/src/main/java/com/example/androidlauncher/data/AppRepository.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/AppRepository.kt
@@ -70,115 +70,123 @@ class AppRepository(private val context: Context) {
     /**
      * Lädt ein einzelnes App-Icon – zuerst aus dem Datei-Cache,
      * bei Cache-Miss vom PackageManager.
-     *
-     * @param packageName Der Paketname der App.
-     * @return Das Icon als [ImageBitmap] oder null bei Fehler.
      */
     suspend fun loadIcon(packageName: String): ImageBitmap? {
-        // 1. Cache prüfen
-        val cached = loadIconFromCache(packageName)
-        if (cached != null) return cached
+        val bitmap = loadBitmap(packageName) ?: return null
+        return bitmap.toPreparedImageBitmap()
+    }
 
-        // 2. Vom System laden und cachen
-        return loadIconFromSystem(packageName)
+    /**
+     * Lädt ein einzelnes App-Icon und berechnet die automatische Fallback-Entscheidung.
+     */
+    suspend fun loadResolvedIcon(app: AppInfo): LoadedAppIcon? {
+        val bitmap = loadBitmap(app.packageName) ?: return null
+        return LoadedAppIcon(
+            imageBitmap = bitmap.toPreparedImageBitmap(),
+            autoFallback = IconQualityEvaluator.evaluate(bitmap, app.packageName, app.label)
+        )
     }
 
     /**
      * Lädt Icons für eine App-Liste mit Priorisierung der Favoriten.
-     * Favoriten-Icons werden zuerst geladen, damit sie sofort sichtbar sind.
-     *
-     * @param apps Die Ziel-Liste der Apps (wird in-place aktualisiert via Callback).
-     * @param favoritePackages Paketnamen der Favoriten (werden priorisiert).
-     * @param onIconLoaded Callback wenn ein Icon geladen wurde (Index + Bitmap).
      */
     suspend fun loadIconsWithPriority(
         apps: List<AppInfo>,
         favoritePackages: List<String>,
-        onIconLoaded: suspend (Int, ImageBitmap) -> Unit
+        onIconLoaded: suspend (Int, LoadedAppIcon) -> Unit
     ) {
         val favSet = favoritePackages.toSet()
-
-        // Indizes nach Priorität sortieren: Favoriten zuerst
         val sortedIndices = apps.indices.sortedByDescending { apps[it].packageName in favSet }
 
         sortedIndices.forEachIndexed { loopIdx, appIdx ->
             if (appIdx >= apps.size) return@forEachIndexed
             val app = apps[appIdx]
-            val bitmap = loadIcon(app.packageName)
-            if (bitmap != null) {
-                onIconLoaded(appIdx, bitmap)
+            val resolvedIcon = loadResolvedIcon(app)
+            if (resolvedIcon != null) {
+                onIconLoaded(appIdx, resolvedIcon)
             }
-            // Periodisch yielden um UI-Thread nicht zu blockieren
             if (loopIdx % 5 == 0) delay(1)
         }
     }
 
     /**
      * Löscht den Icon-Cache komplett.
-     * Nützlich wenn Icons nach App-Updates veraltet sind.
      */
     suspend fun clearIconCache() = withContext(Dispatchers.IO) {
         iconCacheDir.listFiles()?.forEach { it.delete() }
     }
 
+    /**
+     * Löscht den Icon-Cache für genau ein Paket.
+     */
+    suspend fun clearIconCache(packageName: String) = withContext(Dispatchers.IO) {
+        File(iconCacheDir, "$packageName.png").takeIf { it.exists() }?.delete()
+    }
+
     // ── Private Hilfsmethoden ────────────────────────────────────────
 
-    private suspend fun loadIconFromCache(packageName: String): ImageBitmap? =
+    private suspend fun loadBitmap(packageName: String): Bitmap? {
+        val cached = loadBitmapFromCache(packageName)
+        if (cached != null) return cached
+        return loadBitmapFromSystem(packageName)
+    }
+
+    private suspend fun loadBitmapFromCache(packageName: String): Bitmap? =
         withContext(Dispatchers.IO) {
             val iconFile = File(iconCacheDir, "$packageName.png")
             if (!iconFile.exists()) return@withContext null
             try {
-                val b = BitmapFactory.decodeFile(iconFile.absolutePath) ?: return@withContext null
-                val ib = b.asImageBitmap()
-                ib.prepareToDraw()
-                ib
+                BitmapFactory.decodeFile(iconFile.absolutePath)
             } catch (_: Exception) {
                 null
             }
         }
 
-    private suspend fun loadIconFromSystem(packageName: String): ImageBitmap? =
+    private suspend fun loadBitmapFromSystem(packageName: String): Bitmap? =
         withContext(Dispatchers.IO) {
             try {
                 val pm = context.packageManager
                 val info = pm.getApplicationInfo(packageName, 0)
                 val icon = info.loadIcon(pm)
 
-                // Bei AdaptiveIcons nur den Vordergrund verwenden
                 val foregroundDrawable = if (icon is AdaptiveIconDrawable) {
                     icon.foreground ?: icon
                 } else {
                     icon
                 }
 
-                val b = createBitmap(ICON_SIZE, ICON_SIZE)
-                b.applyCanvas {
+                val bitmap = createBitmap(ICON_SIZE, ICON_SIZE)
+                bitmap.applyCanvas {
                     foregroundDrawable.setBounds(0, 0, ICON_SIZE, ICON_SIZE)
                     foregroundDrawable.draw(this)
                 }
 
-                val ib = b.asImageBitmap()
-                ib.prepareToDraw()
-
-                // Im Cache speichern
                 try {
                     FileOutputStream(File(iconCacheDir, "$packageName.png")).use { out ->
-                        b.compress(Bitmap.CompressFormat.PNG, 100, out)
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
                     }
                 } catch (_: Exception) {
                     // Cache-Fehler sind nicht kritisch
                 }
 
-                ib
+                bitmap
             } catch (_: Exception) {
                 null
             }
         }
 
+    private fun Bitmap.toPreparedImageBitmap(): ImageBitmap {
+        val imageBitmap = asImageBitmap()
+        imageBitmap.prepareToDraw()
+        return imageBitmap
+    }
+
+    data class LoadedAppIcon(
+        val imageBitmap: ImageBitmap,
+        val autoFallback: AutoIconFallback
+    )
+
     companion object {
-        /** Größe der gecachten Icons in Pixeln. */
         private const val ICON_SIZE = 144
     }
 }
-
-

--- a/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 private val Context.iconDataStore by preferencesDataStore(name = "icon_mappings")
+private const val AUTO_FALLBACK_PREFIX = "auto_fallback__"
 
 /**
  * Manages custom app icons mapping.
@@ -16,16 +17,34 @@ private val Context.iconDataStore by preferencesDataStore(name = "icon_mappings"
 class IconManager(private val context: Context) {
 
     /**
-     * Returns a flow of the current icon mappings.
+     * Returns a flow of the current manual icon mappings.
      */
     val customIcons: Flow<Map<String, String>> = context.iconDataStore.data
         .map { preferences ->
-            preferences.asMap().mapKeys { it.key.name }.mapValues { it.value as String }
+            preferences.asMap()
+                .filterKeys { !it.name.startsWith(AUTO_FALLBACK_PREFIX) }
+                .mapKeys { it.key.name }
+                .mapValues { it.value as String }
+        }
+
+    /**
+     * Returns a flow of the automatic fallback analysis results.
+     */
+    val autoIconFallbacks: Flow<Map<String, AutoIconFallback>> = context.iconDataStore.data
+        .map { preferences ->
+            preferences.asMap()
+                .filterKeys { it.name.startsWith(AUTO_FALLBACK_PREFIX) }
+                .mapNotNull { (key, value) ->
+                    val packageName = key.name.removePrefix(AUTO_FALLBACK_PREFIX)
+                    val fallback = (value as? String)?.let(AutoIconFallback::deserialize)
+                    if (packageName.isBlank() || fallback == null) null else packageName to fallback
+                }
+                .toMap()
         }
 
     /**
      * Updates the custom icon for a package.
-     * If iconName is null, the custom icon is removed (reverts to default).
+     * If iconName is null, the custom icon is removed (reverts to automatic/default).
      */
     suspend fun setCustomIcon(packageName: String, iconName: String?) {
         context.iconDataStore.edit { preferences ->
@@ -34,6 +53,32 @@ class IconManager(private val context: Context) {
                 preferences[key] = iconName
             } else {
                 preferences.remove(key)
+            }
+        }
+    }
+
+    /**
+     * Persists or removes the automatic fallback decision for a package.
+     */
+    suspend fun setAutoIconFallback(packageName: String, fallback: AutoIconFallback?) {
+        context.iconDataStore.edit { preferences ->
+            val key = stringPreferencesKey("$AUTO_FALLBACK_PREFIX$packageName")
+            if (fallback != null) {
+                preferences[key] = fallback.serialize()
+            } else {
+                preferences.remove(key)
+            }
+        }
+    }
+
+    /**
+     * Removes persisted automatic analysis for a package and optionally the user override.
+     */
+    suspend fun invalidatePackage(packageName: String, removeUserOverride: Boolean = false) {
+        context.iconDataStore.edit { preferences ->
+            preferences.remove(stringPreferencesKey("$AUTO_FALLBACK_PREFIX$packageName"))
+            if (removeUserOverride) {
+                preferences.remove(stringPreferencesKey(packageName))
             }
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.map
 
 private val Context.iconDataStore by preferencesDataStore(name = "icon_mappings")
 private const val AUTO_FALLBACK_PREFIX = "auto_fallback__"
+private const val AUTO_RULE_PREFIX = "auto_rule__"
 
 /**
  * Manages custom app icons mapping.
@@ -22,7 +23,9 @@ class IconManager(private val context: Context) {
     val customIcons: Flow<Map<String, String>> = context.iconDataStore.data
         .map { preferences ->
             preferences.asMap()
-                .filterKeys { !it.name.startsWith(AUTO_FALLBACK_PREFIX) }
+                .filterKeys {
+                    !it.name.startsWith(AUTO_FALLBACK_PREFIX) && !it.name.startsWith(AUTO_RULE_PREFIX)
+                }
                 .mapKeys { it.key.name }
                 .mapValues { it.value as String }
         }
@@ -38,6 +41,21 @@ class IconManager(private val context: Context) {
                     val packageName = key.name.removePrefix(AUTO_FALLBACK_PREFIX)
                     val fallback = (value as? String)?.let(AutoIconFallback::deserialize)
                     if (packageName.isBlank() || fallback == null) null else packageName to fallback
+                }
+                .toMap()
+        }
+
+    /**
+     * Returns a flow of the automatic icon rules.
+     */
+    val autoIconRules: Flow<Map<String, AutoIconRule>> = context.iconDataStore.data
+        .map { preferences ->
+            preferences.asMap()
+                .filterKeys { it.name.startsWith(AUTO_RULE_PREFIX) }
+                .mapNotNull { (key, value) ->
+                    val packageName = key.name.removePrefix(AUTO_RULE_PREFIX)
+                    val rule = (value as? String)?.let(AutoIconRule::deserialize)
+                    if (packageName.isBlank() || rule == null) null else packageName to rule
                 }
                 .toMap()
         }
@@ -72,6 +90,20 @@ class IconManager(private val context: Context) {
     }
 
     /**
+     * Persists or removes the automatic icon rule for a package.
+     */
+    suspend fun setAutoIconRule(packageName: String, rule: AutoIconRule?) {
+        context.iconDataStore.edit { preferences ->
+            val key = stringPreferencesKey("$AUTO_RULE_PREFIX$packageName")
+            if (rule != null) {
+                preferences[key] = rule.serialize()
+            } else {
+                preferences.remove(key)
+            }
+        }
+    }
+
+    /**
      * Removes persisted automatic analysis for a package and optionally the user override.
      */
     suspend fun invalidatePackage(packageName: String, removeUserOverride: Boolean = false) {
@@ -79,6 +111,7 @@ class IconManager(private val context: Context) {
             preferences.remove(stringPreferencesKey("$AUTO_FALLBACK_PREFIX$packageName"))
             if (removeUserOverride) {
                 preferences.remove(stringPreferencesKey(packageName))
+                preferences.remove(stringPreferencesKey("$AUTO_RULE_PREFIX$packageName"))
             }
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -73,6 +73,7 @@ import androidx.compose.ui.zIndex
 import com.example.androidlauncher.LauncherLogic
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.FolderInfo
+import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.theme.LocalAppFont
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
@@ -104,6 +105,7 @@ fun AppDrawer(
     val colorTheme = LocalColorTheme.current
     val fontSize = LocalFontSize.current
     val fontWeight = LocalFontWeight.current
+    val iconSize = LocalIconSize.current
     val appFont = LocalAppFont.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
@@ -550,7 +552,33 @@ fun AppDrawer(
                                 }
                             }
                             
-                            Spacer(modifier = Modifier.height(12.dp))
+                            val folderTitleSpacing = when (iconSize) {
+                                IconSize.SMALL -> 2.dp
+                                IconSize.STANDARD -> 6.dp
+                                IconSize.LARGE -> 12.dp
+                            }
+                            val folderGridTopPadding = when (iconSize) {
+                                IconSize.SMALL -> 0.dp
+                                IconSize.STANDARD -> 2.dp
+                                IconSize.LARGE -> 8.dp
+                            }
+                            val folderItemTopPadding = when (iconSize) {
+                                IconSize.SMALL -> 0.dp
+                                IconSize.STANDARD -> 1.dp
+                                IconSize.LARGE -> 4.dp
+                            }
+                            val folderContentHeight = when (iconSize) {
+                                IconSize.SMALL -> 292.dp
+                                IconSize.STANDARD -> 316.dp
+                                IconSize.LARGE -> 340.dp
+                            }
+                            val folderPagerIndicatorTopPadding = when (iconSize) {
+                                IconSize.SMALL -> 8.dp
+                                IconSize.STANDARD -> 12.dp
+                                IconSize.LARGE -> 16.dp
+                            }
+
+                            Spacer(modifier = Modifier.height(folderTitleSpacing))
 
                             val folderApps = remember(currentActiveFolder.appPackageNames, apps) { currentActiveFolder.appPackageNames.mapNotNull { pkg -> apps.find { it.packageName == pkg } } }
                             val currentFolderApps by rememberUpdatedState(folderApps)
@@ -584,7 +612,7 @@ fun AppDrawer(
                                 }
                             }
 
-                            Box(modifier = Modifier.height(340.dp)) {
+                            Box(modifier = Modifier.height(folderContentHeight)) {
                                 val currentFolderState by rememberUpdatedState(currentActiveFolder)
                                 val currentFoldersState by rememberUpdatedState(folders)
 
@@ -663,7 +691,7 @@ fun AppDrawer(
                                             val startIdx = page * itemsPerPage
                                             val endIdx = (startIdx + itemsPerPage).coerceAtMost(folderApps.size)
                                             val pageApps = folderApps.subList(startIdx, endIdx)
-                                            LazyVerticalGrid(columns = GridCells.Fixed(3), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp), userScrollEnabled = false, contentPadding = PaddingValues(top = 8.dp, start = 8.dp, end = 8.dp)) {
+                                            LazyVerticalGrid(columns = GridCells.Fixed(3), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp), userScrollEnabled = false, contentPadding = PaddingValues(top = folderGridTopPadding, start = 8.dp, end = 8.dp)) {
                                                 itemsIndexed(pageApps, key = { _, app -> app.packageName }) { indexInPage, app ->
                                                     val globalIndex = startIdx + indexInPage
                                                     val isDragging = draggingItemPkg == app.packageName
@@ -671,10 +699,17 @@ fun AppDrawer(
                                                     val minusWidth = LocalIconSize.current.size * 0.14f
                                                     val minusHeight = 1.5.dp
 
-                                                    Box(modifier = Modifier.let { if (isDragging) it else Modifier.animateItem() }.zIndex(if (isDragging) 0f else 1f).graphicsLayer { rotationZ = if (isEditMode && !isDragging) { if (globalIndex % 2 == 0) wiggleAngle else -wiggleAngle } else 0f; alpha = if (isDragging) 0f else 1f }.padding(top = 4.dp, start = 2.dp, end = 2.dp)) {
+                                                    Box(modifier = Modifier.let { if (isDragging) it else Modifier.animateItem() }.zIndex(if (isDragging) 0f else 1f).graphicsLayer { rotationZ = if (isEditMode && !isDragging) { if (globalIndex % 2 == 0) wiggleAngle else -wiggleAngle } else 0f; alpha = if (isDragging) 0f else 1f }.padding(top = folderItemTopPadding, start = 2.dp, end = 2.dp)) {
                                                         AppItem(
-                                                            app = app, adaptiveColumns = 3, isFavorite = isFavorite(app.packageName), onToggleFavorite = onToggleFavorite, folders = folders, onUpdateFolders = onUpdateFolders,
-                                                            isInFolder = true, currentFolderId = currentActiveFolder.id, isEditMode = isEditMode, bouncePackage = returnIconPackage,
+                                                            app = app,
+                                                            adaptiveColumns = 3,
+                                                            isFavorite = isFavorite(app.packageName),
+                                                            onToggleFavorite = onToggleFavorite,
+                                                            folders = folders,
+                                                            onUpdateFolders = onUpdateFolders,
+                                                            isInFolder = true,
+                                                            currentFolderId = currentActiveFolder.id,
+                                                            isEditMode = isEditMode,
                                                             onLongPress = { appInfo, bounds -> haptic.performHapticFeedback(HapticFeedbackType.LongPress); menuApp = appInfo; menuAppBounds = bounds },
                                                             onAppLaunchRequested = { requestedApp, bounds ->
                                                                 context.packageManager.getLaunchIntentForPackage(requestedApp.packageName)?.let { intent ->
@@ -716,7 +751,7 @@ fun AppDrawer(
                             }
                             
                             if (pages > 1) {
-                                Row(Modifier.wrapContentHeight().fillMaxWidth().padding(top = 16.dp), horizontalArrangement = Arrangement.Center) {
+                                Row(Modifier.wrapContentHeight().fillMaxWidth().padding(top = folderPagerIndicatorTopPadding), horizontalArrangement = Arrangement.Center) {
                                     repeat(pages) { iteration ->
                                         val color = if (pagerState.currentPage == iteration) mainTextColor else mainTextColor.copy(alpha = 0.3f)
                                         Box(modifier = Modifier.padding(horizontal = 4.dp).clip(CircleShape).background(color).size(6.dp))

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -73,7 +73,6 @@ import androidx.compose.ui.zIndex
 import com.example.androidlauncher.LauncherLogic
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.FolderInfo
-import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.ui.theme.LocalAppFont
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
@@ -105,7 +104,6 @@ fun AppDrawer(
     val colorTheme = LocalColorTheme.current
     val fontSize = LocalFontSize.current
     val fontWeight = LocalFontWeight.current
-    val iconSize = LocalIconSize.current
     val appFont = LocalAppFont.current
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
@@ -357,11 +355,7 @@ fun AppDrawer(
             }
             Spacer(modifier = Modifier.height(24.dp))
 
-            val adaptiveColumns = when (iconSize) {
-                IconSize.SMALL -> 5
-                IconSize.STANDARD -> 4
-                IconSize.LARGE -> 3
-            }
+            val adaptiveColumns = 4
 
             val gridState = rememberLazyGridState()
             var swipeDragY by remember { mutableStateOf(0f) }

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -553,18 +553,18 @@ fun AppDrawer(
                             }
                             
                             val folderTitleSpacing = when (iconSize) {
-                                IconSize.SMALL -> 2.dp
-                                IconSize.STANDARD -> 6.dp
+                                IconSize.SMALL -> 5.dp
+                                IconSize.STANDARD -> 8.dp
                                 IconSize.LARGE -> 12.dp
                             }
                             val folderGridTopPadding = when (iconSize) {
-                                IconSize.SMALL -> 0.dp
-                                IconSize.STANDARD -> 2.dp
+                                IconSize.SMALL -> 3.dp
+                                IconSize.STANDARD -> 5.dp
                                 IconSize.LARGE -> 8.dp
                             }
                             val folderItemTopPadding = when (iconSize) {
-                                IconSize.SMALL -> 0.dp
-                                IconSize.STANDARD -> 1.dp
+                                IconSize.SMALL -> 2.dp
+                                IconSize.STANDARD -> 3.dp
                                 IconSize.LARGE -> 4.dp
                             }
                             val folderContentHeight = when (iconSize) {

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -550,8 +550,8 @@ fun AppDrawer(
                                 }
                             }
                             
-                            Spacer(modifier = Modifier.height(24.dp))
-                            
+                            Spacer(modifier = Modifier.height(12.dp))
+
                             val folderApps = remember(currentActiveFolder.appPackageNames, apps) { currentActiveFolder.appPackageNames.mapNotNull { pkg -> apps.find { it.packageName == pkg } } }
                             val currentFolderApps by rememberUpdatedState(folderApps)
                             
@@ -663,7 +663,7 @@ fun AppDrawer(
                                             val startIdx = page * itemsPerPage
                                             val endIdx = (startIdx + itemsPerPage).coerceAtMost(folderApps.size)
                                             val pageApps = folderApps.subList(startIdx, endIdx)
-                                            LazyVerticalGrid(columns = GridCells.Fixed(3), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp), userScrollEnabled = false, contentPadding = PaddingValues(top = 20.dp, start = 8.dp, end = 8.dp)) {
+                                            LazyVerticalGrid(columns = GridCells.Fixed(3), modifier = Modifier.fillMaxSize(), horizontalArrangement = Arrangement.spacedBy(16.dp), verticalArrangement = Arrangement.spacedBy(16.dp), userScrollEnabled = false, contentPadding = PaddingValues(top = 8.dp, start = 8.dp, end = 8.dp)) {
                                                 itemsIndexed(pageApps, key = { _, app -> app.packageName }) { indexInPage, app ->
                                                     val globalIndex = startIdx + indexInPage
                                                     val isDragging = draggingItemPkg == app.packageName
@@ -671,7 +671,7 @@ fun AppDrawer(
                                                     val minusWidth = LocalIconSize.current.size * 0.14f
                                                     val minusHeight = 1.5.dp
 
-                                                    Box(modifier = Modifier.let { if (isDragging) it else Modifier.animateItem() }.zIndex(if (isDragging) 0f else 1f).graphicsLayer { rotationZ = if (isEditMode && !isDragging) { if (globalIndex % 2 == 0) wiggleAngle else -wiggleAngle } else 0f; alpha = if (isDragging) 0f else 1f }.padding(top = 12.dp, start = 2.dp, end = 2.dp)) {
+                                                    Box(modifier = Modifier.let { if (isDragging) it else Modifier.animateItem() }.zIndex(if (isDragging) 0f else 1f).graphicsLayer { rotationZ = if (isEditMode && !isDragging) { if (globalIndex % 2 == 0) wiggleAngle else -wiggleAngle } else 0f; alpha = if (isDragging) 0f else 1f }.padding(top = 4.dp, start = 2.dp, end = 2.dp)) {
                                                         AppItem(
                                                             app = app, adaptiveColumns = 3, isFavorite = isFavorite(app.packageName), onToggleFavorite = onToggleFavorite, folders = folders, onUpdateFolders = onUpdateFolders,
                                                             isInFolder = true, currentFolderId = currentActiveFolder.id, isEditMode = isEditMode, bouncePackage = returnIconPackage,

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -193,7 +194,7 @@ fun AppDrawer(
     var showFolderSelection by remember { mutableStateOf(false) }
     var folderSelectionApp by remember { mutableStateOf<AppInfo?>(null) }
 
-    Box(modifier = Modifier.fillMaxSize().onGloballyPositioned { drawerSize = it.size }) {
+    Box(modifier = Modifier.fillMaxSize().testTag("app_drawer").onGloballyPositioned { drawerSize = it.size }) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
@@ -336,7 +337,7 @@ fun AppDrawer(
                 Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
             }
 
-            Box(modifier = Modifier.fillMaxWidth().then(searchBarModifier).padding(horizontal = 16.dp, vertical = 14.dp).clickable(
+            Box(modifier = Modifier.fillMaxWidth().testTag("app_drawer_search_field").then(searchBarModifier).padding(horizontal = 16.dp, vertical = 14.dp).clickable(
                 interactionSource = searchIntSrc,
                 indication = null
             ) { focusRequester.requestFocus() }) {

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material.icons.Icons
@@ -25,24 +24,18 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import com.composables.icons.lucide.*
 import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.data.AutoIconFallbackType
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
-import com.example.androidlauncher.LauncherLogic
 import kotlinx.coroutines.delay
-import java.lang.reflect.Method
 
 /**
  * Konfigurationsmenü für benutzerdefinierte App-Icons.
@@ -134,10 +127,11 @@ fun IconConfigMenu(
         ) {
             itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { index, app ->
                 val customIconName = customIcons[app.packageName]
-                
+                val autoStatus = remember(app.autoIconFallback) { app.autoIconFallback.toStatusLabel() }
+
                 val isSearching = searchQuery.isNotBlank()
                 var isVisible by remember(app.packageName, isSearching) { mutableStateOf(!isSearching) }
-                
+
                 LaunchedEffect(app.packageName, isSearching) {
                     if (isSearching) {
                         delay((index % 12) * 30L)
@@ -147,7 +141,7 @@ fun IconConfigMenu(
 
                 AnimatedVisibility(
                     visible = isVisible,
-                    enter = fadeIn(animationSpec = tween(400)) + 
+                    enter = fadeIn(animationSpec = tween(400)) +
                             scaleIn(initialScale = 0.95f, animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)) +
                             slideInVertically(initialOffsetY = { 20 }, animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)),
                     exit = fadeOut(animationSpec = tween(200))
@@ -176,8 +170,13 @@ fun IconConfigMenu(
                             Spacer(modifier = Modifier.width(16.dp))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(app.label, color = mainTextColor, fontSize = 16.sp, fontWeight = fontWeight.weight)
-                                if (customIconName != null) {
-                                    Text(customIconName, color = mainTextColor.copy(alpha = 0.5f), fontSize = 12.sp)
+                                when {
+                                    customIconName != null -> {
+                                        Text("Manuell · $customIconName", color = mainTextColor.copy(alpha = 0.55f), fontSize = 12.sp)
+                                    }
+                                    autoStatus != null -> {
+                                        Text(autoStatus, color = mainTextColor.copy(alpha = 0.5f), fontSize = 12.sp)
+                                    }
                                 }
                             }
                             if (customIconName != null) {
@@ -202,6 +201,15 @@ fun IconConfigMenu(
             isLiquidGlassEnabled = isLiquidGlassEnabled,
             isDarkTextEnabled = isDarkTextEnabled
         )
+    }
+}
+
+private fun com.example.androidlauncher.data.AutoIconFallback?.toStatusLabel(): String? {
+    return when (this?.type) {
+        AutoIconFallbackType.ORIGINAL -> "Auto · Original"
+        AutoIconFallbackType.LUCIDE -> "Auto · Lucide ${lucideIconName.orEmpty()}".trim()
+        AutoIconFallbackType.NEUTRAL -> "Auto · Neutraler Container"
+        null -> null
     }
 }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -2,6 +2,7 @@ package com.example.androidlauncher.ui
 
 import androidx.compose.animation.*
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
@@ -30,11 +31,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import com.composables.icons.lucide.*
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.AutoIconRule
 import com.example.androidlauncher.data.AutoIconRuleMode
@@ -44,6 +47,7 @@ import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 /**
  * Konfigurationsmenü für benutzerdefinierte App-Icons.
@@ -271,197 +275,265 @@ private fun IconActionDialog(
     val menuSurfaceColor = remember(colorTheme, isDarkTextEnabled) {
         colorTheme.menuSurfaceColor(isDarkTextEnabled)
     }
-    val shape = RoundedCornerShape(28.dp)
-    val scrimColor = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.26f) else Color.Black.copy(alpha = 0.38f)
+    val shape = RoundedCornerShape(topStart = 30.dp, topEnd = 30.dp, bottomStart = 26.dp, bottomEnd = 26.dp)
+    val scrimColor = Color.Black.copy(alpha = if (isDarkTextEnabled) 0.24f else 0.42f)
+    val scope = rememberCoroutineScope()
+    var isVisible by remember { mutableStateOf(false) }
+    var isClosing by remember { mutableStateOf(false) }
+    val scrimAlpha by animateFloatAsState(
+        targetValue = if (isVisible) 1f else 0f,
+        animationSpec = tween(durationMillis = if (isVisible) 220 else 180),
+        label = "iconActionScrimAlpha"
+    )
+
+    LaunchedEffect(Unit) { isVisible = true }
+
+    fun dismissSheet() {
+        if (isClosing) return
+        isClosing = true
+        isVisible = false
+        scope.launch {
+            delay(190)
+            onDismiss()
+        }
+    }
 
     Dialog(
-        onDismissRequest = onDismiss,
+        onDismissRequest = ::dismissSheet,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(scrimColor)
-                .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) { onDismiss() }
-                .padding(horizontal = 24.dp, vertical = 32.dp),
-            contentAlignment = Alignment.Center
+                .background(scrimColor.copy(alpha = scrimAlpha))
+                .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) { dismissSheet() }
+                .padding(horizontal = 14.dp, vertical = 12.dp)
         ) {
-            Surface(
+            AnimatedVisibility(
+                visible = isVisible,
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .widthIn(max = 420.dp)
-                    .testTag("icon_action_dialog")
-                    .clip(shape)
-                    .then(
-                        Modifier.conditionalGlass(
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding(),
+                enter = slideInVertically(
+                    initialOffsetY = { fullHeight -> fullHeight / 3 },
+                    animationSpec = tween(260)
+                ) + fadeIn(animationSpec = tween(220)),
+                exit = slideOutVertically(
+                    targetOffsetY = { fullHeight -> fullHeight / 4 },
+                    animationSpec = tween(180)
+                ) + fadeOut(animationSpec = tween(160))
+            ) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .widthIn(max = 460.dp)
+                        .testTag("icon_action_dialog")
+                        .clip(shape)
+                        .conditionalGlass(
                             shape = shape,
                             isDarkText = isDarkTextEnabled,
                             isEnabled = isLiquidGlassEnabled,
                             fallbackAlpha = 0.08f
                         )
-                    )
-                    .clickable(enabled = false) {},
-                color = menuSurfaceColor.copy(alpha = if (isLiquidGlassEnabled) 0.78f else 0.96f),
-                shape = shape,
-                shadowElevation = 24.dp
-            ) {
-                Column(
-                    modifier = Modifier
-                        .padding(22.dp)
-                        .verticalScroll(rememberScrollState()),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                        .clickable(enabled = false) {},
+                    color = menuSurfaceColor.copy(alpha = if (isLiquidGlassEnabled) 0.84f else 0.96f),
+                    shape = shape,
+                    shadowElevation = 28.dp
                 ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.Top
-                    ) {
-                        Row(
-                            modifier = Modifier.weight(1f),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(14.dp)
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .size(52.dp)
-                                    .clip(CircleShape)
-                                    .conditionalGlass(CircleShape, isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.06f),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                AppIconView(app = app, modifier = Modifier.size(30.dp))
-                            }
-                            Column {
-                                Text(
-                                    text = app.label,
-                                    color = mainTextColor,
-                                    style = MaterialTheme.typography.titleLarge,
-                                    fontWeight = fontWeight.weight
-                                )
-                                Text(
-                                    text = "Icon-Optionen",
-                                    color = secondaryTextColor,
-                                    style = MaterialTheme.typography.bodyMedium
-                                )
-                            }
-                        }
-                        IconButton(onClick = onDismiss) {
-                            Icon(Icons.Default.Close, contentDescription = "Schließen", tint = mainTextColor)
-                        }
-                    }
-
                     Column(
                         modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(RoundedCornerShape(20.dp))
-                            .conditionalGlass(RoundedCornerShape(20.dp), isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.05f)
-                            .padding(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                            .padding(horizontal = 18.dp, vertical = 16.dp)
+                            .verticalScroll(rememberScrollState()),
+                        verticalArrangement = Arrangement.spacedBy(14.dp)
                     ) {
-                        currentStatus?.let {
-                            Text(
-                                text = it,
-                                color = mainTextColor,
-                                style = MaterialTheme.typography.bodyMedium,
-                                fontWeight = fontWeight.weight
-                            )
-                        }
-                        Text(
-                            text = app.packageName,
-                            color = secondaryTextColor,
-                            style = MaterialTheme.typography.bodySmall
+                        Box(
+                            modifier = Modifier
+                                .align(Alignment.CenterHorizontally)
+                                .size(width = 42.dp, height = 4.dp)
+                                .clip(RoundedCornerShape(50))
+                                .background(mainTextColor.copy(alpha = 0.18f))
                         )
-                        if (customIconName != null) {
+
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.Top
+                        ) {
+                            Row(
+                                modifier = Modifier.weight(1f),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(14.dp)
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(54.dp)
+                                        .clip(CircleShape)
+                                        .conditionalGlass(CircleShape, isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.06f),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    AppIconView(app = app, modifier = Modifier.size(30.dp))
+                                }
+                                Column {
+                                    Text(
+                                        text = app.label,
+                                        color = mainTextColor,
+                                        style = MaterialTheme.typography.titleLarge,
+                                        fontWeight = fontWeight.weight
+                                    )
+                                    Text(
+                                        text = "Icon-Optionen",
+                                        color = secondaryTextColor,
+                                        style = MaterialTheme.typography.bodyMedium
+                                    )
+                                }
+                            }
+                            IconButton(onClick = ::dismissSheet) {
+                                Icon(Icons.Default.Close, contentDescription = "Schließen", tint = mainTextColor)
+                            }
+                        }
+
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(20.dp))
+                                .conditionalGlass(RoundedCornerShape(20.dp), isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.05f)
+                                .padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            currentStatus?.let {
+                                Text(
+                                    text = it,
+                                    color = mainTextColor,
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    fontWeight = fontWeight.weight
+                                )
+                            }
                             Text(
-                                text = "Manueller Override aktiv: $customIconName",
+                                text = app.packageName,
                                 color = secondaryTextColor,
                                 style = MaterialTheme.typography.bodySmall
                             )
+                            if (customIconName != null) {
+                                Text(
+                                    text = "Manueller Override aktiv: $customIconName",
+                                    color = secondaryTextColor,
+                                    style = MaterialTheme.typography.bodySmall
+                                )
+                            }
                         }
-                    }
 
-                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                        Text(
-                            text = "Direkte Aktionen",
-                            color = secondaryTextColor,
-                            style = MaterialTheme.typography.labelLarge
-                        )
-                        IconActionButton(
-                            title = "Lucide-Icon auswählen",
-                            subtitle = "Weise dieser App direkt ein eigenes Icon zu",
-                            testTag = "icon_action_pick_lucide",
-                            onClick = onPickLucide,
-                            isPrimary = true,
-                            isLiquidGlassEnabled = isLiquidGlassEnabled,
-                            isDarkTextEnabled = isDarkTextEnabled
-                        )
-                        IconActionButton(
-                            title = "Auto neu analysieren",
-                            subtitle = "Prüft Original, Form und Lesbarkeit erneut",
-                            testTag = "icon_action_reanalyze",
-                            onClick = onReanalyze,
-                            isLiquidGlassEnabled = isLiquidGlassEnabled,
-                            isDarkTextEnabled = isDarkTextEnabled
-                        )
-                    }
-
-                    HorizontalDivider(color = mainTextColor.copy(alpha = 0.08f))
-
-                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-                        Text(
-                            text = "Automatische Regeln",
-                            color = secondaryTextColor,
-                            style = MaterialTheme.typography.labelLarge
-                        )
-                        IconActionButton(
-                            title = "Original immer behalten",
-                            subtitle = "Überschreibt die Heuristik und zeigt das echte App-Icon",
-                            testTag = "icon_action_keep_original",
-                            onClick = { onSelectRule(AutoIconRuleMode.KEEP_ORIGINAL) },
-                            isSelected = explicitRule?.mode == AutoIconRuleMode.KEEP_ORIGINAL,
-                            isLiquidGlassEnabled = isLiquidGlassEnabled,
-                            isDarkTextEnabled = isDarkTextEnabled
-                        )
-                        IconActionButton(
-                            title = "Automatischen Fallback bevorzugen",
-                            subtitle = "Erzwingt Lucide oder neutralen Container",
-                            testTag = "icon_action_force_fallback",
-                            onClick = { onSelectRule(AutoIconRuleMode.FORCE_FALLBACK) },
-                            isSelected = explicitRule?.mode == AutoIconRuleMode.FORCE_FALLBACK,
-                            isLiquidGlassEnabled = isLiquidGlassEnabled,
-                            isDarkTextEnabled = isDarkTextEnabled
-                        )
-                        IconActionButton(
-                            title = "Nur Heuristik verwenden",
-                            subtitle = "Entscheidung wieder automatisch treffen lassen",
-                            testTag = "icon_action_follow_heuristic",
-                            onClick = { onSelectRule(AutoIconRuleMode.FOLLOW_HEURISTIC) },
-                            isSelected = explicitRule?.mode == AutoIconRuleMode.FOLLOW_HEURISTIC,
-                            isLiquidGlassEnabled = isLiquidGlassEnabled,
-                            isDarkTextEnabled = isDarkTextEnabled
-                        )
-                        if (explicitRule != null) {
+                        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            Text(
+                                text = "Direkte Aktionen",
+                                color = secondaryTextColor,
+                                style = MaterialTheme.typography.labelLarge
+                            )
                             IconActionButton(
-                                title = "Gespeicherte Regel entfernen",
-                                subtitle = "Fällt auf die Standardlogik des Launchers zurück",
-                                testTag = "icon_action_clear_rule",
-                                onClick = { onSelectRule(null) },
+                                icon = Lucide.Palette,
+                                title = "Lucide-Icon auswählen",
+                                subtitle = "Weise dieser App direkt ein eigenes Icon zu",
+                                testTag = "icon_action_pick_lucide",
+                                onClick = {
+                                    dismissSheet()
+                                    onPickLucide()
+                                },
+                                isPrimary = true,
+                                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                isDarkTextEnabled = isDarkTextEnabled
+                            )
+                            IconActionButton(
+                                icon = Lucide.RefreshCcw,
+                                title = "Auto neu analysieren",
+                                subtitle = "Prüft Original, Form und Lesbarkeit erneut",
+                                testTag = "icon_action_reanalyze",
+                                onClick = {
+                                    dismissSheet()
+                                    onReanalyze()
+                                },
                                 isLiquidGlassEnabled = isLiquidGlassEnabled,
                                 isDarkTextEnabled = isDarkTextEnabled
                             )
                         }
-                    }
 
-                    if (customIconName != null) {
                         HorizontalDivider(color = mainTextColor.copy(alpha = 0.08f))
-                        IconActionButton(
-                            title = "Manuellen Override entfernen",
-                            subtitle = "Nutzt wieder die automatische Entscheidung des Launchers",
-                            testTag = "icon_action_reset_manual",
-                            onClick = onResetManual,
-                            isDestructive = true,
-                            isLiquidGlassEnabled = isLiquidGlassEnabled,
-                            isDarkTextEnabled = isDarkTextEnabled
-                        )
+
+                        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                            Text(
+                                text = "Automatische Regeln",
+                                color = secondaryTextColor,
+                                style = MaterialTheme.typography.labelLarge
+                            )
+                            IconActionButton(
+                                icon = Lucide.ShieldCheck,
+                                title = "Original immer behalten",
+                                subtitle = "Überschreibt die Heuristik und zeigt das echte App-Icon",
+                                testTag = "icon_action_keep_original",
+                                onClick = {
+                                    dismissSheet()
+                                    onSelectRule(AutoIconRuleMode.KEEP_ORIGINAL)
+                                },
+                                isSelected = explicitRule?.mode == AutoIconRuleMode.KEEP_ORIGINAL,
+                                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                isDarkTextEnabled = isDarkTextEnabled
+                            )
+                            IconActionButton(
+                                icon = Lucide.Replace,
+                                title = "Automatischen Fallback bevorzugen",
+                                subtitle = "Erzwingt Lucide oder neutralen Container",
+                                testTag = "icon_action_force_fallback",
+                                onClick = {
+                                    dismissSheet()
+                                    onSelectRule(AutoIconRuleMode.FORCE_FALLBACK)
+                                },
+                                isSelected = explicitRule?.mode == AutoIconRuleMode.FORCE_FALLBACK,
+                                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                isDarkTextEnabled = isDarkTextEnabled
+                            )
+                            IconActionButton(
+                                icon = Lucide.Search,
+                                title = "Nur Heuristik verwenden",
+                                subtitle = "Entscheidung wieder automatisch treffen lassen",
+                                testTag = "icon_action_follow_heuristic",
+                                onClick = {
+                                    dismissSheet()
+                                    onSelectRule(AutoIconRuleMode.FOLLOW_HEURISTIC)
+                                },
+                                isSelected = explicitRule?.mode == AutoIconRuleMode.FOLLOW_HEURISTIC,
+                                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                isDarkTextEnabled = isDarkTextEnabled
+                            )
+                            if (explicitRule != null) {
+                                IconActionButton(
+                                    icon = Lucide.Eraser,
+                                    title = "Gespeicherte Regel entfernen",
+                                    subtitle = "Fällt auf die Standardlogik des Launchers zurück",
+                                    testTag = "icon_action_clear_rule",
+                                    onClick = {
+                                        dismissSheet()
+                                        onSelectRule(null)
+                                    },
+                                    isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                    isDarkTextEnabled = isDarkTextEnabled
+                                )
+                            }
+                        }
+
+                        if (customIconName != null) {
+                            HorizontalDivider(color = mainTextColor.copy(alpha = 0.08f))
+                            IconActionButton(
+                                icon = Lucide.Trash2,
+                                title = "Manuellen Override entfernen",
+                                subtitle = "Nutzt wieder die automatische Entscheidung des Launchers",
+                                testTag = "icon_action_reset_manual",
+                                onClick = {
+                                    dismissSheet()
+                                    onResetManual()
+                                },
+                                isDestructive = true,
+                                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                isDarkTextEnabled = isDarkTextEnabled
+                            )
+                        }
                     }
                 }
             }
@@ -471,6 +543,7 @@ private fun IconActionDialog(
 
 @Composable
 private fun IconActionButton(
+    icon: ImageVector,
     title: String,
     subtitle: String,
     testTag: String,
@@ -506,14 +579,22 @@ private fun IconActionButton(
             .clickable(onClick = onClick)
             .padding(horizontal = 16.dp, vertical = 14.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        horizontalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         Box(
             modifier = Modifier
-                .size(10.dp)
+                .size(34.dp)
                 .clip(CircleShape)
-                .background(accentColor.copy(alpha = if (isSelected || isPrimary || isDestructive) 0.95f else 0.4f))
-        )
+                .background(accentColor.copy(alpha = if (isSelected || isPrimary || isDestructive) 0.14f else 0.08f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = accentColor,
+                modifier = Modifier.size(18.dp)
+            )
+        }
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = title,

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -309,6 +310,11 @@ private fun IconActionDialog(
                 .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) { dismissSheet() }
                 .padding(horizontal = 14.dp, vertical = 12.dp)
         ) {
+            val configuration = LocalConfiguration.current
+            val maxSheetHeight = remember(configuration.screenHeightDp) {
+                (configuration.screenHeightDp.dp * 0.82f)
+            }
+
             AnimatedVisibility(
                 visible = isVisible,
                 modifier = Modifier
@@ -327,6 +333,7 @@ private fun IconActionDialog(
                     modifier = Modifier
                         .fillMaxWidth()
                         .widthIn(max = 460.dp)
+                        .heightIn(max = maxSheetHeight)
                         .testTag("icon_action_dialog")
                         .clip(shape)
                         .conditionalGlass(
@@ -342,8 +349,11 @@ private fun IconActionDialog(
                 ) {
                     Column(
                         modifier = Modifier
+                            .fillMaxWidth()
+                            .navigationBarsPadding()
                             .padding(horizontal = 18.dp, vertical = 16.dp)
-                            .verticalScroll(rememberScrollState()),
+                            .verticalScroll(rememberScrollState())
+                            .padding(bottom = 20.dp),
                         verticalArrangement = Arrangement.spacedBy(14.dp)
                     ) {
                         Box(

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -14,8 +14,10 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Search
@@ -26,12 +28,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.example.androidlauncher.data.AppInfo
-import com.example.androidlauncher.data.AutoIconFallbackType
+import com.example.androidlauncher.data.AutoIconRule
+import com.example.androidlauncher.data.AutoIconRuleMode
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
@@ -53,24 +57,29 @@ import kotlinx.coroutines.delay
 fun IconConfigMenu(
     apps: List<AppInfo>,
     customIcons: Map<String, String>,
+    iconRules: Map<String, AutoIconRule>,
     onIconSelected: (String, String?) -> Unit,
+    onAutoRuleSelected: (String, AutoIconRuleMode?) -> Unit,
+    onReanalyzeRequested: (String) -> Unit,
     onClose: () -> Unit
 ) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val fontWeight = LocalFontWeight.current
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
-    
+
     var searchQuery by remember { mutableStateOf("") }
     val filteredApps = remember(apps, searchQuery) {
         if (searchQuery.isBlank()) apps else apps.filter { it.label.contains(searchQuery, ignoreCase = true) }
     }
 
-    var selectedAppForIcon by remember { mutableStateOf<AppInfo?>(null) }
+    var selectedAppForActions by remember { mutableStateOf<AppInfo?>(null) }
+    var selectedAppForPicker by remember { mutableStateOf<AppInfo?>(null) }
 
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .testTag("icon_config_menu")
             .statusBarsPadding()
             .navigationBarsPadding()
             .padding(horizontal = 24.dp, vertical = 16.dp)
@@ -127,7 +136,10 @@ fun IconConfigMenu(
         ) {
             itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { index, app ->
                 val customIconName = customIcons[app.packageName]
-                val autoStatus = remember(app.autoIconFallback) { app.autoIconFallback.toStatusLabel() }
+                val explicitRule = iconRules[app.packageName]
+                val autoStatus = remember(app.autoIconFallback, app.autoIconRule, explicitRule) {
+                    buildIconStatusLabel(app, explicitRule)
+                }
 
                 val isSearching = searchQuery.isNotBlank()
                 var isVisible by remember(app.packageName, isSearching) { mutableStateOf(!isSearching) }
@@ -157,16 +169,17 @@ fun IconConfigMenu(
                     Surface(
                         modifier = Modifier
                             .fillMaxWidth()
+                            .testTag("icon_config_item_${app.packageName}")
                             .clip(RoundedCornerShape(16.dp))
                             .then(itemBackgroundModifier)
-                            .clickable { selectedAppForIcon = app },
+                            .clickable { selectedAppForActions = app },
                         color = Color.Transparent
                     ) {
                         Row(
                             modifier = Modifier.padding(12.dp),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            AppIconView(app, modifier = Modifier.size(40.dp))
+                            AppIconView(app, modifier = Modifier.size(40.dp), customIcons = customIcons)
                             Spacer(modifier = Modifier.width(16.dp))
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(app.label, color = mainTextColor, fontSize = 16.sp, fontWeight = fontWeight.weight)
@@ -179,11 +192,11 @@ fun IconConfigMenu(
                                     }
                                 }
                             }
-                            if (customIconName != null) {
-                                TextButton(onClick = { onIconSelected(app.packageName, null) }) {
-                                    Text("Reset", color = Color.Red.copy(alpha = 0.7f))
-                                }
-                            }
+                            Text(
+                                text = "Anpassen",
+                                color = mainTextColor.copy(alpha = 0.72f),
+                                fontSize = 12.sp
+                            )
                         }
                     }
                 }
@@ -191,24 +204,148 @@ fun IconConfigMenu(
         }
     }
 
-    if (selectedAppForIcon != null) {
+    selectedAppForActions?.let { app ->
+        IconActionDialog(
+            app = app,
+            customIconName = customIcons[app.packageName],
+            explicitRule = iconRules[app.packageName],
+            onPickLucide = {
+                selectedAppForPicker = app
+                selectedAppForActions = null
+            },
+            onResetManual = {
+                onIconSelected(app.packageName, null)
+                selectedAppForActions = null
+            },
+            onSelectRule = { mode ->
+                onAutoRuleSelected(app.packageName, mode)
+                selectedAppForActions = null
+            },
+            onReanalyze = {
+                onReanalyzeRequested(app.packageName)
+                selectedAppForActions = null
+            },
+            onDismiss = { selectedAppForActions = null },
+            isLiquidGlassEnabled = isLiquidGlassEnabled,
+            isDarkTextEnabled = isDarkTextEnabled
+        )
+    }
+
+    if (selectedAppForPicker != null) {
         LucideIconPicker(
             onIconSelected = { iconName ->
-                onIconSelected(selectedAppForIcon!!.packageName, iconName)
-                selectedAppForIcon = null
+                onIconSelected(selectedAppForPicker!!.packageName, iconName)
+                selectedAppForPicker = null
             },
-            onDismiss = { selectedAppForIcon = null },
+            onDismiss = { selectedAppForPicker = null },
             isLiquidGlassEnabled = isLiquidGlassEnabled,
             isDarkTextEnabled = isDarkTextEnabled
         )
     }
 }
 
-private fun com.example.androidlauncher.data.AutoIconFallback?.toStatusLabel(): String? {
-    return when (this?.type) {
-        AutoIconFallbackType.ORIGINAL -> "Auto · Original"
-        AutoIconFallbackType.LUCIDE -> "Auto · Lucide ${lucideIconName.orEmpty()}".trim()
-        AutoIconFallbackType.NEUTRAL -> "Auto · Neutraler Container"
+@Composable
+private fun IconActionDialog(
+    app: AppInfo,
+    customIconName: String?,
+    explicitRule: AutoIconRule?,
+    onPickLucide: () -> Unit,
+    onResetManual: () -> Unit,
+    onSelectRule: (AutoIconRuleMode?) -> Unit,
+    onReanalyze: () -> Unit,
+    onDismiss: () -> Unit,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean
+) {
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    val cardModifier = if (isLiquidGlassEnabled) {
+        Modifier
+            .background(LiquidGlass.glassBrush(isDarkTextEnabled, startAlpha = 0.12f, endAlpha = 0.04f), RoundedCornerShape(24.dp))
+            .border(BorderStroke(1.dp, LiquidGlass.borderBrush(isDarkTextEnabled, startAlpha = 0.18f, endAlpha = 0.06f)), RoundedCornerShape(24.dp))
+    } else {
+        Modifier.background(MaterialTheme.colorScheme.surface, RoundedCornerShape(24.dp))
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("icon_action_dialog")
+                .then(cardModifier),
+            color = Color.Transparent,
+            shape = RoundedCornerShape(24.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(20.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Text(app.label, color = mainTextColor, style = MaterialTheme.typography.titleLarge)
+                Text(app.packageName, color = mainTextColor.copy(alpha = 0.5f), style = MaterialTheme.typography.bodySmall)
+
+                IconActionButton(text = "Lucide-Icon auswählen", testTag = "icon_action_pick_lucide", onClick = onPickLucide)
+                IconActionButton(text = "Auto neu analysieren", testTag = "icon_action_reanalyze", onClick = onReanalyze)
+                IconActionButton(text = "Original immer behalten", testTag = "icon_action_keep_original") {
+                    onSelectRule(AutoIconRuleMode.KEEP_ORIGINAL)
+                }
+                IconActionButton(text = "Automatischen Fallback bevorzugen", testTag = "icon_action_force_fallback") {
+                    onSelectRule(AutoIconRuleMode.FORCE_FALLBACK)
+                }
+                IconActionButton(text = "Nur Heuristik verwenden", testTag = "icon_action_follow_heuristic") {
+                    onSelectRule(AutoIconRuleMode.FOLLOW_HEURISTIC)
+                }
+                if (explicitRule != null) {
+                    IconActionButton(text = "Gespeicherte Regel entfernen", testTag = "icon_action_clear_rule") {
+                        onSelectRule(null)
+                    }
+                }
+                if (customIconName != null) {
+                    IconActionButton(text = "Manuellen Override entfernen", testTag = "icon_action_reset_manual", onClick = onResetManual)
+                }
+                TextButton(
+                    modifier = Modifier.align(Alignment.End),
+                    onClick = onDismiss
+                ) {
+                    Text("Schließen")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun IconActionButton(
+    text: String,
+    testTag: String,
+    onClick: () -> Unit
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(testTag)
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)
+        )
+    }
+}
+
+private fun buildIconStatusLabel(app: AppInfo, explicitRule: AutoIconRule?): String? {
+    val ruleLabel = when (explicitRule?.mode) {
+        AutoIconRuleMode.KEEP_ORIGINAL -> "Regel · Original bevorzugen"
+        AutoIconRuleMode.FORCE_FALLBACK -> "Regel · Fallback bevorzugen"
+        AutoIconRuleMode.FOLLOW_HEURISTIC -> "Regel · Nur Heuristik"
+        null -> null
+    }
+    return ruleLabel ?: when (app.autoIconFallback?.type) {
+        com.example.androidlauncher.data.AutoIconFallbackType.ORIGINAL -> "Auto · Original"
+        com.example.androidlauncher.data.AutoIconFallbackType.LUCIDE -> "Auto · Lucide ${app.autoIconFallback.lucideIconName.orEmpty()}".trim()
+        com.example.androidlauncher.data.AutoIconFallbackType.NEUTRAL -> "Auto · Neutraler Container"
         null -> null
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IconConfigMenu.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -15,6 +16,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
@@ -36,6 +38,8 @@ import androidx.compose.ui.window.DialogProperties
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.AutoIconRule
 import com.example.androidlauncher.data.AutoIconRuleMode
+import com.example.androidlauncher.ui.LiquidGlass.conditionalGlass
+import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
@@ -66,7 +70,8 @@ fun IconConfigMenu(
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val fontWeight = LocalFontWeight.current
-    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    val mainTextColor = LiquidGlass.mainTextColor(isDarkTextEnabled)
+    val secondaryTextColor = LiquidGlass.secondaryTextColor(isDarkTextEnabled)
 
     var searchQuery by remember { mutableStateOf("") }
     val filteredApps = remember(apps, searchQuery) {
@@ -122,7 +127,7 @@ fun IconConfigMenu(
                     textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 16.sp),
                     cursorBrush = SolidColor(mainTextColor),
                     singleLine = true,
-                    decorationBox = { if (searchQuery.isEmpty()) Text("Apps durchsuchen...", color = mainTextColor.copy(alpha = 0.4f), fontSize = 16.sp); it() }
+                    decorationBox = { if (searchQuery.isEmpty()) Text("Apps durchsuchen...", color = secondaryTextColor, fontSize = 16.sp); it() }
                 )
             }
         }
@@ -188,7 +193,7 @@ fun IconConfigMenu(
                                         Text("Manuell · $customIconName", color = mainTextColor.copy(alpha = 0.55f), fontSize = 12.sp)
                                     }
                                     autoStatus != null -> {
-                                        Text(autoStatus, color = mainTextColor.copy(alpha = 0.5f), fontSize = 12.sp)
+                                        Text(autoStatus, color = secondaryTextColor, fontSize = 12.sp)
                                     }
                                 }
                             }
@@ -209,6 +214,7 @@ fun IconConfigMenu(
             app = app,
             customIconName = customIcons[app.packageName],
             explicitRule = iconRules[app.packageName],
+            currentStatus = buildIconStatusLabel(app, iconRules[app.packageName]),
             onPickLucide = {
                 selectedAppForPicker = app
                 selectedAppForActions = null
@@ -249,6 +255,7 @@ private fun IconActionDialog(
     app: AppInfo,
     customIconName: String?,
     explicitRule: AutoIconRule?,
+    currentStatus: String?,
     onPickLucide: () -> Unit,
     onResetManual: () -> Unit,
     onSelectRule: (AutoIconRuleMode?) -> Unit,
@@ -257,57 +264,205 @@ private fun IconActionDialog(
     isLiquidGlassEnabled: Boolean,
     isDarkTextEnabled: Boolean
 ) {
-    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
-    val cardModifier = if (isLiquidGlassEnabled) {
-        Modifier
-            .background(LiquidGlass.glassBrush(isDarkTextEnabled, startAlpha = 0.12f, endAlpha = 0.04f), RoundedCornerShape(24.dp))
-            .border(BorderStroke(1.dp, LiquidGlass.borderBrush(isDarkTextEnabled, startAlpha = 0.18f, endAlpha = 0.06f)), RoundedCornerShape(24.dp))
-    } else {
-        Modifier.background(MaterialTheme.colorScheme.surface, RoundedCornerShape(24.dp))
+    val colorTheme = LocalColorTheme.current
+    val fontWeight = LocalFontWeight.current
+    val mainTextColor = LiquidGlass.mainTextColor(isDarkTextEnabled)
+    val secondaryTextColor = LiquidGlass.secondaryTextColor(isDarkTextEnabled)
+    val menuSurfaceColor = remember(colorTheme, isDarkTextEnabled) {
+        colorTheme.menuSurfaceColor(isDarkTextEnabled)
     }
+    val shape = RoundedCornerShape(28.dp)
+    val scrimColor = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.26f) else Color.Black.copy(alpha = 0.38f)
 
-    Dialog(onDismissRequest = onDismiss) {
-        Surface(
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .testTag("icon_action_dialog")
-                .then(cardModifier),
-            color = Color.Transparent,
-            shape = RoundedCornerShape(24.dp)
+                .fillMaxSize()
+                .background(scrimColor)
+                .clickable(indication = null, interactionSource = remember { MutableInteractionSource() }) { onDismiss() }
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+            contentAlignment = Alignment.Center
         ) {
-            Column(
+            Surface(
                 modifier = Modifier
-                    .padding(20.dp)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                    .fillMaxWidth()
+                    .widthIn(max = 420.dp)
+                    .testTag("icon_action_dialog")
+                    .clip(shape)
+                    .then(
+                        Modifier.conditionalGlass(
+                            shape = shape,
+                            isDarkText = isDarkTextEnabled,
+                            isEnabled = isLiquidGlassEnabled,
+                            fallbackAlpha = 0.08f
+                        )
+                    )
+                    .clickable(enabled = false) {},
+                color = menuSurfaceColor.copy(alpha = if (isLiquidGlassEnabled) 0.78f else 0.96f),
+                shape = shape,
+                shadowElevation = 24.dp
             ) {
-                Text(app.label, color = mainTextColor, style = MaterialTheme.typography.titleLarge)
-                Text(app.packageName, color = mainTextColor.copy(alpha = 0.5f), style = MaterialTheme.typography.bodySmall)
-
-                IconActionButton(text = "Lucide-Icon auswählen", testTag = "icon_action_pick_lucide", onClick = onPickLucide)
-                IconActionButton(text = "Auto neu analysieren", testTag = "icon_action_reanalyze", onClick = onReanalyze)
-                IconActionButton(text = "Original immer behalten", testTag = "icon_action_keep_original") {
-                    onSelectRule(AutoIconRuleMode.KEEP_ORIGINAL)
-                }
-                IconActionButton(text = "Automatischen Fallback bevorzugen", testTag = "icon_action_force_fallback") {
-                    onSelectRule(AutoIconRuleMode.FORCE_FALLBACK)
-                }
-                IconActionButton(text = "Nur Heuristik verwenden", testTag = "icon_action_follow_heuristic") {
-                    onSelectRule(AutoIconRuleMode.FOLLOW_HEURISTIC)
-                }
-                if (explicitRule != null) {
-                    IconActionButton(text = "Gespeicherte Regel entfernen", testTag = "icon_action_clear_rule") {
-                        onSelectRule(null)
-                    }
-                }
-                if (customIconName != null) {
-                    IconActionButton(text = "Manuellen Override entfernen", testTag = "icon_action_reset_manual", onClick = onResetManual)
-                }
-                TextButton(
-                    modifier = Modifier.align(Alignment.End),
-                    onClick = onDismiss
+                Column(
+                    modifier = Modifier
+                        .padding(22.dp)
+                        .verticalScroll(rememberScrollState()),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    Text("Schließen")
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.Top
+                    ) {
+                        Row(
+                            modifier = Modifier.weight(1f),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(14.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(52.dp)
+                                    .clip(CircleShape)
+                                    .conditionalGlass(CircleShape, isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.06f),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                AppIconView(app = app, modifier = Modifier.size(30.dp))
+                            }
+                            Column {
+                                Text(
+                                    text = app.label,
+                                    color = mainTextColor,
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = fontWeight.weight
+                                )
+                                Text(
+                                    text = "Icon-Optionen",
+                                    color = secondaryTextColor,
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                            }
+                        }
+                        IconButton(onClick = onDismiss) {
+                            Icon(Icons.Default.Close, contentDescription = "Schließen", tint = mainTextColor)
+                        }
+                    }
+
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(20.dp))
+                            .conditionalGlass(RoundedCornerShape(20.dp), isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.05f)
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        currentStatus?.let {
+                            Text(
+                                text = it,
+                                color = mainTextColor,
+                                style = MaterialTheme.typography.bodyMedium,
+                                fontWeight = fontWeight.weight
+                            )
+                        }
+                        Text(
+                            text = app.packageName,
+                            color = secondaryTextColor,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                        if (customIconName != null) {
+                            Text(
+                                text = "Manueller Override aktiv: $customIconName",
+                                color = secondaryTextColor,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(
+                            text = "Direkte Aktionen",
+                            color = secondaryTextColor,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                        IconActionButton(
+                            title = "Lucide-Icon auswählen",
+                            subtitle = "Weise dieser App direkt ein eigenes Icon zu",
+                            testTag = "icon_action_pick_lucide",
+                            onClick = onPickLucide,
+                            isPrimary = true,
+                            isLiquidGlassEnabled = isLiquidGlassEnabled,
+                            isDarkTextEnabled = isDarkTextEnabled
+                        )
+                        IconActionButton(
+                            title = "Auto neu analysieren",
+                            subtitle = "Prüft Original, Form und Lesbarkeit erneut",
+                            testTag = "icon_action_reanalyze",
+                            onClick = onReanalyze,
+                            isLiquidGlassEnabled = isLiquidGlassEnabled,
+                            isDarkTextEnabled = isDarkTextEnabled
+                        )
+                    }
+
+                    HorizontalDivider(color = mainTextColor.copy(alpha = 0.08f))
+
+                    Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                        Text(
+                            text = "Automatische Regeln",
+                            color = secondaryTextColor,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                        IconActionButton(
+                            title = "Original immer behalten",
+                            subtitle = "Überschreibt die Heuristik und zeigt das echte App-Icon",
+                            testTag = "icon_action_keep_original",
+                            onClick = { onSelectRule(AutoIconRuleMode.KEEP_ORIGINAL) },
+                            isSelected = explicitRule?.mode == AutoIconRuleMode.KEEP_ORIGINAL,
+                            isLiquidGlassEnabled = isLiquidGlassEnabled,
+                            isDarkTextEnabled = isDarkTextEnabled
+                        )
+                        IconActionButton(
+                            title = "Automatischen Fallback bevorzugen",
+                            subtitle = "Erzwingt Lucide oder neutralen Container",
+                            testTag = "icon_action_force_fallback",
+                            onClick = { onSelectRule(AutoIconRuleMode.FORCE_FALLBACK) },
+                            isSelected = explicitRule?.mode == AutoIconRuleMode.FORCE_FALLBACK,
+                            isLiquidGlassEnabled = isLiquidGlassEnabled,
+                            isDarkTextEnabled = isDarkTextEnabled
+                        )
+                        IconActionButton(
+                            title = "Nur Heuristik verwenden",
+                            subtitle = "Entscheidung wieder automatisch treffen lassen",
+                            testTag = "icon_action_follow_heuristic",
+                            onClick = { onSelectRule(AutoIconRuleMode.FOLLOW_HEURISTIC) },
+                            isSelected = explicitRule?.mode == AutoIconRuleMode.FOLLOW_HEURISTIC,
+                            isLiquidGlassEnabled = isLiquidGlassEnabled,
+                            isDarkTextEnabled = isDarkTextEnabled
+                        )
+                        if (explicitRule != null) {
+                            IconActionButton(
+                                title = "Gespeicherte Regel entfernen",
+                                subtitle = "Fällt auf die Standardlogik des Launchers zurück",
+                                testTag = "icon_action_clear_rule",
+                                onClick = { onSelectRule(null) },
+                                isLiquidGlassEnabled = isLiquidGlassEnabled,
+                                isDarkTextEnabled = isDarkTextEnabled
+                            )
+                        }
+                    }
+
+                    if (customIconName != null) {
+                        HorizontalDivider(color = mainTextColor.copy(alpha = 0.08f))
+                        IconActionButton(
+                            title = "Manuellen Override entfernen",
+                            subtitle = "Nutzt wieder die automatische Entscheidung des Launchers",
+                            testTag = "icon_action_reset_manual",
+                            onClick = onResetManual,
+                            isDestructive = true,
+                            isLiquidGlassEnabled = isLiquidGlassEnabled,
+                            isDarkTextEnabled = isDarkTextEnabled
+                        )
+                    }
                 }
             }
         }
@@ -316,22 +471,69 @@ private fun IconActionDialog(
 
 @Composable
 private fun IconActionButton(
-    text: String,
+    title: String,
+    subtitle: String,
     testTag: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    isPrimary: Boolean = false,
+    isDestructive: Boolean = false,
+    isSelected: Boolean = false,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean
 ) {
-    Surface(
+    val mainTextColor = LiquidGlass.mainTextColor(isDarkTextEnabled)
+    val secondaryTextColor = LiquidGlass.secondaryTextColor(isDarkTextEnabled)
+    val accentColor = when {
+        isDestructive -> Color(0xFFEF5350)
+        isPrimary -> mainTextColor
+        else -> mainTextColor
+    }
+    val shape = RoundedCornerShape(18.dp)
+    val containerModifier = if (isSelected) {
+        Modifier
+            .background(accentColor.copy(alpha = if (isDarkTextEnabled) 0.10f else 0.16f), shape)
+            .border(BorderStroke(1.dp, accentColor.copy(alpha = 0.38f)), shape)
+    } else {
+        Modifier.conditionalGlass(shape, isDarkTextEnabled, isLiquidGlassEnabled, fallbackAlpha = 0.05f)
+    }
+
+    Row(
         modifier = Modifier
             .fillMaxWidth()
             .testTag(testTag)
-            .clickable(onClick = onClick),
-        shape = RoundedCornerShape(16.dp),
-        color = MaterialTheme.colorScheme.surface.copy(alpha = 0.5f)
+            .clip(shape)
+            .then(containerModifier)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Text(
-            text = text,
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp)
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(accentColor.copy(alpha = if (isSelected || isPrimary || isDestructive) 0.95f else 0.4f))
         )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = title,
+                color = accentColor,
+                style = MaterialTheme.typography.bodyLarge
+            )
+            Spacer(modifier = Modifier.height(2.dp))
+            Text(
+                text = subtitle,
+                color = secondaryTextColor,
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+        if (isSelected) {
+            Text(
+                text = "Aktiv",
+                color = accentColor,
+                style = MaterialTheme.typography.labelMedium
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -48,9 +49,7 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
@@ -61,29 +60,12 @@ import androidx.compose.ui.zIndex
 import com.composables.icons.lucide.Lucide
 import com.example.androidlauncher.NotificationService
 import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.data.AutoIconFallbackType
 import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalIconSize
 import kotlin.math.max
 import kotlin.math.roundToInt
-
-/**
- * Default system-side mapping for app icons to Lucide icons.
- */
-val DEFAULT_ICON_MAPPINGS: Map<String, String> = mapOf(
-    "com.android.chrome" to "Chrome",
-    "com.android.vending" to "Play",
-    "com.google.android.youtube" to "Youtube",
-    "com.google.android.apps.youtube.music" to "Music",
-    "com.google.android.calendar" to "Calendar",
-    "com.android.calendar" to "Calendar",
-    "com.android.camera" to "Camera",
-    "com.google.android.GoogleCamera" to "Camera",
-    "com.google.android.calculator" to "Calculator",
-    "com.google.android.googlequicksearchbox" to "Mic",
-    "com.google.android.apps.nbu.files" to "FolderOpen",
-    "com.example.androidlauncher" to "Crown"
-)
 
 fun Context.findActivity(): Activity? {
     var context = this
@@ -106,11 +88,11 @@ fun Modifier.bounceClick(interactionSource: MutableInteractionSource, enabled: B
 
 /**
  * Composable das ein App-Icon rendert.
- * Zeigt Lucide-Icons oder App-eigene Bitmap-Icons an.
+ * Priorität: manueller Override > automatischer Lucide-Fallback > automatischer Container > Original.
  */
 @Composable
 fun AppIconView(
-    app: AppInfo, 
+    app: AppInfo,
     modifier: Modifier = Modifier,
     showBadge: Boolean = false,
     customIcons: Map<String, String>? = null
@@ -133,31 +115,53 @@ fun AppIconView(
     }
     val hasNotification = showBadge && app.packageName in activeNotifications
 
-    val customIconName = resolvedCustomIcons[app.packageName] ?: DEFAULT_ICON_MAPPINGS[app.packageName]
-    val lucideIcon = if (customIconName != null) getLucideIconByName(customIconName) else app.lucideIcon
+    val manualLucideIcon = resolvedCustomIcons[app.packageName]?.let(::getLucideIconByName)
+    val autoFallback = app.autoIconFallback
+    val autoLucideIcon = autoFallback?.lucideIconName?.let(::getLucideIconByName)
 
     Box(
         modifier = modifier.size(iconSize),
         contentAlignment = Alignment.Center
     ) {
         when {
-            lucideIcon != null -> {
+            manualLucideIcon != null -> {
                 Icon(
-                    imageVector = lucideIcon,
+                    imageVector = manualLucideIcon,
                     contentDescription = null,
                     modifier = Modifier.size(iconSize * 0.65f),
                     tint = tintColor
                 )
             }
+            autoFallback?.type == AutoIconFallbackType.LUCIDE && autoLucideIcon != null -> {
+                Icon(
+                    imageVector = autoLucideIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(iconSize * 0.65f),
+                    tint = tintColor
+                )
+            }
+            autoFallback?.type == AutoIconFallbackType.NEUTRAL -> {
+                NeutralIconFallback(
+                    label = app.label,
+                    tintColor = tintColor,
+                    iconSize = iconSize
+                )
+            }
             app.iconBitmap != null -> {
                 Image(
-                    bitmap = app.iconBitmap, 
-                    contentDescription = null, 
+                    bitmap = app.iconBitmap,
+                    contentDescription = null,
                     modifier = Modifier.size(iconSize),
                     colorFilter = ColorFilter.tint(tintColor)
                 )
             }
-            else -> Box(modifier = Modifier.size(iconSize).background(tintColor.copy(alpha = 0.05f), CircleShape))
+            else -> {
+                NeutralIconFallback(
+                    label = app.label,
+                    tintColor = tintColor,
+                    iconSize = iconSize
+                )
+            }
         }
 
         if (hasNotification) {
@@ -171,6 +175,30 @@ fun AppIconView(
                     .border(1.dp, Color.Black.copy(alpha = 0.1f), CircleShape)
             )
         }
+    }
+}
+
+@Composable
+private fun NeutralIconFallback(
+    label: String,
+    tintColor: Color,
+    iconSize: androidx.compose.ui.unit.Dp
+) {
+    val initial = remember(label) {
+        label.firstOrNull { it.isLetterOrDigit() }?.uppercase() ?: "•"
+    }
+
+    Box(
+        modifier = Modifier
+            .size(iconSize * 0.82f)
+            .background(tintColor.copy(alpha = 0.04f), CircleShape)
+            .border(1.dp, tintColor.copy(alpha = 0.45f), CircleShape),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initial,
+            color = tintColor.copy(alpha = 0.92f)
+        )
     }
 }
 

--- a/app/src/test/java/com/example/androidlauncher/DataModelsTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/DataModelsTest.kt
@@ -72,6 +72,7 @@ class DataModelsTest {
         assertNull(app.iconBitmap)
         assertNull(app.lucideIcon)
         assertNull(app.autoIconFallback)
+        assertNull(app.autoIconRule)
     }
 
     @Test
@@ -103,6 +104,7 @@ class DataModelsTest {
         assertEquals("com.app", copied.packageName)
         assertNull(copied.iconBitmap)
         assertNull(copied.autoIconFallback)
+        assertNull(copied.autoIconRule)
     }
 
     @Test

--- a/app/src/test/java/com/example/androidlauncher/DataModelsTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/DataModelsTest.kt
@@ -36,24 +36,24 @@ class DataModelsTest {
 
     @Test
     fun `FontSize values count is 3`() {
-        assertEquals(3, FontSize.values().size)
+        assertEquals(3, FontSize.entries.size)
     }
 
     @Test
     fun `IconSize values count is 3`() {
-        assertEquals(3, IconSize.values().size)
+        assertEquals(3, IconSize.entries.size)
     }
 
     @Test
     fun `FontSize valueOf works for all entries`() {
-        FontSize.values().forEach { fs ->
+        FontSize.entries.forEach { fs ->
             assertEquals(fs, FontSize.valueOf(fs.name))
         }
     }
 
     @Test
     fun `IconSize valueOf works for all entries`() {
-        IconSize.values().forEach { ic ->
+        IconSize.entries.forEach { ic ->
             assertEquals(ic, IconSize.valueOf(ic.name))
         }
     }
@@ -71,6 +71,7 @@ class DataModelsTest {
         val app = AppInfo(label = "Test", packageName = "com.test")
         assertNull(app.iconBitmap)
         assertNull(app.lucideIcon)
+        assertNull(app.autoIconFallback)
     }
 
     @Test
@@ -101,6 +102,7 @@ class DataModelsTest {
         assertEquals("NewApp", copied.label)
         assertEquals("com.app", copied.packageName)
         assertNull(copied.iconBitmap)
+        assertNull(copied.autoIconFallback)
     }
 
     @Test


### PR DESCRIPTION
# 🎨 Issue: Einheitlicher Icon-Fallback mit Qualitätsprüfung

## 🎯 Ziel

Ein robustes System entwickeln, das sicherstellt, dass alle App-Icons auf der Startseite und im AppDrawer **visuell konsistent** bleiben, selbst wenn Hintergrundentfernung oder Minimalismus-Konvertierungen durchgeführt werden.  
Icons, die bereits gut aussehen (z. B. Firefox-Logo), sollen **nicht automatisch ersetzt** werden. Problematische Icons sollen automatisch einen Fallback erhalten.

---

## 🧩 Hintergrund

- Der Launcher nutzt einen minimalistischen Stil:
  - Icons haben meist **keinen Hintergrund**
  - Einige Icons wurden durch **Lucide Icons** ersetzt
  - Nutzer können eigene Lucide Icons zuweisen
- Problem: Neue oder manche Apps haben Icons, die nach Hintergrundentfernung **zu quadratisch, farbig oder schlecht erkennbar** sind
- Ziel: Einheitliche Darstellung ohne das Layout zu zerstören, aber gute Icons sollen **unverändert bleiben**

---

## ✨ Erwartetes Verhalten

- Icons, die nach Hintergrundentfernung gut aussehen → **Original-Icon bleibt**
- Problematische Icons → **automatischer Fallback**:
  - Lucide-Icon, wenn verfügbar
  - Alternativ generischer minimalistischer Container (rund, Outline, monochrom)
- Nutzer kann jederzeit ein eigenes Icon zuweisen

---

## 🧠 Funktionslogik

- [x] Prüfung jedes Icons nach Installation oder Update:
  - Kontrast
  - Form
  - Lesbarkeit
- [x] Nur problematische Icons erhalten Fallback
- [x] Original-Icons, die passen, bleiben unverändert
- [x] Fallback automatisch generieren (Lucide oder neutraler Container)
- [x] Nutzer-Override ermöglichen (manuelle Zuweisung)

---

## ⚙️ Technische Anforderungen

- [x] Automatische Analyse bei Installation / Update / Änderung
- [x] Speicherung von Icon-Zustand (Original vs. Fallback)
- [x] Einheitlicher Stil für alle Fallback-Icons
- [x] Keine Performance-Einbußen
- [x] Möglichkeit, zukünftige Icon-Packs zu integrieren

---

## 🎨 UI-Anforderungen

- Fallback-Icons:
  - minimalistisch
  - monochrom
  - klar erkennbar
  - konsistent im Grid
- Original-Icons bleiben sichtbar, wenn sie zum Design passen
- Keine großen Farbblöcke oder quadratischen Störungen

---

## 🧪 Testfälle

- [x] Neue Apps mit problematischen Icons → Fallback wird korrekt angewendet
- [x] Gute Icons (z. B. Firefox) → bleiben unverändert
- [x] Nutzer kann Icon manuell ändern
- [x] Fallbacks wirken konsistent auf Startseite und AppDrawer
- [x] Keine Performance-Einbußen

---

## 🚀 Ergebnis

Ein **intelligentes Icon-System**, das minimalistische Ästhetik bewahrt, problematische Icons automatisch ersetzt und gleichzeitig beliebte Original-Icons wie Firefox korrekt darstellt.  
Damit bleibt das UI **sauber, konsistent und visuell ruhig**, egal welche Apps installiert werden.