### PR TITLE
feat: Island Media v2.4 – Seek-Leiste mit clientseitiger Extrapolation

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -1327,6 +1327,7 @@ class MainActivity : ComponentActivity() {
                                     onMediaPlayPause = { dynamicIslandManager.mediaPlayPause() },
                                     onMediaNext = { dynamicIslandManager.mediaNext() },
                                     onMediaPrev = { dynamicIslandManager.mediaPrevious() },
+                                    onMediaSeekTo = { positionMs -> dynamicIslandManager.mediaSeekTo(positionMs) },
                                     islandColor = dynamicIslandColor
                                 )
                             }

--- a/app/src/main/java/com/example/androidlauncher/MediaPlayback.kt
+++ b/app/src/main/java/com/example/androidlauncher/MediaPlayback.kt
@@ -1,0 +1,54 @@
+package com.example.androidlauncher
+
+/**
+ * Wiedergabe-Fortschritt einer MediaSession zum Zeitpunkt der letzten
+ * PlaybackState-Änderung. Die Insel-Karte rechnet die aktuelle Position daraus
+ * **clientseitig** hoch ([extrapolateMediaPositionMs]) – es wird also nicht
+ * gepollt, sondern nur bei State-Änderungen neu gelesen (Island Media v2.4).
+ *
+ * @param positionMs Position zum Zeitpunkt [positionUpdatedAtElapsedMs].
+ * @param durationMs Gesamtlänge (> 0, sonst wird kein Fortschritt angeboten).
+ * @param playbackSpeed Wiedergabegeschwindigkeit (1.0 = normal).
+ * @param positionUpdatedAtElapsedMs Zeitstempel der Positionsmessung in der
+ *        `SystemClock.elapsedRealtime()`-Domäne (wie von PlaybackState geliefert).
+ */
+data class MediaProgress(
+    val positionMs: Long,
+    val durationMs: Long,
+    val playbackSpeed: Float,
+    val positionUpdatedAtElapsedMs: Long,
+)
+
+/**
+ * Rechnet die aktuelle Wiedergabeposition aus dem letzten bekannten Fortschritt
+ * hoch: bei laufender Wiedergabe wächst sie mit `playbackSpeed` seit der letzten
+ * Messung, pausiert bleibt sie stehen. Ergebnis ist auf `0..durationMs` begrenzt.
+ * Reine Logik – ohne Framework unit-testbar.
+ */
+fun extrapolateMediaPositionMs(
+    progress: MediaProgress,
+    isPlaying: Boolean,
+    nowElapsedMs: Long,
+): Long {
+    val base = progress.positionMs
+    val advanced = if (isPlaying) {
+        val elapsed = (nowElapsedMs - progress.positionUpdatedAtElapsedMs).coerceAtLeast(0L)
+        base + (elapsed * progress.playbackSpeed).toLong()
+    } else {
+        base
+    }
+    return advanced.coerceIn(0L, progress.durationMs)
+}
+
+/** Formatiert eine Wiedergabezeit als `m:ss` bzw. `h:mm:ss` (für die Seek-Leiste). */
+fun formatMediaTime(ms: Long): String {
+    val totalSeconds = (ms.coerceAtLeast(0L)) / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+    return if (hours > 0) {
+        "%d:%02d:%02d".format(hours, minutes, seconds)
+    } else {
+        "%d:%02d".format(minutes, seconds)
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/NotificationModels.kt
+++ b/app/src/main/java/com/example/androidlauncher/NotificationModels.kt
@@ -37,11 +37,15 @@ data class TimerInfo(
 
 /**
  * Aktuelle Medienwiedergabe (aus der aktiven MediaSession) für die Dynamic Island.
+ *
+ * @param progress Wiedergabe-Fortschritt für die Seek-Leiste; `null`, wenn die
+ *        Session keine (plausible) Dauer/Position meldet.
  */
 data class MediaInfo(
     val title: String,
     val artist: String,
     val isPlaying: Boolean,
     val art: Bitmap?,
-    val packageName: String
+    val packageName: String,
+    val progress: MediaProgress? = null
 )

--- a/app/src/main/java/com/example/androidlauncher/data/DynamicIslandManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/DynamicIslandManager.kt
@@ -173,7 +173,9 @@ class DynamicIslandManager(
     /** Aktive Medienwiedergabe aus der MediaSession (oder `null`). */
     private val mediaFlow: Flow<IslandContent.Media?> =
         notifications.activeMedia.map { media ->
-            media?.let { IslandContent.Media(it.title, it.artist, it.isPlaying, it.art, it.packageName) }
+            media?.let {
+                IslandContent.Media(it.title, it.artist, it.isPlaying, it.art, it.packageName, it.progress)
+            }
         }
 
     /** Vom Nutzer gewählte „Haupt"-Aktivität (activityId) oder `null` = höchste Priorität. */
@@ -182,6 +184,7 @@ class DynamicIslandManager(
     fun mediaPlayPause() = notifications.mediaPlayPause()
     fun mediaNext() = notifications.mediaNext()
     fun mediaPrevious() = notifications.mediaPrevious()
+    fun mediaSeekTo(positionMs: Long) = notifications.mediaSeekTo(positionMs)
 
     /** Alle aktiven Aktivitäten, prioritätssortiert. */
     private val contentsFlow: Flow<List<IslandContent>> =

--- a/app/src/main/java/com/example/androidlauncher/data/IslandState.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IslandState.kt
@@ -2,6 +2,7 @@ package com.example.androidlauncher.data
 
 import android.app.PendingIntent
 import android.graphics.Bitmap
+import com.example.androidlauncher.MediaProgress
 
 /**
  * Eine einzelne Aktion einer Benachrichtigung (z. B. „Antworten", „Markieren"),
@@ -35,7 +36,9 @@ sealed interface IslandContent {
         val artist: String,
         val isPlaying: Boolean,
         val art: Bitmap? = null,
-        val packageName: String = ""
+        val packageName: String = "",
+        /** Fortschritt für die Seek-Leiste der Karte (`null` = keine Dauer bekannt). */
+        val progress: MediaProgress? = null
     ) : IslandContent
 
     /**

--- a/app/src/main/java/com/example/androidlauncher/data/MediaSessionMonitor.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/MediaSessionMonitor.kt
@@ -8,6 +8,7 @@ import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
 import android.os.Handler
 import com.example.androidlauncher.MediaInfo
+import com.example.androidlauncher.MediaProgress
 
 /**
  * Beobachtet die aktiven MediaSessions und meldet die relevante Wiedergabe als
@@ -115,7 +116,8 @@ class MediaSessionMonitor(
         // Buffering/Skip als „spielend" werten: beim Track-Wechsel durchläuft der Player
         // kurz diese Zustände. Würden sie als Pause gelten, flackerte `isPlaying` und die
         // Insel-Reihenfolge (spielend vs. pausiert) würde springen.
-        val playbackState = active.playbackState?.state
+        val state = active.playbackState
+        val playbackState = state?.state
         val isPlaying = playbackState == PlaybackState.STATE_PLAYING ||
             playbackState == PlaybackState.STATE_BUFFERING ||
             playbackState == PlaybackState.STATE_SKIPPING_TO_NEXT ||
@@ -126,9 +128,29 @@ class MediaSessionMonitor(
                 artist = artist,
                 isPlaying = isPlaying,
                 art = art,
-                packageName = active.packageName ?: ""
+                packageName = active.packageName ?: "",
+                progress = toMediaProgress(state, md)
             ),
             active.transportControls
+        )
+    }
+
+    /**
+     * Baut den Seek-Fortschritt aus PlaybackState + Metadata. `null`, wenn die Session
+     * keine plausible Dauer/Position meldet (dann zeigt die Karte keine Seek-Leiste).
+     */
+    private fun toMediaProgress(state: PlaybackState?, metadata: MediaMetadata?): MediaProgress? {
+        if (state == null) return null
+        val durationMs = metadata?.getLong(MediaMetadata.METADATA_KEY_DURATION) ?: 0L
+        val positionMs = state.position
+        if (durationMs <= 0L || positionMs < 0L) return null
+        return MediaProgress(
+            positionMs = positionMs.coerceAtMost(durationMs),
+            durationMs = durationMs,
+            // 0 (z. B. bei Pause von manchen Playern gemeldet) als Normal-Tempo werten,
+            // damit die Extrapolation nach dem Fortsetzen nicht stehen bleibt.
+            playbackSpeed = state.playbackSpeed.takeIf { it > 0f } ?: 1f,
+            positionUpdatedAtElapsedMs = state.lastPositionUpdateTime,
         )
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/data/NotificationStateStore.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/NotificationStateStore.kt
@@ -78,6 +78,11 @@ class NotificationStateStore {
     fun mediaPrevious() {
         transportControls?.skipToPrevious()
     }
+
+    /** Springt in der aktiven Wiedergabe an die gewünschte Position (Seek-Leiste der Karte). */
+    fun mediaSeekTo(positionMs: Long) {
+        transportControls?.seekTo(positionMs.coerceAtLeast(0L))
+    }
 }
 
 /**

--- a/app/src/main/java/com/example/androidlauncher/ui/IslandExpandedCard.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/IslandExpandedCard.kt
@@ -1,5 +1,6 @@
 package com.example.androidlauncher.ui
 
+import android.os.SystemClock
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.SizeTransform
@@ -22,6 +23,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -39,6 +41,8 @@ import androidx.compose.material.icons.rounded.SkipNext
 import androidx.compose.material.icons.rounded.SkipPrevious
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.SliderDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -55,6 +59,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -63,8 +68,11 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.example.androidlauncher.MediaProgress
 import com.example.androidlauncher.data.IslandContent
 import com.example.androidlauncher.data.NotificationAction
+import com.example.androidlauncher.extrapolateMediaPositionMs
+import com.example.androidlauncher.formatMediaTime
 import com.example.androidlauncher.isPauseActionTitle
 import com.example.androidlauncher.isResumeActionTitle
 import com.example.androidlauncher.ui.theme.LocalAnimationSpeed
@@ -73,6 +81,7 @@ import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.RethroneShapes
 import com.example.androidlauncher.ui.theme.RethroneSprings
+import kotlinx.coroutines.delay
 
 /**
  * Bündelt die aus dem App-Theme abgeleiteten Farben der Insel-Karte, damit die Unterkarten
@@ -126,6 +135,7 @@ fun IslandExpandedCard(
     onMediaPlayPause: () -> Unit = {},
     onMediaNext: () -> Unit = {},
     onMediaPrev: () -> Unit = {},
+    onMediaSeekTo: (Long) -> Unit = {},
     islandColor: Color = Color(0xFF0B0B0C)
 ) {
     val colors = rememberIslandCardColors(islandColor)
@@ -235,7 +245,8 @@ fun IslandExpandedCard(
                 Column {
                     when (c) {
                         is IslandContent.Notification -> NotificationCard(c, colors, onAction, onReply)
-                        is IslandContent.Media -> MediaCard(c, colors, onMediaPlayPause, onMediaNext, onMediaPrev)
+                        is IslandContent.Media ->
+                            MediaCard(c, colors, onMediaPlayPause, onMediaNext, onMediaPrev, onMediaSeekTo)
                         is IslandContent.Timer -> TimerCard(c, colors, onTimerControl)
                         is IslandContent.Battery -> SimpleCard(
                             if (c.charging) "Wird geladen" else "Netzteil getrennt",
@@ -470,17 +481,21 @@ private fun MediaCard(
     colors: IslandCardColors,
     onPlayPause: () -> Unit,
     onNext: () -> Unit,
-    onPrev: () -> Unit
+    onPrev: () -> Unit,
+    onSeekTo: (Long) -> Unit
 ) {
+    // Cover-Slot konstant halten: Beim Track-Wechsel kommt das neue Album-Bitmap
+    // asynchron (kurzzeitig null) nach. Würde das Bild bedingt gerendert, schrumpft
+    // und wächst die Karte – die Größen-Animation des umschließenden AnimatedContent
+    // staucht/clippt dann den Inhalt für ein paar Frames. Letztes Cover puffern und
+    // immer eine 56.dp-Box (Bild oder Platzhalter) zeichnen.
+    var lastArt by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    if (content.art != null) lastArt = content.art
+    val art = content.art ?: lastArt
+    // Album-Akzent: dominanter Farbton des Covers (1×1-Downscale), zur Lesbarkeit mit
+    // der Kartentextfarbe aufgehellt/abgedunkelt. Ohne Cover bleibt der Theme-Akzent.
+    val albumAccent = remember(art, colors) { art?.dominantColor()?.readableOn(colors) ?: colors.accent }
     Row(verticalAlignment = Alignment.CenterVertically) {
-        // Cover-Slot konstant halten: Beim Track-Wechsel kommt das neue Album-Bitmap
-        // asynchron (kurzzeitig null) nach. Würde das Bild bedingt gerendert, schrumpft
-        // und wächst die Karte – die Größen-Animation des umschließenden AnimatedContent
-        // staucht/clippt dann den Inhalt für ein paar Frames. Letztes Cover puffern und
-        // immer eine 56.dp-Box (Bild oder Platzhalter) zeichnen.
-        var lastArt by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
-        if (content.art != null) lastArt = content.art
-        val art = content.art ?: lastArt
         val bmp = remember(art) { art?.asImageBitmap() }
         Box(
             modifier = Modifier
@@ -519,6 +534,15 @@ private fun MediaCard(
             }
         }
     }
+    content.progress?.let { progress ->
+        MediaSeekBar(
+            progress = progress,
+            isPlaying = content.isPlaying,
+            colors = colors,
+            accent = albumAccent,
+            onSeekTo = onSeekTo
+        )
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -531,10 +555,98 @@ private fun MediaCard(
             if (content.isPlaying) Icons.Rounded.Pause else Icons.Rounded.PlayArrow,
             colors,
             onPlayPause,
-            emphasized = true
+            emphasized = true,
+            accent = albumAccent
         )
         TransportButton(Icons.Rounded.SkipNext, colors, onNext)
     }
+}
+
+/**
+ * Seek-Leiste der Media-Karte (Island Media v2.4). Die angezeigte Position wird
+ * **clientseitig** aus dem letzten PlaybackState hochgerechnet
+ * ([extrapolateMediaPositionMs]) – getickt wird nur, solange die Karte offen ist
+ * und Wiedergabe läuft; die Session selbst wird nicht gepollt. Während des
+ * Ziehens gewinnt die Finger-Position; losgelassen wird via [onSeekTo] gesprungen.
+ */
+@Composable
+private fun MediaSeekBar(
+    progress: MediaProgress,
+    isPlaying: Boolean,
+    colors: IslandCardColors,
+    accent: Color,
+    onSeekTo: (Long) -> Unit
+) {
+    // Tick nur bei offener Karte + laufender Wiedergabe (Composable verlässt die
+    // Composition beim Schließen → Coroutine endet automatisch).
+    var nowElapsedMs by remember { mutableStateOf(SystemClock.elapsedRealtime()) }
+    LaunchedEffect(progress, isPlaying) {
+        nowElapsedMs = SystemClock.elapsedRealtime()
+        while (isPlaying) {
+            delay(500L)
+            nowElapsedMs = SystemClock.elapsedRealtime()
+        }
+    }
+    val livePositionMs = extrapolateMediaPositionMs(progress, isPlaying, nowElapsedMs)
+
+    // Während des Ziehens zeigt die Leiste die Finger-Position statt der Live-Zeit.
+    var dragPositionMs by remember { mutableStateOf<Long?>(null) }
+    val shownMs = dragPositionMs ?: livePositionMs
+
+    Column(modifier = Modifier.fillMaxWidth().padding(top = 12.dp)) {
+        Slider(
+            value = shownMs.toFloat(),
+            onValueChange = { dragPositionMs = it.toLong() },
+            onValueChangeFinished = {
+                dragPositionMs?.let(onSeekTo)
+                dragPositionMs = null
+            },
+            valueRange = 0f..progress.durationMs.toFloat(),
+            colors = SliderDefaults.colors(
+                thumbColor = accent,
+                activeTrackColor = accent,
+                inactiveTrackColor = colors.text.copy(alpha = 0.15f)
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(24.dp)
+        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = formatMediaTime(shownMs),
+                color = colors.subText,
+                style = MaterialTheme.typography.labelSmall
+            )
+            Text(
+                text = formatMediaTime(progress.durationMs),
+                color = colors.subText,
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
+    }
+}
+
+/** Dominanter Farbton eines Covers via 1×1-Downscale (billig, ohne Palette-Abhängigkeit). */
+private fun android.graphics.Bitmap.dominantColor(): Color = try {
+    val pixel = android.graphics.Bitmap.createScaledBitmap(this, 1, 1, true).getPixel(0, 0)
+    Color(pixel)
+} catch (_: Exception) {
+    Color.Unspecified
+}
+
+/**
+ * Macht den Album-Akzent auf der Kartenfläche lesbar: zu dunkle/zu helle Töne werden
+ * Richtung Kartentextfarbe gemischt; `Unspecified` fällt auf den Theme-Akzent zurück.
+ */
+private fun Color.readableOn(colors: IslandCardColors): Color {
+    if (this == Color.Unspecified) return colors.accent
+    val cardIsDark = colors.surface.luminance() <= 0.5f
+    val tooDim = cardIsDark && luminance() < 0.25f
+    val tooBright = !cardIsDark && luminance() > 0.75f
+    return if (tooDim || tooBright) lerp(this, colors.text, 0.5f) else this
 }
 
 /**
@@ -547,13 +659,14 @@ private fun TransportButton(
     icon: androidx.compose.ui.graphics.vector.ImageVector,
     colors: IslandCardColors,
     onClick: () -> Unit,
-    emphasized: Boolean = false
+    emphasized: Boolean = false,
+    accent: Color = colors.accent
 ) {
     Box(
         modifier = Modifier
             .size(50.dp)
             .clip(CircleShape)
-            .then(if (emphasized) Modifier.background(colors.accent.copy(alpha = 0.16f)) else Modifier)
+            .then(if (emphasized) Modifier.background(accent.copy(alpha = 0.16f)) else Modifier)
             .clickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = null,
@@ -564,7 +677,7 @@ private fun TransportButton(
         Icon(
             icon,
             contentDescription = null,
-            tint = if (emphasized) colors.accent else colors.text,
+            tint = if (emphasized) accent else colors.text,
             modifier = Modifier.size(32.dp)
         )
     }

--- a/app/src/test/java/com/example/androidlauncher/MediaPlaybackTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/MediaPlaybackTest.kt
@@ -1,0 +1,58 @@
+package com.example.androidlauncher
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests der clientseitigen Positions-Extrapolation der Media-Seek-Leiste
+ * (Island Media v2.4): kein Polling – die Position wird aus dem letzten
+ * PlaybackState hochgerechnet.
+ */
+class MediaPlaybackTest {
+
+    private fun progress(
+        positionMs: Long = 30_000L,
+        durationMs: Long = 180_000L,
+        speed: Float = 1f,
+        updatedAtMs: Long = 100_000L,
+    ) = MediaProgress(positionMs, durationMs, speed, updatedAtMs)
+
+    @Test
+    fun `playing position advances with elapsed time`() {
+        val p = progress()
+        assertEquals(35_000L, extrapolateMediaPositionMs(p, isPlaying = true, nowElapsedMs = 105_000L))
+    }
+
+    @Test
+    fun `playback speed scales the advance`() {
+        val p = progress(speed = 2f)
+        assertEquals(40_000L, extrapolateMediaPositionMs(p, isPlaying = true, nowElapsedMs = 105_000L))
+    }
+
+    @Test
+    fun `paused position stays at the last known value`() {
+        val p = progress()
+        assertEquals(30_000L, extrapolateMediaPositionMs(p, isPlaying = false, nowElapsedMs = 500_000L))
+    }
+
+    @Test
+    fun `position is clamped to the duration`() {
+        val p = progress(positionMs = 179_000L)
+        assertEquals(180_000L, extrapolateMediaPositionMs(p, isPlaying = true, nowElapsedMs = 200_000L))
+    }
+
+    @Test
+    fun `clock skew backwards does not rewind the position`() {
+        val p = progress()
+        // now < letzter Update-Zeitpunkt (z. B. Race beim State-Wechsel) → Basisposition halten.
+        assertEquals(30_000L, extrapolateMediaPositionMs(p, isPlaying = true, nowElapsedMs = 99_000L))
+    }
+
+    @Test
+    fun `formatMediaTime renders minutes and hours`() {
+        assertEquals("0:07", formatMediaTime(7_000L))
+        assertEquals("3:05", formatMediaTime(185_000L))
+        assertEquals("1:01:05", formatMediaTime(3_665_000L))
+        assertEquals("0:00", formatMediaTime(-500L))
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/MediaSessionMonitorTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/MediaSessionMonitorTest.kt
@@ -31,19 +31,34 @@ class MediaSessionMonitorTest {
         onMediaChanged = { media, controls -> received += media to controls },
     )
 
+    /** Gestubbter Wiedergabe-Fortschritt für [controller]. */
+    private data class ProgressStub(
+        val positionMs: Long = -1L,
+        val durationMs: Long = 0L,
+        val speed: Float = 0f,
+        val updatedAtMs: Long = 0L,
+    )
+
     private fun controller(
         state: Int,
         title: String = "Song",
         artist: String = "Artist",
         pkg: String = "com.music",
         token: MediaSession.Token = mockk(),
+        progress: ProgressStub = ProgressStub(),
     ): MediaController = mockk(relaxed = true) {
-        every { playbackState } returns mockk { every { this@mockk.state } returns state }
+        every { playbackState } returns mockk(relaxed = true) {
+            every { this@mockk.state } returns state
+            every { position } returns progress.positionMs
+            every { playbackSpeed } returns progress.speed
+            every { lastPositionUpdateTime } returns progress.updatedAtMs
+        }
         every { sessionToken } returns token
         every { packageName } returns pkg
         every { metadata } returns mockk(relaxed = true) {
             every { getString(MediaMetadata.METADATA_KEY_TITLE) } returns title
             every { getString(MediaMetadata.METADATA_KEY_ARTIST) } returns artist
+            every { getLong(MediaMetadata.METADATA_KEY_DURATION) } returns progress.durationMs
             every { getBitmap(any()) } returns null
         }
     }
@@ -83,6 +98,53 @@ class MediaSessionMonitorTest {
         val media = received.last().first
         assertEquals("Podcast", media?.title)
         assertEquals(false, media?.isPlaying)
+    }
+
+    @Test
+    fun `progress is mapped from playback state and metadata duration`() {
+        val playing = controller(
+            PlaybackState.STATE_PLAYING,
+            progress = ProgressStub(positionMs = 42_000L, durationMs = 180_000L, speed = 1.5f, updatedAtMs = 99_000L),
+        )
+        every { msm.getActiveSessions(any()) } returns listOf(playing)
+
+        monitor.recomputeMedia()
+
+        val progress = received.last().first?.progress
+        assertEquals(42_000L, progress?.positionMs)
+        assertEquals(180_000L, progress?.durationMs)
+        assertEquals(1.5f, progress?.playbackSpeed)
+        assertEquals(99_000L, progress?.positionUpdatedAtElapsedMs)
+    }
+
+    @Test
+    fun `missing duration or position yields no progress`() {
+        // Session ohne Dauer (z. B. Livestream) → keine Seek-Leiste.
+        val noDuration =
+            controller(PlaybackState.STATE_PLAYING, progress = ProgressStub(positionMs = 10_000L, durationMs = 0L))
+        every { msm.getActiveSessions(any()) } returns listOf(noDuration)
+        monitor.recomputeMedia()
+        assertNull(received.last().first?.progress)
+
+        // Unbekannte Position → ebenfalls keine Seek-Leiste.
+        val noPosition =
+            controller(PlaybackState.STATE_PLAYING, progress = ProgressStub(positionMs = -1L, durationMs = 180_000L))
+        every { msm.getActiveSessions(any()) } returns listOf(noPosition)
+        monitor.recomputeMedia()
+        assertNull(received.last().first?.progress)
+    }
+
+    @Test
+    fun `zero playback speed falls back to normal tempo`() {
+        val paused = controller(
+            PlaybackState.STATE_PLAYING,
+            progress = ProgressStub(positionMs = 1_000L, durationMs = 60_000L, speed = 0f),
+        )
+        every { msm.getActiveSessions(any()) } returns listOf(paused)
+
+        monitor.recomputeMedia()
+
+        assertEquals(1f, received.last().first?.progress?.playbackSpeed)
     }
 
     @Test


### PR DESCRIPTION
## Was dieser PR macht

Erweitert die Media-Karte der Dynamic Island um eine Seek-Leiste mit Seek-to und Album-Akzentfarbe (Plan-Item B2, „Media v2.4"). Baut direkt auf dem in #114 extrahierten `MediaSessionMonitor` auf.

## Änderungen

- **`MediaPlayback.kt`**: `MediaProgress`-Modell + pure Extrapolations-Funktion — die aktuelle Position wird clientseitig aus dem letzten `PlaybackState` hochgerechnet (Position + `playbackSpeed` + `lastPositionUpdateTime`). **Die Session wird nicht gepollt**; neu gelesen wird nur bei State-Änderungen.
- **`MediaSessionMonitor`** liefert den Fortschritt mit (`null` bei fehlender Dauer, z. B. Livestreams → keine Leiste; gemeldetes Tempo 0 wird als Normaltempo gewertet, damit die Anzeige nach dem Fortsetzen nicht stehen bleibt).
- **`NotificationStateStore.mediaSeekTo`** + Durchreichung über `DynamicIslandManager` bis in die Karte.
- **`IslandExpandedCard`/`MediaCard`**: Slider mit Zeit-Labels; der 500-ms-Anzeige-Tick läuft nur bei offener Karte und laufender Wiedergabe (endet mit der Composition). Während des Ziehens gewinnt die Finger-Position, Loslassen springt in der Wiedergabe.
- **Album-Akzentfarbe**: dominanter Cover-Farbton per 1×1-Downscale (keine Palette-Abhängigkeit), zur Lesbarkeit gegen die Kartenfläche gemischt; färbt Seek-Leiste und Play/Pause-Button. Ohne Cover bleibt der Theme-Akzent.
- Insel-Priorität (Timer > Media) unverändert. Das im Plan erwähnte Output-Device-Label ist bewusst nicht enthalten (bräuchte MediaRouter, unklarer Nutzen).

## Für Reviewer

- 10 neue Testfälle: Extrapolation (Speed-Skalierung, Clamping auf Dauer, Pause, Uhr-Rücksprung), Zeitformatierer, Monitor-Mapping der Progress-Felder.
- **Gerätetest empfohlen:** Seek-Leiste mit Spotify/YouTube Music (Position springt korrekt nach Seek? Extrapolation driftet nicht?), Akzentfarbe auf hellen und dunklen Covern, Verhalten bei Livestreams (keine Leiste).
- Gates lokal grün: `detekt`, `testDebugUnitTest`, `koverVerifyDebug`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)