### PR TITLE
#107 Feature: Apps direkt im Bearbeitungsmenü deinstallieren

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -93,6 +93,7 @@ import com.example.androidlauncher.ui.FontSelectionMenu
 import com.example.androidlauncher.ui.HomeScreen
 import com.example.androidlauncher.ui.IconConfigMenu
 import com.example.androidlauncher.ui.InfoDialog
+import com.example.androidlauncher.ui.UninstallAppsMenu
 import com.example.androidlauncher.ui.LaunchAnimationOverlay
 import com.example.androidlauncher.ui.NiagaraAppDrawer
 import com.example.androidlauncher.ui.ReturnAnimationOverlay
@@ -348,6 +349,7 @@ class MainActivity : ComponentActivity() {
                 var isFontSelectionOpen by remember { mutableStateOf(false) }
                 var isEditConfigOpen by remember { mutableStateOf(false) }
                 var isIconConfigOpen by remember { mutableStateOf(false) }
+                var isUninstallAppsOpen by remember { mutableStateOf(false) }
                 var isWallpaperConfigOpen by remember { mutableStateOf(false) }
                 var isInfoOpen by remember { mutableStateOf(false) }
                 var selectedFolderForConfig by remember { mutableStateOf<FolderInfo?>(null) }
@@ -759,6 +761,7 @@ class MainActivity : ComponentActivity() {
                         isFontSelectionOpen = false
                         isEditConfigOpen = false
                         isIconConfigOpen = false
+                        isUninstallAppsOpen = false
                         isWallpaperConfigOpen = false
                         isInfoOpen = false
                         isHomeEditMode = false
@@ -769,12 +772,12 @@ class MainActivity : ComponentActivity() {
                 LaunchedEffect(
                     isDrawerOpen, isFavoritesConfigOpen, isColorConfigOpen,
                     isSizeConfigOpen, isFontSelectionOpen, isEditConfigOpen,
-                    isIconConfigOpen, isWallpaperConfigOpen, isInfoOpen,
+                    isIconConfigOpen, isUninstallAppsOpen, isWallpaperConfigOpen, isInfoOpen,
                     selectedFolderForConfig, isSearchOpen, isHomeEditMode
                 ) {
                     val anyModalOpen = isDrawerOpen || isFavoritesConfigOpen ||
                         isColorConfigOpen || isSizeConfigOpen || isFontSelectionOpen ||
-                        isEditConfigOpen || isIconConfigOpen || isWallpaperConfigOpen ||
+                        isEditConfigOpen || isIconConfigOpen || isUninstallAppsOpen || isWallpaperConfigOpen ||
                         isInfoOpen || selectedFolderForConfig != null || isSearchOpen || isHomeEditMode
                     backCallback.isEnabled = !anyModalOpen
                 }
@@ -782,7 +785,7 @@ class MainActivity : ComponentActivity() {
                 BackHandler(
                     enabled = isDrawerOpen || isFavoritesConfigOpen || isColorConfigOpen ||
                         isSizeConfigOpen || isFontSelectionOpen || isEditConfigOpen ||
-                        isIconConfigOpen || isWallpaperConfigOpen || isInfoOpen ||
+                        isIconConfigOpen || isUninstallAppsOpen || isWallpaperConfigOpen || isInfoOpen ||
                         selectedFolderForConfig != null || isSearchOpen || isHomeEditMode
                 ) {
                     when {
@@ -791,6 +794,7 @@ class MainActivity : ComponentActivity() {
                         isSearchOpen -> isSearchOpen = false
                         isFontSelectionOpen -> isFontSelectionOpen = false
                         isWallpaperConfigOpen -> isWallpaperConfigOpen = false
+                        isUninstallAppsOpen -> isUninstallAppsOpen = false
                         isIconConfigOpen -> isIconConfigOpen = false
                         isDrawerOpen -> isDrawerOpen = false
                         isFavoritesConfigOpen -> isFavoritesConfigOpen = false
@@ -1074,6 +1078,7 @@ class MainActivity : ComponentActivity() {
                                 Toast.makeText(context, context.getString(R.string.home_layout_reset), Toast.LENGTH_SHORT).show()
                             },
                             onOpenIconConfig = { isIconConfigOpen = true },
+                            onOpenUninstallApps = { isUninstallAppsOpen = true },
                             onChangeWallpaper = {
                                 isEditConfigOpen = false
                                 isWallpaperConfigOpen = false
@@ -1192,6 +1197,17 @@ class MainActivity : ComponentActivity() {
                                 }
                             },
                             onClose = { isIconConfigOpen = false }
+                        )
+                    }
+
+                    MenuOverlay(
+                        visible = isUninstallAppsOpen,
+                        backgroundColor = menuBackgroundColor,
+                        onClose = { isUninstallAppsOpen = false }
+                    ) {
+                        UninstallAppsMenu(
+                            apps = allApps,
+                            onClose = { isUninstallAppsOpen = false }
                         )
                     }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -1207,6 +1207,7 @@ class MainActivity : ComponentActivity() {
                     ) {
                         UninstallAppsMenu(
                             apps = allApps,
+                            onRefreshApps = { pkg -> refreshAppList(pkg) },
                             onClose = { isUninstallAppsOpen = false }
                         )
                     }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -183,7 +183,7 @@ class MainActivity : ComponentActivity() {
             val isSmartSuggestionsEnabled by themeManager.isSmartSuggestionsEnabled.collectAsState(initial = true)
             val isHapticFeedbackEnabled by themeManager.isHapticFeedbackEnabled.collectAsState(initial = true)
             val isAnimationsEnabled by themeManager.isAnimationsEnabled.collectAsState(initial = true)
-            val appAccessMode by themeManager.appAccessMode.collectAsState(initial = AppAccessMode.DRAWER_GRID)
+            val appAccessMode by themeManager.appAccessMode.collectAsState(initial = AppAccessMode.DRAWER_LIST)
 
             val customWallpaperUri by themeManager.customWallpaperUri.collectAsState(initial = null)
             val wallpaperBlur by themeManager.wallpaperBlur.collectAsState(initial = 0f)

--- a/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/ThemeManager.kt
@@ -165,12 +165,12 @@ class ThemeManager(private val context: Context) {
         }
 
     /**
-     * Gewählte Art des App-Zugriffs. Default Grid-Drawer (erhält bisheriges Verhalten).
+     * Gewählte Art des App-Zugriffs. Default ist die Drawer-Liste (Niagara-Stil).
      */
     val appAccessMode: Flow<AppAccessMode> = context.dataStore.data
         .map { preferences ->
-            val name = preferences[APP_ACCESS_MODE_KEY] ?: AppAccessMode.DRAWER_GRID.name
-            try { AppAccessMode.valueOf(name) } catch (e: IllegalArgumentException) { AppAccessMode.DRAWER_GRID }
+            val name = preferences[APP_ACCESS_MODE_KEY] ?: AppAccessMode.DRAWER_LIST.name
+            try { AppAccessMode.valueOf(name) } catch (e: IllegalArgumentException) { AppAccessMode.DRAWER_LIST }
         }
 
     /**

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -140,7 +140,10 @@ fun AppDrawer(
     val searchQuery by appDrawerVm.searchQuery.collectAsState()
     val visibleApps by appDrawerVm.visibleApps.collectAsState()
 
-    LaunchedEffect(apps) { appDrawerVm.updateApps(apps) }
+    // apps ist eine in-place mutierte SnapshotStateList – auf den Inhalt keyen (Kopie),
+    // damit Installationen/Deinstallationen den ViewModel-State tatsächlich erreichen.
+    val appsSnapshot = apps.toList()
+    LaunchedEffect(appsSnapshot) { appDrawerVm.updateApps(appsSnapshot) }
     LaunchedEffect(folders) { appDrawerVm.updateFolders(folders) }
 
     val focusRequester = remember { FocusRequester() }

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -41,6 +41,7 @@ import com.composables.icons.lucide.Flashlight
 import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.List
 import com.composables.icons.lucide.PanelRight
+import com.composables.icons.lucide.Trash2
 import com.example.androidlauncher.data.AppAccessMode
 import com.example.androidlauncher.data.ShakeAction
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
@@ -57,6 +58,7 @@ fun EditConfigMenu(
     onOpenHomeLayoutEdit: () -> Unit,
     onResetHomeLayout: () -> Unit,
     onOpenIconConfig: () -> Unit,
+    onOpenUninstallApps: () -> Unit,
     onChangeWallpaper: () -> Unit,
     onResetWallpaper: () -> Unit,
     onOpenWallpaperAdjust: () -> Unit,
@@ -260,6 +262,25 @@ fun EditConfigMenu(
                         isDarkTextEnabled = isDarkTextEnabled
                     )
                 }
+            }
+
+            item {
+                EditSectionHeader(
+                    title = "Apps",
+                    mainTextColor = mainTextColor
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Trash2,
+                    label = "Apps deinstallieren",
+                    onClick = onOpenUninstallApps,
+                    mainTextColor = mainTextColor,
+                    isLiquidGlassEnabled = isLiquidGlassEnabled,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "uninstall_apps_item"
+                )
             }
 
             item {

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeAppScrubber.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeAppScrubber.kt
@@ -101,7 +101,10 @@ fun HomeAppScrubber(
         colorTheme.highlightColor(isDarkTextEnabled)
     }
 
-    val ordered = remember(apps) { groupAppsForScrubber(apps) }
+    // apps ist eine in-place mutierte SnapshotStateList – auf den Inhalt keyen (Kopie),
+    // damit Deinstallationen sofort durchschlagen (sonst bliebe die Gruppierung stale).
+    val appsSnapshot = apps.toList()
+    val ordered = remember(appsSnapshot) { groupAppsForScrubber(appsSnapshot) }
     val letters = remember(ordered) { ordered.keys.toList() }
 
     // Geometrie (px)

--- a/app/src/main/java/com/example/androidlauncher/ui/NiagaraAppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/NiagaraAppDrawer.kt
@@ -97,7 +97,10 @@ fun NiagaraAppDrawer(
     val searchQuery by appDrawerVm.searchQuery.collectAsState()
     val visibleApps by appDrawerVm.visibleApps.collectAsState()
 
-    LaunchedEffect(apps) { appDrawerVm.updateApps(apps) }
+    // apps ist eine in-place mutierte SnapshotStateList – auf den Inhalt keyen (Kopie),
+    // damit Installationen/Deinstallationen den ViewModel-State tatsächlich erreichen.
+    val appsSnapshot = apps.toList()
+    LaunchedEffect(appsSnapshot) { appDrawerVm.updateApps(appsSnapshot) }
 
     val focusRequester = remember { androidx.compose.ui.focus.FocusRequester() }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/NiagaraAppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/NiagaraAppDrawer.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -32,6 +34,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.NestedScrollSource
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInParent
 import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
@@ -54,6 +58,7 @@ import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalHapticFeedbackEnabled
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import kotlin.math.abs
 import kotlinx.coroutines.launch
 
 /**
@@ -271,7 +276,7 @@ fun NiagaraAppDrawer(
                         } else {
                             grouped.forEach { (letter, groupApps) ->
                                 stickyHeader(key = "header_$letter", contentType = "header") {
-                                    NiagaraSectionHeader(letter = letter, mainTextColor = mainTextColor, backgroundBrush = drawerBackgroundBrush)
+                                    NiagaraSectionHeader(letter = letter, mainTextColor = mainTextColor)
                                 }
                                 items(items = groupApps, key = { it.packageName }, contentType = { "app" }) { app ->
                                     NiagaraAppRow(
@@ -297,38 +302,81 @@ fun NiagaraAppDrawer(
                 }
 
                 // Seitliche A–Z-Schnellnavigation – nur ohne aktive Suche.
+                // Tippen springt zum Buchstaben, Wischen entlang der Leiste scrubbt
+                // flüssig durch die Liste (Buchstabe unter dem Finger).
                 if (!isSearching) {
+                    var activeLetter by remember { mutableStateOf<String?>(null) }
+                    // Gemessene vertikale Mitte jedes Buchstabens (relativ zur Leiste).
+                    // Über SpaceEvenly verteilte Buchstaben liegen nicht in gleich großen
+                    // Slabs – daher den Finger auf den tatsächlich nächsten Buchstaben mappen.
+                    val letterCenters = remember(sideBarLetters) { FloatArray(sideBarLetters.size) }
                     Column(
                         modifier = Modifier
                             .align(Alignment.CenterEnd)
                             .fillMaxHeight()
-                            .width(24.dp),
+                            .width(24.dp)
+                            .pointerInput(headerIndexByLetter, sideBarLetters) {
+                                fun resolve(y: Float) {
+                                    var best: String? = null
+                                    var bestDist = Float.MAX_VALUE
+                                    sideBarLetters.forEachIndexed { i, letter ->
+                                        if (headerIndexByLetter[letter] == null) return@forEachIndexed
+                                        val d = abs(letterCenters[i] - y)
+                                        if (d < bestDist) {
+                                            bestDist = d
+                                            best = letter
+                                        }
+                                    }
+                                    val letter = best ?: return
+                                    if (letter != activeLetter) {
+                                        activeLetter = letter
+                                        if (hapticEnabled) {
+                                            @Suppress("DEPRECATION")
+                                            view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+                                        }
+                                        headerIndexByLetter[letter]?.let { target ->
+                                            scope.launch { listState.scrollToItem(target) }
+                                        }
+                                    }
+                                }
+                                awaitEachGesture {
+                                    val down = awaitFirstDown(requireUnconsumed = false)
+                                    activeLetter = null
+                                    resolve(down.position.y)
+                                    down.consume()
+                                    do {
+                                        val event = awaitPointerEvent()
+                                        val change = event.changes.firstOrNull { it.id == down.id }
+                                            ?: event.changes.firstOrNull()
+                                        if (change != null && change.pressed) {
+                                            resolve(change.position.y)
+                                            change.consume()
+                                        }
+                                    } while (event.changes.any { it.pressed })
+                                    activeLetter = null
+                                }
+                            },
                         verticalArrangement = Arrangement.SpaceEvenly,
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        sideBarLetters.forEach { letter ->
-                            val targetIndex = headerIndexByLetter[letter]
-                            val enabled = targetIndex != null
+                        sideBarLetters.forEachIndexed { index, letter ->
+                            val enabled = headerIndexByLetter[letter] != null
+                            val isActive = letter == activeLetter
                             Text(
                                 text = letter,
-                                fontSize = 11.sp,
+                                fontSize = if (isActive) 13.sp else 11.sp,
                                 fontFamily = appFont.fontFamily,
                                 fontWeight = fontWeight.weight,
-                                color = mainTextColor.copy(alpha = if (enabled) 0.75f else 0.22f),
+                                color = mainTextColor.copy(
+                                    alpha = when {
+                                        !enabled -> 0.22f
+                                        isActive -> 1f
+                                        else -> 0.75f
+                                    }
+                                ),
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .then(
-                                        if (enabled) Modifier.clickable(
-                                            interactionSource = remember { MutableInteractionSource() },
-                                            indication = null
-                                        ) {
-                                            if (hapticEnabled) {
-                                                @Suppress("DEPRECATION")
-                                                view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                                            }
-                                            scope.launch { listState.scrollToItem(targetIndex!!) }
-                                        } else Modifier
-                                    )
+                                    .onGloballyPositioned { letterCenters[index] = it.boundsInParent().center.y }
                                     .padding(vertical = 2.dp),
                                 textAlign = androidx.compose.ui.text.style.TextAlign.Center
                             )
@@ -375,23 +423,17 @@ fun NiagaraAppDrawer(
 @Composable
 private fun NiagaraSectionHeader(
     letter: String,
-    mainTextColor: Color,
-    backgroundBrush: androidx.compose.ui.graphics.Brush
+    mainTextColor: Color
 ) {
     val fontWeight = LocalFontWeight.current
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(backgroundBrush)
-            .padding(vertical = 6.dp)
-    ) {
-        Text(
-            text = letter,
-            fontSize = 14.sp,
-            fontWeight = fontWeight.weight,
-            color = mainTextColor.copy(alpha = 0.6f)
-        )
-    }
+    // Bewusst ohne Hintergrund-Balken – nur ein dezenter, linksbündiger Buchstabe.
+    Text(
+        text = letter,
+        fontSize = 13.sp,
+        fontWeight = fontWeight.weight,
+        color = mainTextColor.copy(alpha = 0.5f),
+        modifier = Modifier.padding(start = 4.dp, top = 14.dp, bottom = 6.dp)
+    )
 }
 
 /**

--- a/app/src/main/java/com/example/androidlauncher/ui/UninstallAppsMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/UninstallAppsMenu.kt
@@ -1,0 +1,389 @@
+package com.example.androidlauncher.ui
+
+import android.content.Intent
+import android.content.pm.ApplicationInfo
+import android.net.Uri
+import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Trash2
+import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalFontWeight
+import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** Akzentfarbe für destruktive Aktionen (wie in [IconConfigMenu]). */
+private val DestructiveColor = Color(0xFFEF5350)
+
+/**
+ * Menü zum Deinstallieren installierter Apps.
+ *
+ * Bietet Einzel-Deinstallation per Swipe oder Lösch-Button sowie Mehrfachauswahl
+ * per Checkbox mit einem Sammel-Button. Vor jeder Deinstallation erscheint ein
+ * In-App-Bestätigungsdialog. System-Apps werden ausgeblendet (nur deinstallierbare
+ * Nutzer-Apps und aktualisierte System-Apps erscheinen).
+ *
+ * Die eigentliche Deinstallation läuft über das System ([Intent.ACTION_DELETE]).
+ * Bei Mehrfachauswahl werden die Apps nacheinander abgearbeitet, sobald der
+ * jeweilige System-Dialog geschlossen wird (siehe [LifecycleEventEffect]).
+ * Die Liste aktualisiert sich anschließend automatisch über den
+ * `PACKAGE_REMOVED`-Receiver in der MainActivity.
+ *
+ * @param apps Alle aktuell bekannten Apps (System-Apps werden hier herausgefiltert).
+ * @param onClose Callback zum Schließen des Menüs.
+ */
+@Composable
+fun UninstallAppsMenu(
+    apps: List<AppInfo>,
+    onClose: () -> Unit
+) {
+    val context = LocalContext.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
+    val fontWeight = LocalFontWeight.current
+    val mainTextColor = LiquidGlass.mainTextColor(isDarkTextEnabled)
+    val secondaryTextColor = LiquidGlass.secondaryTextColor(isDarkTextEnabled)
+
+    // System-Apps off-main-thread herausfiltern.
+    val uninstallableApps by produceState(initialValue = emptyList<AppInfo>(), apps.toList()) {
+        value = withContext(Dispatchers.IO) {
+            val pm = context.packageManager
+            apps.filter { app ->
+                try {
+                    val flags = pm.getApplicationInfo(app.packageName, 0).flags
+                    val isSystem = (flags and ApplicationInfo.FLAG_SYSTEM) != 0
+                    val isUpdatedSystem = (flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP) != 0
+                    // Eigene App ausblenden; reine System-Apps ausblenden,
+                    // aktualisierte System-Apps (deinstallierbar) erlauben.
+                    app.packageName != context.packageName && (!isSystem || isUpdatedSystem)
+                } catch (_: Exception) {
+                    false
+                }
+            }
+        }
+    }
+
+    var searchQuery by remember { mutableStateOf("") }
+    val filteredApps = remember(uninstallableApps, searchQuery) {
+        if (searchQuery.isBlank()) uninstallableApps
+        else uninstallableApps.filter { it.label.contains(searchQuery, ignoreCase = true) }
+    }
+
+    val selectedPackages = remember { mutableStateListOf<String>() }
+    // Entfernt Auswahl-Einträge, die nicht mehr deinstallierbar sind (z.B. nach Refresh).
+    LaunchedEffect(uninstallableApps) {
+        val available = uninstallableApps.mapTo(HashSet()) { it.packageName }
+        selectedPackages.retainAll { it in available }
+    }
+
+    // Pakete, für die der Bestätigungsdialog gezeigt wird (1 = Einzel, N = Sammel).
+    var pendingConfirmation by remember { mutableStateOf<List<String>?>(null) }
+
+    // Sequentielle Abarbeitung der Deinstallations-Warteschlange.
+    var uninstallQueue by remember { mutableStateOf<List<String>>(emptyList()) }
+    var awaitingResume by remember { mutableStateOf(false) }
+
+    fun fireUninstall(pkg: String) {
+        try {
+            context.startActivity(
+                Intent(Intent.ACTION_DELETE).apply {
+                    data = Uri.fromParts("package", pkg, null)
+                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
+                }
+            )
+        } catch (_: Exception) {
+            Toast.makeText(context, "Deinstallation konnte nicht gestartet werden", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun processNext() {
+        val next = uninstallQueue.firstOrNull()
+        if (next == null) {
+            awaitingResume = false
+            return
+        }
+        awaitingResume = true
+        fireUninstall(next)
+    }
+
+    fun startUninstall(packages: List<String>) {
+        if (packages.isEmpty()) return
+        selectedPackages.removeAll(packages)
+        uninstallQueue = packages
+        processNext()
+    }
+
+    // Nach Rückkehr aus dem System-Dialog das nächste Paket abarbeiten.
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        if (awaitingResume) {
+            uninstallQueue = uninstallQueue.drop(1)
+            processNext()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("uninstall_apps_menu")
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "Apps deinstallieren",
+                fontSize = 24.sp,
+                fontWeight = fontWeight.weight,
+                color = mainTextColor
+            )
+            IconButton(onClick = onClose) {
+                Icon(Icons.Default.Close, contentDescription = "Close", tint = mainTextColor)
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Suchleiste mit Liquid-Glass-Optik (wie in IconConfigMenu).
+        val searchBarModifier = if (isLiquidGlassEnabled) {
+            Modifier
+                .background(LiquidGlass.glassBrush(isDarkTextEnabled, startAlpha = 0.10f, endAlpha = 0.03f), RoundedCornerShape(12.dp))
+                .border(BorderStroke(1.dp, LiquidGlass.borderBrush(isDarkTextEnabled, startAlpha = 0.2f, endAlpha = 0.05f)), RoundedCornerShape(12.dp))
+        } else {
+            Modifier.background(mainTextColor.copy(alpha = 0.1f), RoundedCornerShape(12.dp))
+        }
+
+        Box(modifier = Modifier.fillMaxWidth().then(searchBarModifier).padding(horizontal = 16.dp, vertical = 12.dp)) {
+            StableSearchFieldContent(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                placeholder = "Apps durchsuchen...",
+                textStyle = androidx.compose.ui.text.TextStyle(color = mainTextColor, fontSize = 16.sp),
+                textColor = mainTextColor,
+                placeholderColor = mainTextColor.copy(alpha = 0.4f),
+                leadingIconTint = mainTextColor.copy(alpha = 0.4f),
+                leadingIconSize = 20.dp
+            )
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        LazyColumn(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
+        ) {
+            itemsIndexed(items = filteredApps, key = { _, app -> app.packageName }) { _, app ->
+                UninstallAppRow(
+                    app = app,
+                    isSelected = app.packageName in selectedPackages,
+                    onToggleSelected = {
+                        if (app.packageName in selectedPackages) selectedPackages.remove(app.packageName)
+                        else selectedPackages.add(app.packageName)
+                    },
+                    onRequestUninstall = { pendingConfirmation = listOf(app.packageName) },
+                    mainTextColor = mainTextColor,
+                    secondaryTextColor = secondaryTextColor,
+                    isLiquidGlassEnabled = isLiquidGlassEnabled,
+                    isDarkTextEnabled = isDarkTextEnabled
+                )
+            }
+        }
+
+        // Sammel-Aktionsleiste bei aktiver Mehrfachauswahl.
+        if (selectedPackages.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(
+                    onClick = { selectedPackages.clear() },
+                    modifier = Modifier.testTag("uninstall_clear_selection")
+                ) {
+                    Text("Auswahl aufheben", color = mainTextColor.copy(alpha = 0.7f))
+                }
+                Button(
+                    onClick = { pendingConfirmation = selectedPackages.toList() },
+                    modifier = Modifier.weight(1f).testTag("uninstall_selected_button"),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = DestructiveColor,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Icon(Lucide.Trash2, contentDescription = null, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("Deinstallieren (${selectedPackages.size})")
+                }
+            }
+        }
+    }
+
+    pendingConfirmation?.let { packages ->
+        val title: String
+        val message: String
+        if (packages.size == 1) {
+            val label = filteredApps.firstOrNull { it.packageName == packages.first() }?.label
+                ?: uninstallableApps.firstOrNull { it.packageName == packages.first() }?.label
+                ?: packages.first()
+            title = "App deinstallieren?"
+            message = "„$label\" wird von diesem Gerät entfernt."
+        } else {
+            title = "Apps deinstallieren?"
+            message = "${packages.size} Apps werden nacheinander entfernt. Bitte bestätige jede App im System-Dialog."
+        }
+
+        AlertDialog(
+            onDismissRequest = { pendingConfirmation = null },
+            title = { Text(title) },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val toUninstall = packages
+                        pendingConfirmation = null
+                        startUninstall(toUninstall)
+                    },
+                    modifier = Modifier.testTag("uninstall_confirm_button")
+                ) {
+                    Text("Deinstallieren", color = DestructiveColor)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { pendingConfirmation = null }) {
+                    Text("Abbrechen")
+                }
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun UninstallAppRow(
+    app: AppInfo,
+    isSelected: Boolean,
+    onToggleSelected: () -> Unit,
+    onRequestUninstall: () -> Unit,
+    mainTextColor: Color,
+    secondaryTextColor: Color,
+    isLiquidGlassEnabled: Boolean,
+    isDarkTextEnabled: Boolean
+) {
+    // Swipe löst die Bestätigung aus; die Zeile bleibt erhalten (confirmValueChange == false),
+    // bis die echte Deinstallation über das System erfolgt ist.
+    val dismissState = rememberSwipeToDismissBoxState(
+        confirmValueChange = { value ->
+            if (value == SwipeToDismissBoxValue.EndToStart) {
+                onRequestUninstall()
+            }
+            false
+        }
+    )
+
+    val itemBackgroundModifier = if (isLiquidGlassEnabled) {
+        Modifier
+            .background(LiquidGlass.glassBrush(isDarkTextEnabled, startAlpha = 0.06f, endAlpha = 0.02f), RoundedCornerShape(16.dp))
+            .border(BorderStroke(1.dp, LiquidGlass.borderBrush(isDarkTextEnabled, startAlpha = 0.15f, endAlpha = 0.03f)), RoundedCornerShape(16.dp))
+    } else {
+        Modifier.background(mainTextColor.copy(alpha = 0.03f), RoundedCornerShape(16.dp))
+    }
+
+    SwipeToDismissBox(
+        state = dismissState,
+        modifier = Modifier.clip(RoundedCornerShape(16.dp)),
+        enableDismissFromStartToEnd = false,
+        enableDismissFromEndToStart = true,
+        backgroundContent = {
+            // Nur während eines aktiven Swipes zeichnen – sonst würde der
+            // Hintergrund durch den durchscheinenden Zeilen-Vordergrund scheinen.
+            val isSwiping = dismissState.dismissDirection == SwipeToDismissBoxValue.EndToStart
+            if (isSwiping) {
+                val revealModifier = if (isLiquidGlassEnabled) {
+                    Modifier
+                        .background(LiquidGlass.glassBrush(isDarkTextEnabled, startAlpha = 0.18f, endAlpha = 0.08f), RoundedCornerShape(16.dp))
+                        .border(BorderStroke(1.dp, LiquidGlass.borderBrush(isDarkTextEnabled, startAlpha = 0.2f, endAlpha = 0.05f)), RoundedCornerShape(16.dp))
+                } else {
+                    Modifier.background(mainTextColor.copy(alpha = 0.10f), RoundedCornerShape(16.dp))
+                }
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(RoundedCornerShape(16.dp))
+                        .then(revealModifier)
+                        .padding(horizontal = 24.dp),
+                    contentAlignment = Alignment.CenterEnd
+                ) {
+                    Icon(Lucide.Trash2, contentDescription = null, tint = DestructiveColor, modifier = Modifier.size(24.dp))
+                }
+            }
+        }
+    ) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("uninstall_item_${app.packageName}")
+                .clip(RoundedCornerShape(16.dp))
+                .then(itemBackgroundModifier)
+                .clickable { onToggleSelected() },
+            color = Color.Transparent
+        ) {
+            Row(
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = isSelected,
+                    onCheckedChange = { onToggleSelected() },
+                    modifier = Modifier.testTag("uninstall_checkbox_${app.packageName}"),
+                    colors = CheckboxDefaults.colors(
+                        checkedColor = DestructiveColor,
+                        uncheckedColor = mainTextColor.copy(alpha = 0.5f),
+                        checkmarkColor = Color.White
+                    )
+                )
+                AppIconView(app, modifier = Modifier.size(40.dp))
+                Spacer(modifier = Modifier.width(16.dp))
+                Text(
+                    app.label,
+                    color = mainTextColor,
+                    fontSize = 16.sp,
+                    modifier = Modifier.weight(1f)
+                )
+                IconButton(
+                    onClick = onRequestUninstall,
+                    modifier = Modifier.testTag("uninstall_button_${app.packageName}")
+                ) {
+                    Icon(Lucide.Trash2, contentDescription = "Deinstallieren", tint = DestructiveColor, modifier = Modifier.size(22.dp))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/UninstallAppsMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/UninstallAppsMenu.kt
@@ -33,6 +33,8 @@ import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalFontWeight
 import com.example.androidlauncher.ui.theme.LocalLiquidGlassEnabled
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /** Akzentfarbe für destruktive Aktionen (wie in [IconConfigMenu]). */
@@ -58,9 +60,11 @@ private val DestructiveColor = Color(0xFFEF5350)
 @Composable
 fun UninstallAppsMenu(
     apps: List<AppInfo>,
+    onRefreshApps: (String?) -> Unit,
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val isLiquidGlassEnabled = LocalLiquidGlassEnabled.current
     val fontWeight = LocalFontWeight.current
@@ -136,10 +140,16 @@ fun UninstallAppsMenu(
         processNext()
     }
 
-    // Nach Rückkehr aus dem System-Dialog das nächste Paket abarbeiten.
+    // Nach Rückkehr aus dem System-Dialog das nächste Paket abarbeiten und die
+    // App-Liste aktualisieren (entfernt das gerade deinstallierte Paket).
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         if (awaitingResume) {
+            val justAttempted = uninstallQueue.firstOrNull()
             uninstallQueue = uninstallQueue.drop(1)
+            scope.launch {
+                delay(500) // System die Deinstallation abschließen lassen
+                onRefreshApps(justAttempted)
+            }
             processNext()
         }
     }


### PR DESCRIPTION
## Beschreibung

Im Bearbeitungsmenü soll ein neuer Bereich hinzugefügt werden, über den Nutzer installierte Apps direkt vom Gerät deinstallieren können. Die Auswahl soll sowohl einzeln (per Swipe oder Button) als auch mehrfach (per Checkboxen) möglich sein.

---

## Erwartetes Verhalten

### Einzeln deinstallieren
Swipe auf eine App oder Tippen auf einen Löschen-Button löst die Deinstallation für genau diese eine App aus.

### Mehrere deinstallieren
Checkboxen bei jeder App ermöglichen die Mehrfachauswahl. Ein „Deinstallieren"-Button entfernt alle gewählten Apps nacheinander.

### Bestätigung
Vor jeder Deinstallation erscheint ein Bestätigungsdialog, um versehentliches Löschen zu verhindern.

---

## Technische Anforderungen

- [x] Neuer Bereich „Apps deinstallieren" im Bearbeitungsmenü
- [x] Einzeldeinstallation per Swipe oder Button
- [x] Mehrfachauswahl per Checkboxen
- [x] Bestätigungsdialog vor jeder Deinstallation
- [x] Deinstallation über Android-System-Intent (ACTION_DELETE)
- [x] App-Liste nach Deinstallation automatisch aktualisieren
- [x] System-Apps nicht deinstallierbar (ausblenden oder deaktivieren)

---

## Akzeptanzkriterien

- [x] Apps können einzeln per Swipe oder Button deinstalliert werden
- [x] Mehrere Apps können gleichzeitig per Checkbox ausgewählt und deinstalliert werden
- [x] Bestätigungsdialog erscheint vor jeder Deinstallation
- [x] App-Liste aktualisiert sich nach der Deinstallation automatisch
- [x] System-Apps können nicht deinstalliert werden
- [x] Kein Build-Fehler nach Umsetzung
- [x] Keine Abstürze oder unerwartetes Verhalten beim Deinstallieren