### PR TITLE
#91 In den Einstellungen kann man den Launcher direkt als Standard Launcher auswählen

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -32,6 +32,7 @@ import com.composables.icons.lucide.Image
 import com.composables.icons.lucide.Pencil
 import com.composables.icons.lucide.Shield
 import com.composables.icons.lucide.Hand
+import com.composables.icons.lucide.House
 import com.composables.icons.lucide.Smartphone
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
@@ -69,11 +70,13 @@ fun EditConfigMenu(
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
     val menuListState = rememberLazyListState()
 
+    var isDefaultLauncherSet by remember { mutableStateOf(isDefaultLauncher(context)) }
     var isNotificationEnabled by remember { mutableStateOf(isNotificationServiceEnabled(context)) }
     var isAccessibilityEnabled by remember { mutableStateOf(LauncherAccessibilityService.isAccessibilityServiceEnabled(context)) }
     var isUsageAccessEnabled by remember { mutableStateOf(ForegroundAppResolver.hasUsageAccess(context)) }
 
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        isDefaultLauncherSet = isDefaultLauncher(context)
         isNotificationEnabled = isNotificationServiceEnabled(context)
         isAccessibilityEnabled = LauncherAccessibilityService.isAccessibilityServiceEnabled(context)
         isUsageAccessEnabled = ForegroundAppResolver.hasUsageAccess(context)
@@ -289,6 +292,21 @@ fun EditConfigMenu(
                 EditSectionHeader(
                     title = "Zugriffe",
                     mainTextColor = mainTextColor
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.House,
+                    label = "Standard-Launcher",
+                    onClick = {
+                        openDefaultLauncherSettings(context)
+                    },
+                    statusLabel = if (isDefaultLauncherSet) "An" else "Aus",
+                    mainTextColor = mainTextColor,
+                    isLiquidGlassEnabled = isLiquidGlassEnabled,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "default_launcher_item"
                 )
             }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/Utils.kt
@@ -2,11 +2,13 @@ package com.example.androidlauncher.ui
 
 import android.app.Activity
 import android.app.ActivityOptions
+import android.app.role.RoleManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.Intent
 import android.content.pm.LauncherApps
+import android.content.pm.PackageManager
 import android.content.pm.ShortcutInfo
 import android.os.Build
 import android.os.Process
@@ -415,6 +417,46 @@ fun openNotificationSettings(context: Context) {
 fun openAccessibilitySettings(context: Context) {
     val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
     context.startActivity(intent)
+}
+
+/**
+ * Prüft, ob diese App aktuell als Standard-Launcher (Start-App) gesetzt ist.
+ */
+fun isDefaultLauncher(context: Context): Boolean {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val roleManager = context.getSystemService(RoleManager::class.java)
+        roleManager?.isRoleHeld(RoleManager.ROLE_HOME) == true
+    } else {
+        val resolved = context.packageManager.resolveActivity(
+            Intent(Intent.ACTION_MAIN).apply { addCategory(Intent.CATEGORY_HOME) },
+            PackageManager.MATCH_DEFAULT_ONLY
+        )?.activityInfo?.packageName
+        resolved == context.packageName
+    }
+}
+
+/**
+ * Öffnet den passenden Systembildschirm, um diese App als Standard-Launcher festzulegen.
+ * Auf Android Q+ wird der direkte Auswahl-Dialog (ROLE_HOME) angezeigt, sofern noch nicht Standard.
+ */
+fun openDefaultLauncherSettings(context: Context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        val roleManager = context.getSystemService(RoleManager::class.java)
+        if (roleManager != null && roleManager.isRoleAvailable(RoleManager.ROLE_HOME) &&
+            !roleManager.isRoleHeld(RoleManager.ROLE_HOME)) {
+            val intent = roleManager.createRequestRoleIntent(RoleManager.ROLE_HOME)
+            runCatching { context.startActivity(intent) }.onSuccess { return }
+        }
+    }
+    val homeSettingsIntent = Intent(Settings.ACTION_HOME_SETTINGS).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    runCatching { context.startActivity(homeSettingsIntent) }.onFailure {
+        context.startActivity(
+            Intent(Settings.ACTION_MANAGE_DEFAULT_APPS_SETTINGS)
+                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        )
+    }
 }
 
 fun getLucideIconByName(name: String): ImageVector? {


### PR DESCRIPTION
# ⚙️ Issue: Schnellzugriff im Konfigurationsmenü zum Festlegen des Standard-Launchers

## 🎯 Ziel

Im Konfigurationsmenü soll eine Option hinzugefügt werden, über die Nutzer **direkt zur Systemeinstellung gelangen**, um den Launcher als **Standard-Launcher (Standard-Startbildschirm-App)** festzulegen.

Dies erleichtert insbesondere neuen Nutzern das Einrichten des Launchers.

---

## 🧩 Hintergrund

Viele Nutzer wissen nicht genau, wo sich in den Android-Systemeinstellungen die Option befindet, um einen **Standard-Launcher festzulegen**.

Aktuell muss der Nutzer:

1. In die Systemeinstellungen gehen  
2. Zu **Apps → Standard-Apps → Start-App / Launcher** navigieren  
3. Dort den Launcher auswählen

Ein direkter Zugang aus dem Konfigurationsmenü verbessert die **Benutzerfreundlichkeit und das Onboarding**.

---

## ✨ Erwartetes Verhalten

Im Konfigurationsmenü soll ein neuer Eintrag erscheinen:

**„Als Standard-Launcher festlegen“**

Beim Anklicken:

- wird die passende **Android-Systemeinstellung geöffnet**
- der Nutzer kann dort direkt den Launcher als **Standard-Start-App** auswählen

Optional:

- Wenn der Launcher bereits als Standard gesetzt ist, kann dies visuell angezeigt werden (z. B. Häkchen oder Hinweistext).

---

## ⚙️ Technische Anforderungen

- [x] Neuer Menüpunkt **„Als Standard-Launcher festlegen“** im Konfigurationsmenü
- [x] Öffnen der passenden Android-Systemeinstellung über Intent
- [x] Optional prüfen, ob Launcher bereits als Standard gesetzt ist
- [x] Statusanzeige im Menü (z. B. „Bereits aktiv“)

---

## 🎨 UI-Anforderungen

- Minimalistischer Menüeintrag passend zum bestehenden Design
- Optionales Icon (z. B. Home-Symbol)
- Klarer Hinweistext für neue Nutzer


---

## 🧪 Testfälle

- [x] Klick öffnet korrekt die Systemeinstellung
- [x] Nutzer kann den Launcher als Standard auswählen
- [x] Status wird korrekt erkannt, wenn Launcher bereits Standard ist
- [x] Funktioniert auf verschiedenen Android-Versionen
- [x] Menü reagiert ohne Verzögerung

---

## 🚀 Ergebnis

Ein **einfacher und direkter Weg**, den Launcher als Standard-Startbildschirm festzulegen, wodurch die Einrichtung für neue Nutzer deutlich erleichtert wird.
