### PR TITLE
#89 Issue: Konfigurationsmenü für Shake-Gesten (Gesture Enhancement)

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/LauncherShakeGestureDetector.kt
+++ b/app/src/main/java/com/example/androidlauncher/LauncherShakeGestureDetector.kt
@@ -5,8 +5,8 @@ import kotlin.math.sqrt
 /**
  * Erkennt konservativ Single- und Double-Shake-Muster auf Basis des Accelerometers.
  *
- * - 1 Shake -> Taschenlampe umschalten
- * - 2 schnelle Shakes -> Kamera öffnen
+ * Meldet ausschließlich den erkannten Gestentyp ([ShakeGesture]). Welche Aktion daraus
+ * folgt (Taschenlampe, Kamera, …) entscheidet die vom Nutzer konfigurierte Zuordnung.
  */
 class LauncherShakeGestureDetector(
     private val shakeThresholdG: Float = 2.35f,
@@ -18,9 +18,9 @@ class LauncherShakeGestureDetector(
         private const val EARTH_GRAVITY_MS2 = 9.80665f
     }
 
-    enum class GestureAction {
-        TOGGLE_FLASHLIGHT,
-        OPEN_CAMERA
+    enum class ShakeGesture {
+        SINGLE_SHAKE,
+        DOUBLE_SHAKE
     }
 
     val singleShakeConfirmationDelayMs: Long
@@ -30,12 +30,12 @@ class LauncherShakeGestureDetector(
     private var pendingShakeTimestampMs: Long? = null
     private var lastDispatchedTimestampMs = Long.MIN_VALUE / 4
 
-    fun onAccelerationChanged(x: Float, y: Float, z: Float, timestampMs: Long): GestureAction? {
+    fun onAccelerationChanged(x: Float, y: Float, z: Float, timestampMs: Long): ShakeGesture? {
         val gForce = sqrt((x * x + y * y + z * z).toDouble()).toFloat() / EARTH_GRAVITY_MS2
         return onGForceSample(gForce = gForce, timestampMs = timestampMs)
     }
 
-    fun onGForceSample(gForce: Float, timestampMs: Long): GestureAction? {
+    fun onGForceSample(gForce: Float, timestampMs: Long): ShakeGesture? {
         flushPending(timestampMs)?.let { return it }
 
         if (gForce < shakeThresholdG) {
@@ -56,14 +56,14 @@ class LauncherShakeGestureDetector(
         return if (previousPendingShake != null && timestampMs - previousPendingShake <= doubleShakeWindowMs) {
             pendingShakeTimestampMs = null
             lastDispatchedTimestampMs = timestampMs
-            GestureAction.OPEN_CAMERA
+            ShakeGesture.DOUBLE_SHAKE
         } else {
             pendingShakeTimestampMs = timestampMs
             null
         }
     }
 
-    fun flushPending(timestampMs: Long): GestureAction? {
+    fun flushPending(timestampMs: Long): ShakeGesture? {
         val pendingTimestampMs = pendingShakeTimestampMs ?: return null
         if (timestampMs - pendingTimestampMs < doubleShakeWindowMs) {
             return null
@@ -75,7 +75,7 @@ class LauncherShakeGestureDetector(
         }
 
         lastDispatchedTimestampMs = timestampMs
-        return GestureAction.TOGGLE_FLASHLIGHT
+        return ShakeGesture.SINGLE_SHAKE
     }
 
     fun hasPendingSingleShake(): Boolean = pendingShakeTimestampMs != null

--- a/app/src/main/java/com/example/androidlauncher/LauncherShakeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/LauncherShakeManager.kt
@@ -19,13 +19,13 @@ class LauncherShakeManager(context: Context) {
     private val detector = LauncherShakeGestureDetector()
     private val mainHandler = Handler(Looper.getMainLooper())
 
-    var onGestureAction: ((LauncherShakeGestureDetector.GestureAction) -> Unit)? = null
+    var onGestureAction: ((LauncherShakeGestureDetector.ShakeGesture) -> Unit)? = null
 
     private var isStarted = false
 
     private val confirmSingleShakeRunnable = Runnable {
-        detector.flushPending(SystemClock.elapsedRealtime())?.let { action ->
-            onGestureAction?.invoke(action)
+        detector.flushPending(SystemClock.elapsedRealtime())?.let { gesture ->
+            onGestureAction?.invoke(gesture)
         }
     }
 
@@ -34,16 +34,16 @@ class LauncherShakeManager(context: Context) {
             val values = event.values
             if (values.size < 3) return
 
-            val detectedAction = detector.onAccelerationChanged(
+            val detectedGesture = detector.onAccelerationChanged(
                 x = values[0],
                 y = values[1],
                 z = values[2],
                 timestampMs = SystemClock.elapsedRealtime()
             )
 
-            if (detectedAction != null) {
+            if (detectedGesture != null) {
                 mainHandler.removeCallbacks(confirmSingleShakeRunnable)
-                onGestureAction?.invoke(detectedAction)
+                onGestureAction?.invoke(detectedGesture)
                 return
             }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -80,6 +80,7 @@ import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.data.IconQualityEvaluator
 import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.data.SearchSuggestionsManager
+import com.example.androidlauncher.data.ShakeAction
 import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.ui.AppDrawer
 import com.example.androidlauncher.ui.HybridSearch
@@ -174,6 +175,8 @@ class MainActivity : ComponentActivity() {
             val showFavoriteLabels by themeManager.showFavoriteLabels.collectAsState(initial = false)
             val isLiquidGlassEnabled by themeManager.isLiquidGlassEnabled.collectAsState(initial = true)
             val isShakeGesturesEnabled by themeManager.isShakeGesturesEnabled.collectAsState(initial = true)
+            val singleShakeAction by themeManager.singleShakeAction.collectAsState(initial = ShakeAction.FLASHLIGHT)
+            val doubleShakeAction by themeManager.doubleShakeAction.collectAsState(initial = ShakeAction.CAMERA)
             val isSmartSuggestionsEnabled by themeManager.isSmartSuggestionsEnabled.collectAsState(initial = true)
             val isHapticFeedbackEnabled by themeManager.isHapticFeedbackEnabled.collectAsState(initial = true)
             val isAnimationsEnabled by themeManager.isAnimationsEnabled.collectAsState(initial = true)
@@ -202,8 +205,8 @@ class MainActivity : ComponentActivity() {
             var pendingWallpaperUri by remember { mutableStateOf<Uri?>(null) }
             var showUsageAccessPrompt by remember { mutableStateOf(false) }
             var hasShownUsageAccessPrompt by remember { mutableStateOf(false) }
-            var pendingPermissionGestureAction by remember {
-                mutableStateOf<LauncherShakeGestureDetector.GestureAction?>(null)
+            var pendingPermissionShakeAction by remember {
+                mutableStateOf<ShakeAction?>(null)
             }
 
             val wallpaperPickerLauncher = rememberLauncherForActivityResult(
@@ -218,10 +221,10 @@ class MainActivity : ComponentActivity() {
             val cameraPermissionLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.RequestPermission()
             ) { isGranted ->
-                val pendingAction = pendingPermissionGestureAction
-                pendingPermissionGestureAction = null
+                val pendingAction = pendingPermissionShakeAction
+                pendingPermissionShakeAction = null
 
-                if (pendingAction != LauncherShakeGestureDetector.GestureAction.TOGGLE_FLASHLIGHT) {
+                if (pendingAction != ShakeAction.FLASHLIGHT) {
                     return@rememberLauncherForActivityResult
                 }
 
@@ -254,9 +257,14 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
-            shakeManager.onGestureAction = { gestureAction ->
-                when (gestureAction) {
-                    LauncherShakeGestureDetector.GestureAction.TOGGLE_FLASHLIGHT -> {
+            shakeManager.onGestureAction = { gesture ->
+                val configuredAction = when (gesture) {
+                    LauncherShakeGestureDetector.ShakeGesture.SINGLE_SHAKE -> singleShakeAction
+                    LauncherShakeGestureDetector.ShakeGesture.DOUBLE_SHAKE -> doubleShakeAction
+                }
+                when (configuredAction) {
+                    ShakeAction.NONE -> Unit
+                    ShakeAction.FLASHLIGHT -> {
                         when (launcherDeviceActions.toggleFlashlight()) {
                             is FlashlightToggleResult.Success -> {
                                 launcherDeviceActions.vibrateGestureFeedback(this@MainActivity)
@@ -265,7 +273,7 @@ class MainActivity : ComponentActivity() {
                                 Toast.makeText(context, context.getString(R.string.flashlight_unsupported), Toast.LENGTH_SHORT).show()
                             }
                             FlashlightToggleResult.MissingPermission -> {
-                                pendingPermissionGestureAction = gestureAction
+                                pendingPermissionShakeAction = ShakeAction.FLASHLIGHT
                                 cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
                             }
                             FlashlightToggleResult.Error -> {
@@ -273,7 +281,7 @@ class MainActivity : ComponentActivity() {
                             }
                         }
                     }
-                    LauncherShakeGestureDetector.GestureAction.OPEN_CAMERA -> {
+                    ShakeAction.CAMERA -> {
                         val didOpenCamera = launcherDeviceActions.openCamera(this@MainActivity)
                         if (didOpenCamera) {
                             launcherDeviceActions.vibrateGestureFeedback(this@MainActivity)
@@ -1061,6 +1069,14 @@ class MainActivity : ComponentActivity() {
                             isShakeGesturesEnabled = isShakeGesturesEnabled,
                             onShakeGesturesToggled = { enabled ->
                                 scope.launch { themeManager.setShakeGesturesEnabled(enabled) }
+                            },
+                            singleShakeAction = singleShakeAction,
+                            onSingleShakeActionChange = { action ->
+                                scope.launch { themeManager.setSingleShakeAction(action) }
+                            },
+                            doubleShakeAction = doubleShakeAction,
+                            onDoubleShakeActionChange = { action ->
+                                scope.launch { themeManager.setDoubleShakeAction(action) }
                             },
                             isSmartSuggestionsEnabled = isSmartSuggestionsEnabled,
                             onSmartSuggestionsToggled = { enabled ->

--- a/app/src/main/java/com/example/androidlauncher/data/ShakeAction.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ShakeAction.kt
@@ -1,0 +1,13 @@
+package com.example.androidlauncher.data
+
+/**
+ * Aktion, die einer Shake-Geste zugeordnet werden kann.
+ *
+ * Vom Nutzer pro Geste (1×/2× Schütteln) frei wählbar und in DataStore persistiert.
+ * Erweiterbar für zukünftige Shake-Aktionen.
+ */
+enum class ShakeAction {
+    NONE,
+    FLASHLIGHT,
+    CAMERA
+}

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -44,6 +44,8 @@ class ThemeManager(private val context: Context) {
         private val WALLPAPER_DIM_KEY = floatPreferencesKey("wallpaper_dim")
         private val WALLPAPER_ZOOM_KEY = floatPreferencesKey("wallpaper_zoom")
         private val SHAKE_GESTURES_KEY = booleanPreferencesKey("shake_gestures_enabled")
+        private val SINGLE_SHAKE_ACTION_KEY = stringPreferencesKey("single_shake_action")
+        private val DOUBLE_SHAKE_ACTION_KEY = stringPreferencesKey("double_shake_action")
         private val SMART_SUGGESTIONS_KEY = booleanPreferencesKey("smart_search_enabled")
         private val HAPTIC_FEEDBACK_KEY = booleanPreferencesKey("haptic_feedback_enabled")
         private val ANIMATIONS_ENABLED_KEY = booleanPreferencesKey("animations_enabled")
@@ -144,6 +146,24 @@ class ThemeManager(private val context: Context) {
         }
 
     /**
+     * Aktion für einfaches Schütteln. Default Taschenlampe (erhält bisheriges Verhalten).
+     */
+    val singleShakeAction: Flow<ShakeAction> = context.dataStore.data
+        .map { preferences ->
+            val name = preferences[SINGLE_SHAKE_ACTION_KEY] ?: ShakeAction.FLASHLIGHT.name
+            try { ShakeAction.valueOf(name) } catch (e: IllegalArgumentException) { ShakeAction.FLASHLIGHT }
+        }
+
+    /**
+     * Aktion für doppeltes Schütteln. Default Kamera (erhält bisheriges Verhalten).
+     */
+    val doubleShakeAction: Flow<ShakeAction> = context.dataStore.data
+        .map { preferences ->
+            val name = preferences[DOUBLE_SHAKE_ACTION_KEY] ?: ShakeAction.CAMERA.name
+            try { ShakeAction.valueOf(name) } catch (e: IllegalArgumentException) { ShakeAction.CAMERA }
+        }
+
+    /**
      * Observable flow for intelligent search suggestions.
      */
     val isSmartSuggestionsEnabled: Flow<Boolean> = context.dataStore.data
@@ -229,6 +249,24 @@ class ThemeManager(private val context: Context) {
     suspend fun setShakeGesturesEnabled(enabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[SHAKE_GESTURES_KEY] = enabled
+        }
+    }
+
+    /**
+     * Setzt die Aktion für einfaches Schütteln.
+     */
+    suspend fun setSingleShakeAction(action: ShakeAction) {
+        context.dataStore.edit { preferences ->
+            preferences[SINGLE_SHAKE_ACTION_KEY] = action.name
+        }
+    }
+
+    /**
+     * Setzt die Aktion für doppeltes Schütteln.
+     */
+    suspend fun setDoubleShakeAction(action: ShakeAction) {
+        context.dataStore.edit { preferences ->
+            preferences[DOUBLE_SHAKE_ACTION_KEY] = action.name
         }
     }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -34,6 +34,11 @@ import com.composables.icons.lucide.Shield
 import com.composables.icons.lucide.Hand
 import com.composables.icons.lucide.House
 import com.composables.icons.lucide.Smartphone
+import com.composables.icons.lucide.Ban
+import com.composables.icons.lucide.Camera
+import com.composables.icons.lucide.ChevronDown
+import com.composables.icons.lucide.Flashlight
+import com.example.androidlauncher.data.ShakeAction
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -55,6 +60,10 @@ fun EditConfigMenu(
     isCustomWallpaperSet: Boolean,
     isShakeGesturesEnabled: Boolean,
     onShakeGesturesToggled: (Boolean) -> Unit,
+    singleShakeAction: ShakeAction,
+    onSingleShakeActionChange: (ShakeAction) -> Unit,
+    doubleShakeAction: ShakeAction,
+    onDoubleShakeActionChange: (ShakeAction) -> Unit,
     isSmartSuggestionsEnabled: Boolean,
     onSmartSuggestionsToggled: (Boolean) -> Unit,
     isAnimationsEnabled: Boolean,
@@ -278,7 +287,7 @@ fun EditConfigMenu(
                 EditToggleItem(
                     icon = Lucide.Smartphone,
                     label = "Shake-Gesten",
-                    description = "1× Schütteln: Taschenlampe · 2× Schütteln: Kamera",
+                    description = "Schütteln, um eine Aktion auszulösen. Zuordnung unten anpassbar.",
                     checked = isShakeGesturesEnabled,
                     onCheckedChange = onShakeGesturesToggled,
                     mainTextColor = mainTextColor,
@@ -286,6 +295,32 @@ fun EditConfigMenu(
                     isDarkTextEnabled = isDarkTextEnabled,
                     switchTestTag = "shake_gestures_switch"
                 )
+            }
+
+            if (isShakeGesturesEnabled) {
+                item {
+                    EditActionSelectorItem(
+                        label = "Einfaches Schütteln",
+                        selectedAction = singleShakeAction,
+                        onActionSelected = onSingleShakeActionChange,
+                        mainTextColor = mainTextColor,
+                        isLiquidGlassEnabled = isLiquidGlassEnabled,
+                        isDarkTextEnabled = isDarkTextEnabled,
+                        testTag = "single_shake_action_selector"
+                    )
+                }
+
+                item {
+                    EditActionSelectorItem(
+                        label = "Doppeltes Schütteln",
+                        selectedAction = doubleShakeAction,
+                        onActionSelected = onDoubleShakeActionChange,
+                        mainTextColor = mainTextColor,
+                        isLiquidGlassEnabled = isLiquidGlassEnabled,
+                        isDarkTextEnabled = isDarkTextEnabled,
+                        testTag = "double_shake_action_selector"
+                    )
+                }
             }
 
             item {
@@ -484,6 +519,110 @@ private fun EditToggleItem(
                 onCheckedChange = onCheckedChange,
                 colors = LiquidGlass.switchColors(isDarkTextEnabled, isLiquidGlassEnabled)
             )
+        }
+    }
+}
+
+/** Icon + Anzeigename für eine [ShakeAction] (UI-Mapping; das Enum selbst bleibt rein). */
+private fun shakeActionIcon(action: ShakeAction): ImageVector = when (action) {
+    ShakeAction.NONE -> Lucide.Ban
+    ShakeAction.FLASHLIGHT -> Lucide.Flashlight
+    ShakeAction.CAMERA -> Lucide.Camera
+}
+
+private fun shakeActionLabel(action: ShakeAction): String = when (action) {
+    ShakeAction.NONE -> "Aus"
+    ShakeAction.FLASHLIGHT -> "Taschenlampe"
+    ShakeAction.CAMERA -> "Kamera"
+}
+
+/**
+ * Zeilen-Eintrag, der die aktuell gewählte Aktion einer Shake-Geste anzeigt und bei Klick
+ * ein Dropdown mit allen [ShakeAction]-Optionen öffnet.
+ */
+@Composable
+private fun EditActionSelectorItem(
+    label: String,
+    selectedAction: ShakeAction,
+    onActionSelected: (ShakeAction) -> Unit,
+    mainTextColor: Color,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean,
+    testTag: String
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    val backgroundModifier = if (isLiquidGlassEnabled) {
+        val glassBrush = LiquidGlass.glassBrush(isDarkTextEnabled, startAlpha = 0.10f, endAlpha = 0.03f)
+        val borderBrush = LiquidGlass.borderBrush(isDarkTextEnabled, startAlpha = if (isDarkTextEnabled) 0.2f else 0.25f, endAlpha = 0.05f)
+        Modifier.background(glassBrush, RoundedCornerShape(16.dp)).border(BorderStroke(1.dp, borderBrush), RoundedCornerShape(16.dp))
+    } else {
+        Modifier.background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .then(backgroundModifier)
+            .testTag(testTag)
+            .clickable { expanded = true },
+        color = Color.Transparent
+    ) {
+        Row(
+            modifier = Modifier.padding(vertical = 18.dp, horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = shakeActionIcon(selectedAction),
+                contentDescription = null,
+                tint = mainTextColor,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Text(
+                text = label,
+                color = mainTextColor,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Normal,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = shakeActionLabel(selectedAction),
+                color = mainTextColor.copy(alpha = 0.6f),
+                fontSize = 15.sp,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Icon(
+                imageVector = Lucide.ChevronDown,
+                contentDescription = null,
+                tint = mainTextColor.copy(alpha = 0.5f),
+                modifier = Modifier.size(20.dp)
+            )
+
+            DropdownMenu(
+                expanded = expanded,
+                onDismissRequest = { expanded = false }
+            ) {
+                ShakeAction.entries.forEach { action ->
+                    DropdownMenuItem(
+                        text = { Text(shakeActionLabel(action)) },
+                        leadingIcon = {
+                            Icon(
+                                imageVector = shakeActionIcon(action),
+                                contentDescription = null,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        },
+                        onClick = {
+                            expanded = false
+                            if (action != selectedAction) {
+                                onActionSelected(action)
+                            }
+                        }
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/test/java/com/example/androidlauncher/LauncherShakeGestureDetectorTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/LauncherShakeGestureDetectorTest.kt
@@ -8,27 +8,27 @@ import org.junit.Test
 class LauncherShakeGestureDetectorTest {
 
     @Test
-    fun `single shake becomes flashlight action after confirmation window`() {
+    fun `single shake is reported after confirmation window`() {
         val detector = LauncherShakeGestureDetector()
 
         assertNull(detector.onGForceSample(gForce = 2.7f, timestampMs = 1_000L))
         assertNull(detector.flushPending(timestampMs = 1_600L))
 
-        val action = detector.flushPending(timestampMs = 1_700L)
+        val gesture = detector.flushPending(timestampMs = 1_700L)
 
-        assertEquals(LauncherShakeGestureDetector.GestureAction.TOGGLE_FLASHLIGHT, action)
+        assertEquals(LauncherShakeGestureDetector.ShakeGesture.SINGLE_SHAKE, gesture)
         assertFalse(detector.hasPendingSingleShake())
     }
 
     @Test
-    fun `two fast shakes open the camera`() {
+    fun `two fast shakes are reported as a double shake`() {
         val detector = LauncherShakeGestureDetector()
 
         assertNull(detector.onGForceSample(gForce = 2.8f, timestampMs = 1_000L))
 
-        val action = detector.onGForceSample(gForce = 2.9f, timestampMs = 1_400L)
+        val gesture = detector.onGForceSample(gForce = 2.9f, timestampMs = 1_400L)
 
-        assertEquals(LauncherShakeGestureDetector.GestureAction.OPEN_CAMERA, action)
+        assertEquals(LauncherShakeGestureDetector.ShakeGesture.DOUBLE_SHAKE, gesture)
         assertFalse(detector.hasPendingSingleShake())
     }
 
@@ -49,9 +49,9 @@ class LauncherShakeGestureDetectorTest {
         assertNull(detector.onGForceSample(gForce = 2.8f, timestampMs = 1_000L))
         assertNull(detector.onGForceSample(gForce = 3.0f, timestampMs = 1_120L))
 
-        val action = detector.flushPending(timestampMs = 1_700L)
+        val gesture = detector.flushPending(timestampMs = 1_700L)
 
-        assertEquals(LauncherShakeGestureDetector.GestureAction.TOGGLE_FLASHLIGHT, action)
+        assertEquals(LauncherShakeGestureDetector.ShakeGesture.SINGLE_SHAKE, gesture)
     }
 }
 

--- a/app/src/test/java/com/example/androidlauncher/LauncherShakeManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/LauncherShakeManagerTest.kt
@@ -101,9 +101,9 @@ class LauncherShakeManagerTest {
             every { event.values } returns floatArrayOf(20f, 20f, 20f)
         }
 
-        var actionReceived: LauncherShakeGestureDetector.GestureAction? = null
-        manager.onGestureAction = { action ->
-            actionReceived = action
+        var gestureReceived: LauncherShakeGestureDetector.ShakeGesture? = null
+        manager.onGestureAction = { gesture ->
+            gestureReceived = gesture
         }
 
         listener.onSensorChanged(event)


### PR DESCRIPTION
# 🌀 Issue: Konfigurationsmenü für Shake-Gesten (Gesture Enhancement)

## 🎯 Ziel

Ein Einstellungsmenü implementieren, in dem Nutzer die **Shake-Gesten konfigurieren und anpassen** können.

Dabei sollen die vorhandenen Shake-Gesten (z. B. Taschenlampe und Kamera) **aktiviert, deaktiviert oder untereinander vertauscht** werden können.

---

## 🧩 Hintergrund

Der Launcher unterstützt bereits Shake-Gesten für:

- 📸 Kamera öffnen (Doppel-Shake)
- 🔦 Taschenlampe ein-/ausschalten (einfacher Shake)

Da Nutzer unterschiedliche Präferenzen haben, soll ein **Gesture-Enhancement-Menü** eingeführt werden, um diese Gesten individuell anzupassen.

---

## ✨ Erwartetes Verhalten

Im Konfigurationsmenü soll ein Bereich **„Shake-Gesten“** hinzugefügt werden.

Dort können Nutzer:

- Shake-Gesten aktivieren oder deaktivieren
- Aktionen der Gesten vertauschen
- Optional zukünftige Shake-Aktionen konfigurieren

Beispiel:

| Geste | Aktion |
|------|------|
| Einfaches Schütteln | Taschenlampe |
| Doppeltes Schütteln | Kamera |

Der Nutzer kann diese Zuordnung **beliebig tauschen**.

---

## ⚙️ Technische Anforderungen

- [x] Neuer Menübereich **„Shake-Gesten“** im Einstellungsmenü
- [x] Toggle zum Aktivieren/Deaktivieren der Shake-Gesten
- [x] Auswahlmenü für Aktionen pro Geste
- [x] Speicherung der Konfiguration (z. B. DataStore)
- [x] Dynamische Anwendung ohne Neustart des Launchers

---

## 🎨 UI-Anforderungen

- Minimalistisches Menü passend zum Launcher-Design
- Klare Darstellung der Gesten-Zuordnung
- Nutzung von Icons (z. B. Kamera, Taschenlampe)
- Optional kurze Erklärung der Gesten

---

## 🧪 Testfälle

- [x] Nutzer kann Gesten aktivieren/deaktivieren
- [x] Nutzer kann Aktionen der Gesten tauschen
- [x] Konfiguration bleibt nach Neustart erhalten
- [x] Gesten lösen die korrekt zugewiesene Aktion aus
- [x] Keine Fehltrigger durch Konfigurationsänderungen

---

## 🚀 Ergebnis

Ein flexibles **Shake-Gesten-Konfigurationssystem**, das Nutzern erlaubt, die Gesten an ihre persönlichen Vorlieben anzupassen und die Bedienung des Launchers weiter zu personalisieren.