### PR TITLE
#101 Feature/Fix: Icon- und Schriftfarbe über RGB-Farbpalette anpassbar machen

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -169,6 +169,8 @@ class MainActivity : ComponentActivity() {
             val currentIconSize by themeManager.selectedIconSize.collectAsState(initial = IconSize.STANDARD)
             val currentAppFont by themeManager.selectedAppFont.collectAsState(initial = AppFont.SYSTEM_DEFAULT)
             val isDarkTextEnabled by themeManager.isDarkTextEnabled.collectAsState(initial = false)
+            val iconColor by themeManager.iconColor.collectAsState(initial = Color.White)
+            val homeTextColor by themeManager.homeTextColor.collectAsState(initial = Color.White)
             val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val isLiquidGlassEnabled by themeManager.isLiquidGlassEnabled.collectAsState(initial = true)
             val isShakeGesturesEnabled by themeManager.isShakeGesturesEnabled.collectAsState(initial = true)
@@ -288,6 +290,8 @@ class MainActivity : ComponentActivity() {
                 fontWeight = currentFontWeight,
                 iconSize = currentIconSize,
                 darkTextEnabled = isDarkTextEnabled,
+                iconColor = iconColor,
+                homeTextColor = homeTextColor,
                 showFavoriteLabels = showFavoriteLabels,
                 liquidGlassEnabled = isLiquidGlassEnabled,
                 appFont = currentAppFont,
@@ -971,7 +975,10 @@ class MainActivity : ComponentActivity() {
                             selectedTheme = currentTheme,
                             onThemeSelected = { scope.launch { themeManager.setTheme(it) } },
                             isDarkTextEnabled = isDarkTextEnabled,
-                            onDarkTextToggled = { scope.launch { themeManager.setDarkTextEnabled(it) } },
+                            iconColor = iconColor,
+                            onIconColorChange = { scope.launch { themeManager.setIconColor(it) } },
+                            homeTextColor = homeTextColor,
+                            onHomeTextColorChange = { scope.launch { themeManager.setHomeTextColor(it) } },
                             isLiquidGlassEnabled = isLiquidGlassEnabled,
                             onLiquidGlassToggled = { scope.launch { themeManager.setLiquidGlassEnabled(it) } },
                             customWallpaperUri = customWallpaperUri,

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -5,9 +5,12 @@ import android.database.ContentObserver
 import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.example.androidlauncher.ui.theme.ColorTheme
@@ -30,6 +33,9 @@ class ThemeManager(private val context: Context) {
         private val FONT_WEIGHT_KEY = stringPreferencesKey("font_weight")
         private val ICON_SIZE_KEY = stringPreferencesKey("icon_size")
         private val DARK_TEXT_KEY = booleanPreferencesKey("dark_text_enabled")
+        // ARGB-Werte für frei wählbare Icon-/Schriftfarbe (Default Weiß).
+        private val ICON_COLOR_KEY = intPreferencesKey("icon_color")
+        private val HOME_TEXT_COLOR_KEY = intPreferencesKey("home_text_color")
         private val SHOW_FAVORITE_LABELS_KEY = booleanPreferencesKey("show_favorite_labels")
         private val LIQUID_GLASS_KEY = booleanPreferencesKey("liquid_glass_enabled")
         private val APP_FONT_KEY = stringPreferencesKey("app_font")
@@ -76,6 +82,14 @@ class ThemeManager(private val context: Context) {
 
     val isDarkTextEnabled: Flow<Boolean> = context.dataStore.data
         .map { it[DARK_TEXT_KEY] ?: false }
+
+    // Frei wählbare Iconfarbe (gilt überall). Default Weiß.
+    val iconColor: Flow<Color> = context.dataStore.data
+        .map { Color(it[ICON_COLOR_KEY] ?: Color.White.toArgb()) }
+
+    // Frei wählbare Schriftfarbe – nur Startbildschirm. Default Weiß.
+    val homeTextColor: Flow<Color> = context.dataStore.data
+        .map { Color(it[HOME_TEXT_COLOR_KEY] ?: Color.White.toArgb()) }
 
     val showFavoriteLabels: Flow<Boolean> = context.dataStore.data
         .map { it[SHOW_FAVORITE_LABELS_KEY] ?: false }
@@ -167,6 +181,8 @@ class ThemeManager(private val context: Context) {
     suspend fun setFontWeight(fontWeight: FontWeightLevel) { context.dataStore.edit { it[FONT_WEIGHT_KEY] = fontWeight.name } }
     suspend fun setIconSize(iconSize: IconSize) { context.dataStore.edit { it[ICON_SIZE_KEY] = iconSize.name } }
     suspend fun setDarkTextEnabled(enabled: Boolean) { context.dataStore.edit { it[DARK_TEXT_KEY] = enabled } }
+    suspend fun setIconColor(color: Color) { context.dataStore.edit { it[ICON_COLOR_KEY] = color.toArgb() } }
+    suspend fun setHomeTextColor(color: Color) { context.dataStore.edit { it[HOME_TEXT_COLOR_KEY] = color.toArgb() } }
     suspend fun setShowFavoriteLabels(show: Boolean) { context.dataStore.edit { it[SHOW_FAVORITE_LABELS_KEY] = show } }
     suspend fun setLiquidGlassEnabled(enabled: Boolean) { context.dataStore.edit { it[LIQUID_GLASS_KEY] = enabled } }
     suspend fun setAppFont(font: AppFont) { context.dataStore.edit { it[APP_FONT_KEY] = font.name } }

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -11,7 +11,10 @@ import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,9 +25,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Moon
-import com.composables.icons.lucide.Sun
 import com.composables.icons.lucide.Droplets
 import com.composables.icons.lucide.Square
 import com.example.androidlauncher.ui.theme.ColorTheme
@@ -39,7 +41,10 @@ fun ColorConfigMenu(
     selectedTheme: ColorTheme,
     onThemeSelected: (ColorTheme) -> Unit,
     isDarkTextEnabled: Boolean,
-    onDarkTextToggled: (Boolean) -> Unit,
+    iconColor: Color,
+    onIconColorChange: (Color) -> Unit,
+    homeTextColor: Color,
+    onHomeTextColorChange: (Color) -> Unit,
     isLiquidGlassEnabled: Boolean,
     onLiquidGlassToggled: (Boolean) -> Unit,
     customWallpaperUri: String? = null,
@@ -52,6 +57,11 @@ fun ColorConfigMenu(
     }
     val orderedThemes = remember {
         ColorTheme.entries.sortedWith(compareByDescending<ColorTheme> { it.isArtTheme }.thenBy { it.themeName })
+    }
+    // Welcher Farbwähler ist gerade offen: "text", "icon" oder null.
+    var activePicker by remember { mutableStateOf<String?>(null) }
+    val dialogBackground = remember(selectedTheme, isDarkTextEnabled) {
+        selectedTheme.menuSurfaceColor(isDarkTextEnabled)
     }
 
     Box(modifier = Modifier.fillMaxSize().testTag("color_config_menu")) {
@@ -74,22 +84,21 @@ fun ColorConfigMenu(
 
             Spacer(modifier = Modifier.weight(0.5f).heightIn(min = 8.dp, max = 24.dp))
 
-            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                Text("Vorschau", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
-                val darkTextSwitchColors = LiquidGlass.switchColors(isDarkTextEnabled, isLiquidGlassEnabled)
-                Switch(
-                    checked = isDarkTextEnabled,
-                    onCheckedChange = onDarkTextToggled,
-                    colors = darkTextSwitchColors,
-                    thumbContent = {
-                        if (isDarkTextEnabled) {
-                            Icon(imageVector = Lucide.Moon, contentDescription = null, modifier = Modifier.size(16.dp), tint = Color.White)
-                        } else {
-                            Icon(imageVector = Lucide.Sun, contentDescription = null, modifier = Modifier.size(16.dp), tint = Color(0xFFFFB300))
-                        }
-                    }
-                )
-            }
+            Text("Farben", color = mainTextColor.copy(alpha = 0.5f), fontSize = 14.sp)
+            Spacer(modifier = Modifier.height(12.dp))
+            ColorPickerRow(
+                label = "Schriftfarbe (Startseite)",
+                color = homeTextColor,
+                mainTextColor = mainTextColor,
+                onClick = { activePicker = "text" }
+            )
+            Spacer(modifier = Modifier.height(10.dp))
+            ColorPickerRow(
+                label = "Iconfarbe",
+                color = iconColor,
+                mainTextColor = mainTextColor,
+                onClick = { activePicker = "icon" }
+            )
 
             Spacer(modifier = Modifier.height(12.dp))
 
@@ -136,6 +145,75 @@ fun ColorConfigMenu(
                         onClick = { onThemeSelected(theme) }
                     )
                 }
+            }
+        }
+
+        if (activePicker != null) {
+            val isText = activePicker == "text"
+            ColorPickerDialog(
+                title = if (isText) "Schriftfarbe (Startseite)" else "Iconfarbe",
+                color = if (isText) homeTextColor else iconColor,
+                onColorChange = if (isText) onHomeTextColorChange else onIconColorChange,
+                backgroundColor = dialogBackground,
+                mainTextColor = mainTextColor,
+                onDismiss = { activePicker = null }
+            )
+        }
+    }
+}
+
+/** Eine antippbare Zeile mit Beschriftung und Farb-Swatch, öffnet den Farbwähler. */
+@Composable
+fun ColorPickerRow(label: String, color: Color, mainTextColor: Color, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(mainTextColor.copy(alpha = 0.05f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(label, color = mainTextColor, fontSize = 16.sp)
+        Box(
+            modifier = Modifier
+                .size(28.dp)
+                .clip(CircleShape)
+                .background(color)
+                .border(1.dp, mainTextColor.copy(alpha = 0.3f), CircleShape)
+        )
+    }
+}
+
+/** Modaler Dialog mit dem HSV-Farbwähler. */
+@Composable
+fun ColorPickerDialog(
+    title: String,
+    color: Color,
+    onColorChange: (Color) -> Unit,
+    backgroundColor: Color,
+    mainTextColor: Color,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(24.dp))
+                .background(backgroundColor)
+                .padding(24.dp)
+        ) {
+            Text(title, color = mainTextColor, fontSize = 20.sp, fontWeight = FontWeight.SemiBold)
+            Spacer(modifier = Modifier.height(20.dp))
+            ColorWheelPicker(
+                color = color,
+                onColorChange = onColorChange,
+                mainTextColor = mainTextColor
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+                Text("Fertig", color = mainTextColor, fontSize = 16.sp)
             }
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorWheelPicker.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorWheelPicker.kt
@@ -1,0 +1,176 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.material3.Text
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/** Wandelt HSV (h:0..360, s/v:0..1) in eine Compose-Farbe. */
+private fun hsvToColor(h: Float, s: Float, v: Float): Color =
+    Color(android.graphics.Color.HSVToColor(floatArrayOf(h.coerceIn(0f, 360f), s.coerceIn(0f, 1f), v.coerceIn(0f, 1f))))
+
+/** Zerlegt eine Farbe in HSV-Komponenten. */
+private fun Color.toHsv(): FloatArray {
+    val out = FloatArray(3)
+    android.graphics.Color.colorToHSV(this.toArgb(), out)
+    return out
+}
+
+private val hueColors: List<Color> = listOf(
+    Color(0xFFFF0000), Color(0xFFFFFF00), Color(0xFF00FF00),
+    Color(0xFF00FFFF), Color(0xFF0000FF), Color(0xFFFF00FF), Color(0xFFFF0000)
+)
+
+private val quickSwatches: List<Color> = listOf(
+    Color.White, Color(0xFF010101), Color(0xFFEF4444), Color(0xFFF59E0B),
+    Color(0xFF22C55E), Color(0xFF0EA5E9), Color(0xFF6366F1), Color(0xFFEC4899)
+)
+
+/**
+ * Freier HSV-Farbwähler in purem Compose: Sättigungs-/Helligkeitsfeld, Hue-Slider,
+ * Live-Vorschau und Schnellwahl-Swatches (inkl. Weiß als Standard).
+ *
+ * Während des Ziehens wird nur die lokale Vorschau aktualisiert; [onColorChange]
+ * wird beim Loslassen bzw. Tippen aufgerufen, um unnötige Persistenz-Schreibvorgänge
+ * zu vermeiden.
+ */
+@Composable
+fun ColorWheelPicker(
+    color: Color,
+    onColorChange: (Color) -> Unit,
+    mainTextColor: Color,
+    modifier: Modifier = Modifier
+) {
+    // Lokaler HSV-Zustand, initial aus der übergebenen Farbe abgeleitet.
+    val initialHsv = remember(color) { color.toHsv() }
+    var hue by remember(color) { mutableStateOf(initialHsv[0]) }
+    var sat by remember(color) { mutableStateOf(initialHsv[1]) }
+    var value by remember(color) { mutableStateOf(initialHsv[2]) }
+
+    val currentColor = hsvToColor(hue, sat, value)
+
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        // Sättigungs-/Helligkeitsfeld
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(180.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .border(1.dp, mainTextColor.copy(alpha = 0.2f), RoundedCornerShape(16.dp))
+                .pointerInput(Unit) {
+                    detectTapGestures { offset ->
+                        sat = (offset.x / size.width).coerceIn(0f, 1f)
+                        value = (1f - offset.y / size.height).coerceIn(0f, 1f)
+                        onColorChange(hsvToColor(hue, sat, value))
+                    }
+                }
+                .pointerInput(Unit) {
+                    detectDragGestures(
+                        onDragEnd = { onColorChange(hsvToColor(hue, sat, value)) }
+                    ) { change, _ ->
+                        sat = (change.position.x / size.width).coerceIn(0f, 1f)
+                        value = (1f - change.position.y / size.height).coerceIn(0f, 1f)
+                    }
+                }
+        ) {
+            drawSaturationValueField(hue)
+            // Auswahl-Indikator
+            val cx = sat * size.width
+            val cy = (1f - value) * size.height
+            drawCircle(color = Color.White, radius = 10f, center = Offset(cx, cy), style = Stroke(width = 3f))
+            drawCircle(color = Color.Black.copy(alpha = 0.6f), radius = 13f, center = Offset(cx, cy), style = Stroke(width = 1.5f))
+        }
+
+        // Hue-Slider
+        Canvas(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(28.dp)
+                .clip(RoundedCornerShape(999.dp))
+                .border(1.dp, mainTextColor.copy(alpha = 0.2f), RoundedCornerShape(999.dp))
+                .pointerInput(Unit) {
+                    detectTapGestures { offset ->
+                        hue = (offset.x / size.width).coerceIn(0f, 1f) * 360f
+                        onColorChange(hsvToColor(hue, sat, value))
+                    }
+                }
+                .pointerInput(Unit) {
+                    detectDragGestures(
+                        onDragEnd = { onColorChange(hsvToColor(hue, sat, value)) }
+                    ) { change, _ ->
+                        hue = (change.position.x / size.width).coerceIn(0f, 1f) * 360f
+                    }
+                }
+        ) {
+            drawRect(brush = Brush.horizontalGradient(hueColors))
+            val x = (hue / 360f) * size.width
+            drawCircle(color = Color.White, radius = size.height / 2f - 2f, center = Offset(x.coerceIn(0f, size.width), size.height / 2f), style = Stroke(width = 3f))
+        }
+
+        // Vorschau + Hex
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(currentColor)
+                    .border(1.dp, mainTextColor.copy(alpha = 0.3f), CircleShape)
+            )
+            val hex = remember(currentColor) {
+                "#%06X".format(0xFFFFFF and currentColor.toArgb())
+            }
+            Text(hex, color = mainTextColor, fontSize = 16.sp)
+        }
+
+        // Schnellwahl-Swatches
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            quickSwatches.forEach { swatch ->
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .aspectRatio(1f)
+                        .clip(CircleShape)
+                        .background(swatch)
+                        .border(1.dp, mainTextColor.copy(alpha = 0.25f), CircleShape)
+                        .pointerInput(swatch) {
+                            detectTapGestures {
+                                val hsv = swatch.toHsv()
+                                hue = hsv[0]; sat = hsv[1]; value = hsv[2]
+                                onColorChange(swatch)
+                            }
+                        }
+                )
+            }
+        }
+    }
+}
+
+/** Zeichnet das Sättigungs-/Helligkeitsfeld für den gegebenen Farbton. */
+private fun DrawScope.drawSaturationValueField(hue: Float) {
+    val hueColor = hsvToColor(hue, 1f, 1f)
+    // Horizontal: Weiß -> reiner Farbton (Sättigung)
+    drawRect(brush = Brush.horizontalGradient(listOf(Color.White, hueColor)))
+    // Vertikal: Transparent -> Schwarz (Helligkeit)
+    drawRect(brush = Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -119,7 +119,8 @@ fun HomeScreen(
     val animationsEnabled = LocalAnimationsEnabled.current
     val density = androidx.compose.ui.platform.LocalDensity.current
 
-    val mainTextColor = LiquidGlass.mainTextColor(isDarkTextEnabled)
+    // Schriftfarbe nur auf dem Startbildschirm frei wählbar.
+    val mainTextColor = LocalHomeTextColor.current
     var rootSize by remember { mutableStateOf(IntSize.Zero) }
 
     // --- Bearbeitungs-States (Lokal für Live-Vorschau) ---
@@ -1352,8 +1353,8 @@ fun ClockHeader(
     val context = LocalContext.current
     val fontSize = LocalFontSize.current
     val appFontWeight = LocalFontWeight.current
-    val isDarkTextEnabled = LocalDarkTextEnabled.current
-    val mainTextColor = LiquidGlass.mainTextColor(isDarkTextEnabled)
+    // Uhr/Datum nutzen die frei wählbare Startbildschirm-Schriftfarbe.
+    val mainTextColor = LocalHomeTextColor.current
     var currentTime by remember { mutableStateOf(Calendar.getInstance().time) }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -1,9 +1,6 @@
 package com.example.androidlauncher.ui
 
 import androidx.compose.animation.core.*
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
@@ -29,7 +26,9 @@ import com.composables.icons.lucide.ALargeSmall
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Palette
 import com.composables.icons.lucide.Pencil
+import com.example.androidlauncher.ui.LiquidGlass.conditionalGlass
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalHomeTextColor
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import kotlinx.coroutines.delay
 import kotlin.math.*
@@ -62,8 +61,8 @@ fun SettingsPaletteMenu(
 ) {
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
-    // Verwendung von #010101 gegen HW-Artefakte
-    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+    // Icon-Tönung folgt der gewählten Farbe – wie alles andere auf der Startseite.
+    val mainTextColor = LocalHomeTextColor.current
     
     val settingsItems = remember {
         listOf(
@@ -121,16 +120,13 @@ fun SettingsPaletteMenu(
                 val targetX = (cos(angleRad) * radius).toFloat()
                 val targetY = (-sin(angleRad) * radius).toFloat()
 
-                // Styles
-                val backgroundModifier = if (isLiquidGlassEnabled) {
-                    Modifier
-                        .background(LiquidGlass.glassBrush(isDarkTextEnabled), CircleShape)
-                        .border(BorderStroke(1.2.dp, LiquidGlass.borderBrush(isDarkTextEnabled)), CircleShape)
-                } else {
-                    Modifier
-                        .background(mainTextColor.copy(alpha = if (isSettingsOpen) 0.1f else 0.15f), CircleShape)
-                        .border(BorderStroke(1.dp, mainTextColor.copy(alpha = 0.25f)), CircleShape)
-                }
+                // Gleicher innerer Kreis-Hintergrund wie der Einstellungs-Button selbst.
+                val backgroundModifier = Modifier.conditionalGlass(
+                    CircleShape,
+                    isDarkTextEnabled,
+                    isLiquidGlassEnabled,
+                    fallbackAlpha = if (isSettingsOpen) 0.1f else 0.15f
+                )
 
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SizeConfigMenu.kt
@@ -50,10 +50,10 @@ fun SizeConfigMenu(
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
     val secondaryTextColor = if (isDarkTextEnabled) Color.Black.copy(alpha = 0.6f) else Color.White.copy(alpha = 0.6f)
 
-    val backgroundColor = if (isDarkTextEnabled) colorTheme.lightBackground else colorTheme.drawerBackground
+    val backgroundBrush = colorTheme.menuBrush(isDarkTextEnabled, alpha = 0.95f)
     Box(modifier = Modifier.fillMaxSize()) {
         SystemWallpaperView(customWallpaperUri)
-        Box(modifier = Modifier.fillMaxSize().background(backgroundColor.copy(alpha = 0.95f)))
+        Box(modifier = Modifier.fillMaxSize().background(backgroundBrush))
 
         Column(
             modifier = Modifier

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -80,7 +80,7 @@ import com.example.androidlauncher.NotificationService
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.AutoIconFallbackType
 import com.example.androidlauncher.data.IconManager
-import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalIconColor
 import com.example.androidlauncher.ui.theme.LocalIconSize
 import kotlin.math.roundToInt
 
@@ -295,8 +295,7 @@ fun AppIconView(
     }
 
     val iconSize = LocalIconSize.current.size
-    val isDarkTextEnabled = LocalDarkTextEnabled.current
-    val tintColor = if (isDarkTextEnabled) Color.Black else Color.White
+    val tintColor = LocalIconColor.current
 
     val activeNotifications by if (showBadge) {
         NotificationService.activeNotificationPackages.collectAsState()

--- a/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/theme/Theme.kt
@@ -29,6 +29,10 @@ val LocalFontSize = staticCompositionLocalOf { FontSize.STANDARD }
 val LocalIconSize = staticCompositionLocalOf { IconSize.STANDARD }
 val LocalFontWeight = staticCompositionLocalOf { FontWeightLevel.NORMAL }
 val LocalDarkTextEnabled = staticCompositionLocalOf { false }
+/** Frei wählbare Iconfarbe (gilt überall). */
+val LocalIconColor = staticCompositionLocalOf { Color.White }
+/** Frei wählbare Schriftfarbe – nur Startbildschirm. */
+val LocalHomeTextColor = staticCompositionLocalOf { Color.White }
 val LocalShowFavoriteLabels = staticCompositionLocalOf { false }
 val LocalLiquidGlassEnabled = staticCompositionLocalOf { true }
 val LocalAppFont = staticCompositionLocalOf { AppFont.SYSTEM_DEFAULT }
@@ -48,6 +52,8 @@ fun AndroidLauncherTheme(
     iconSize: IconSize = IconSize.STANDARD,
     fontWeight: FontWeightLevel = FontWeightLevel.NORMAL,
     darkTextEnabled: Boolean = false,
+    iconColor: Color = Color.White,
+    homeTextColor: Color = Color.White,
     showFavoriteLabels: Boolean = false,
     liquidGlassEnabled: Boolean = true,
     appFont: AppFont = AppFont.SYSTEM_DEFAULT,
@@ -112,6 +118,8 @@ fun AndroidLauncherTheme(
         LocalIconSize provides iconSize,
         LocalFontWeight provides fontWeight,
         LocalDarkTextEnabled provides darkTextEnabled,
+        LocalIconColor provides iconColor,
+        LocalHomeTextColor provides homeTextColor,
         LocalShowFavoriteLabels provides showFavoriteLabels,
         LocalLiquidGlassEnabled provides liquidGlassEnabled,
         LocalAppFont provides appFont,


### PR DESCRIPTION
## Beschreibung

Der bisherige Dark-/Lightmode-Schalter soll durch eine RGB-Farbpalette ersetzt werden, über die Nutzer die Icon- und Schriftfarbe individuell anpassen können.

Die Schriftfarbe betrifft ausschließlich den Startbildschirm. Icons können ebenfalls eingefärbt werden. Alle anderen Bereiche des Launchers (AppDrawer, Einstellungen, etc.) bleiben von der Farbauswahl unberührt.

---

## Betroffene Bereiche

- [x] Startbildschirm – Schriftfarbe
- [x] Startbildschirm – Icons
- [x] AppDrawer – nicht betroffen
- [x] Einstellungen – nicht betroffen

---

## Technische Anforderungen

- [x] Dark-/Lightmode-Schalter entfernen oder ersetzen
- [x] RGB-Farbwähler im Konfigurationsmenü integrieren (Iconfarbe)
- [x] RGB-Farbwähler für Schriftfarbe – nur Startbildschirm
- [x] Ausgewählte Farben persistent speichern
- [x] Farbänderungen sofort anwenden (ohne Neustart)
- [x] Standardwert definieren (z.B. Weiß) als Fallback
- [x] Andere Screens bleiben von der Farbauswahl isoliert

---

## Akzeptanzkriterien

- [x] Nutzer kann Iconfarbe über RGB-Palette frei wählen
- [x] Nutzer kann Schriftfarbe für den Startbildschirm frei wählen
- [x] Farbänderungen sind sofort sichtbar
- [x] Einstellungen bleiben nach Neustart erhalten
- [x] AppDrawer, Einstellungsmenü und andere Screens sind nicht betroffen
- [x] Kein Build-Fehler nach Umsetzung
- [x] Keine visuellen Bugs beim Farbwechsel