### PR TITLE
refactor: EditConfigMenu von der MainActivity entkoppelt (A8)

### DIFF
--- a/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
+++ b/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
@@ -7,18 +7,23 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.example.androidlauncher.data.AppAccessMode
+import androidx.compose.ui.geometry.Offset
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.AutoIconRuleMode
-import com.example.androidlauncher.data.IslandAnimationStyle
+import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.settings.HomeLayoutSettings
 import com.example.androidlauncher.ui.AppDrawer
 import com.example.androidlauncher.ui.EditConfigMenu
 import com.example.androidlauncher.ui.HomeScreen
 import com.example.androidlauncher.ui.IconConfigMenu
+import com.example.androidlauncher.ui.home.EditConfigActions
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
+import javax.inject.Inject
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
@@ -35,6 +40,9 @@ class LauncherComposableUiTest {
 
     @get:Rule(order = 1)
     val composeRule = createAndroidComposeRule<DebugComposeHostActivity>()
+
+    @Inject
+    lateinit var homeLayoutSettings: HomeLayoutSettings
 
     @Test
     fun homeScreen_rendersCoreControls() {
@@ -125,108 +133,48 @@ class LauncherComposableUiTest {
     }
 
     // TODO Emulator-Verifikation noetig: 'edit_home_layout_reset' liegt in einer LazyColumn und ist
-    // bei isCustomHomeLayoutSet=true zwar komponiert, aber evtl. ausserhalb des Viewports. Fix:
+    // bei gesetztem Custom-Layout zwar komponiert, aber evtl. ausserhalb des Viewports. Fix:
     // LazyColumn einen testTag geben und performScrollToNode(hasTestTag("edit_home_layout_reset"))
     // vor assertIsDisplayed()/performClick() nutzen. Reaktivieren nach Emulator-Check.
     @Ignore("LazyColumn-Scroll noetig (performScrollToNode) – mit Emulator verifizieren, dann reaktivieren")
     @Test
     fun editConfigMenu_showsHomeLayoutResetWhenCustomLayoutIsSet() {
-        var wasHomeLayoutReset = false
+        // A8: Das Menue versorgt sich selbst aus den Settings-Stores -> Custom-Layout
+        // direkt im injizierten Store setzen statt per Parameter.
+        hiltRule.inject()
+        runBlocking { homeLayoutSettings.setHomeLayout(HomeLayout(clock = Offset(24f, 0f))) }
 
         composeRule.setContent {
             AndroidLauncherTheme {
-                EditConfigMenu(
-                    onOpenHomeLayoutEdit = {},
-                    onResetHomeLayout = { wasHomeLayoutReset = true },
-                    onOpenIconConfig = {},
-                    onOpenUninstallApps = {},
-                    onOpenHiddenApps = {},
-                    onOpenAppLock = {},
-                    onOpenDefaultLauncher = {},
-                    onChangeWallpaper = {},
-                    onResetWallpaper = {},
-                    onOpenWallpaperAdjust = {},
-                    isCustomHomeLayoutSet = true,
-                    isCustomWallpaperSet = false,
-                    onOpenGesturesConfig = {},
-                    isSmartSuggestionsEnabled = false,
-                    onSmartSuggestionsToggled = {},
-                    isAnimationsEnabled = true,
-                    onAnimationsToggled = {},
-                    onOpenAnimationsConfig = {},
-                    isWeatherWidgetEnabled = false,
-                    onWeatherWidgetToggled = {},
-                    isClockWidgetEnabled = true,
-                    onClockWidgetToggled = {},
-                    isCalendarWidgetEnabled = false,
-                    onCalendarWidgetToggled = {},
-                    isDynamicIslandEnabled = true,
-                    onDynamicIslandToggled = {},
-                    islandAnimationStyle = IslandAnimationStyle.FROM_NOTCH,
-                    onIslandAnimationStyleChange = {},
-                    isEdgeLightingEnabled = false,
-                    onOpenEdgeLightingConfig = {},
-                    appAccessMode = AppAccessMode.HOME_LIST,
-                    onAppAccessModeChange = {},
-                    onClearSearchHistory = {},
-                    isHapticFeedbackEnabled = true,
-                    onHapticFeedbackToggled = {},
-                    onClose = {}
-                )
+                EditConfigMenu(actions = NoopEditConfigActions)
             }
         }
 
         composeRule.onNodeWithTag("edit_home_layout_reset").assertIsDisplayed().performClick()
-        assertEquals(true, wasHomeLayoutReset)
+        // Reset laeuft jetzt ueber das EditConfigViewModel -> im Store verifizieren.
+        composeRule.waitUntil(3_000) {
+            runBlocking { homeLayoutSettings.homeLayout.first() } == HomeLayout()
+        }
     }
 
     @Test
     fun editConfigMenu_hidesHomeLayoutResetWhenLayoutIsDefault() {
+        hiltRule.inject()
+        runBlocking { homeLayoutSettings.setHomeLayout(HomeLayout()) }
+
         composeRule.setContent {
             AndroidLauncherTheme {
-                EditConfigMenu(
-                    onOpenHomeLayoutEdit = {},
-                    onResetHomeLayout = {},
-                    onOpenIconConfig = {},
-                    onOpenUninstallApps = {},
-                    onOpenHiddenApps = {},
-                    onOpenAppLock = {},
-                    onOpenDefaultLauncher = {},
-                    onChangeWallpaper = {},
-                    onResetWallpaper = {},
-                    onOpenWallpaperAdjust = {},
-                    isCustomHomeLayoutSet = false,
-                    isCustomWallpaperSet = false,
-                    onOpenGesturesConfig = {},
-                    isSmartSuggestionsEnabled = false,
-                    onSmartSuggestionsToggled = {},
-                    isAnimationsEnabled = true,
-                    onAnimationsToggled = {},
-                    onOpenAnimationsConfig = {},
-                    isWeatherWidgetEnabled = false,
-                    onWeatherWidgetToggled = {},
-                    isClockWidgetEnabled = true,
-                    onClockWidgetToggled = {},
-                    isCalendarWidgetEnabled = false,
-                    onCalendarWidgetToggled = {},
-                    isDynamicIslandEnabled = true,
-                    onDynamicIslandToggled = {},
-                    islandAnimationStyle = IslandAnimationStyle.FROM_NOTCH,
-                    onIslandAnimationStyleChange = {},
-                    isEdgeLightingEnabled = false,
-                    onOpenEdgeLightingConfig = {},
-                    appAccessMode = AppAccessMode.HOME_LIST,
-                    onAppAccessModeChange = {},
-                    onClearSearchHistory = {},
-                    isHapticFeedbackEnabled = true,
-                    onHapticFeedbackToggled = {},
-                    onClose = {}
-                )
+                EditConfigMenu(actions = NoopEditConfigActions)
             }
         }
 
         composeRule.waitUntil(3_000) {
             composeRule.onAllNodesWithTag("edit_home_layout_reset").fetchSemanticsNodes().isEmpty()
         }
+    }
+
+    private object NoopEditConfigActions : EditConfigActions {
+        override fun openDefaultLauncherPrompt() = Unit
+        override fun pickWallpaper() = Unit
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -79,7 +79,6 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
-import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -140,6 +139,7 @@ import com.example.androidlauncher.ui.WallpaperConfigMenu
 import com.example.androidlauncher.ui.WallpaperCropScreen
 import com.example.androidlauncher.ui.expandNotifications
 import com.example.androidlauncher.ui.home.ActiveOverlay
+import com.example.androidlauncher.ui.home.EditConfigActions
 import com.example.androidlauncher.ui.home.HomeViewModel
 import com.example.androidlauncher.ui.home.rememberLaunchTransitionState
 import com.example.androidlauncher.ui.launchAppNoTransition
@@ -1504,117 +1504,21 @@ class MainActivity : ComponentActivity() {
                         customWallpaperUri = customWallpaperUri,
                         onClose = { homeViewModel.closeOverlay() }
                     ) {
-                        EditConfigMenu(
-                            onOpenHomeLayoutEdit = {
-                                homeViewModel.closeOverlay()
-                                homeViewModel.setHomeEditMode(true)
-                            },
-                            onResetHomeLayout = {
-                                scope.launch {
-                                    themeManager.setHomeLayout(HomeLayout())
+                        // A8-Split: Navigation + Einstellungen holt sich das Menü selbst
+                        // (HomeViewModel/EditConfigViewModel); hier bleiben nur die Effekte,
+                        // die die Activity braucht (ActivityResult-Launcher).
+                        val editConfigActions = remember {
+                            object : EditConfigActions {
+                                override fun openDefaultLauncherPrompt() = requestDefaultLauncher()
+
+                                override fun pickWallpaper() {
+                                    wallpaperPickerLauncher.launch(
+                                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                    )
                                 }
-                                Toast.makeText(
-                                    context,
-                                    context.getString(R.string.home_layout_reset),
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            },
-                            onOpenIconConfig = { homeViewModel.openOverlay(ActiveOverlay.IconConfig) },
-                            onOpenUninstallApps = { homeViewModel.openOverlay(ActiveOverlay.UninstallApps) },
-                            onOpenHiddenApps = { homeViewModel.openOverlay(ActiveOverlay.HiddenApps) },
-                            onOpenAppLock = { homeViewModel.openOverlay(ActiveOverlay.AppLock) },
-                            onOpenDefaultLauncher = { requestDefaultLauncher() },
-                            onChangeWallpaper = {
-                                homeViewModel.closeOverlay()
-                                wallpaperPickerLauncher.launch(
-                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                )
-                            },
-                            onResetWallpaper = {
-                                scope.launch {
-                                    themeManager.setCustomWallpaperUri(null)
-                                    themeManager.setWallpaperBlur(0f)
-                                    themeManager.setWallpaperDim(0.1f)
-                                    themeManager.setWallpaperZoom(1.0f)
-                                }
-                                Toast.makeText(
-                                    context,
-                                    context.getString(R.string.wallpaper_removed),
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            },
-                            onOpenWallpaperAdjust = { homeViewModel.openOverlay(ActiveOverlay.WallpaperConfig) },
-                            isCustomHomeLayoutSet =
-                            abs(homeLayout.clock.x) > 0.5f || abs(homeLayout.clock.y) > 0.5f ||
-                                abs(homeLayout.date.x) > 0.5f || abs(homeLayout.date.y) > 0.5f ||
-                                abs(homeLayout.weather.x) > 0.5f || abs(homeLayout.weather.y) > 0.5f ||
-                                abs(homeLayout.favorites.x) > 0.5f || abs(homeLayout.favorites.y) > 0.5f,
-                            isCustomWallpaperSet = customWallpaperUri != null,
-                            onOpenGesturesConfig = { homeViewModel.openOverlay(ActiveOverlay.GesturesConfig) },
-                            isSmartSuggestionsEnabled = isSmartSuggestionsEnabled,
-                            onSmartSuggestionsToggled = { enabled ->
-                                scope.launch { themeManager.setSmartSuggestionsEnabled(enabled) }
-                            },
-                            isAnimationsEnabled = isAnimationsEnabled,
-                            onAnimationsToggled = { enabled ->
-                                scope.launch { themeManager.setAnimationsEnabled(enabled) }
-                            },
-                            onOpenAnimationsConfig = { homeViewModel.openOverlay(ActiveOverlay.AnimationsConfig) },
-                            isWeatherWidgetEnabled = isWeatherWidgetEnabled,
-                            onWeatherWidgetToggled = { enabled ->
-                                scope.launch { themeManager.setWeatherWidgetEnabled(enabled) }
-                            },
-                            isClockWidgetEnabled = isClockWidgetEnabled,
-                            onClockWidgetToggled = { enabled ->
-                                scope.launch { themeManager.setClockWidgetEnabled(enabled) }
-                            },
-                            isCalendarWidgetEnabled = isCalendarWidgetEnabled,
-                            onCalendarWidgetToggled = { enabled ->
-                                scope.launch { themeManager.setCalendarWidgetEnabled(enabled) }
-                            },
-                            isDynamicIslandEnabled = isDynamicIslandEnabled,
-                            onDynamicIslandToggled = { enabled ->
-                                scope.launch { themeManager.setDynamicIslandEnabled(enabled) }
-                            },
-                            islandAnimationStyle = islandAnimationStyle,
-                            onIslandAnimationStyleChange = { style ->
-                                scope.launch { themeManager.setIslandAnimationStyle(style) }
-                            },
-                            isEdgeLightingEnabled = isEdgeLightingEnabled,
-                            onOpenEdgeLightingConfig = { homeViewModel.openOverlay(ActiveOverlay.EdgeLightingConfig) },
-                            appAccessMode = appAccessMode,
-                            onAppAccessModeChange = { mode ->
-                                scope.launch { themeManager.setAppAccessMode(mode) }
-                            },
-                            onClearSearchHistory = {
-                                scope.launch { searchSuggestionsManager.clearWebHistory() }
-                                Toast.makeText(
-                                    context,
-                                    context.getString(R.string.search_history_cleared),
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            },
-                            isHapticFeedbackEnabled = isHapticFeedbackEnabled,
-                            onHapticFeedbackToggled = { enabled ->
-                                scope.launch {
-                                    if (Settings.System.canWrite(context)) {
-                                        themeManager.setHapticFeedbackEnabled(enabled)
-                                    } else {
-                                        val writeSettingsIntent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
-                                            data = ("package:" + context.packageName).toUri()
-                                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                                        }
-                                        context.startActivity(writeSettingsIntent)
-                                        Toast.makeText(
-                                            context,
-                                            context.getString(R.string.write_settings_permission_required),
-                                            Toast.LENGTH_LONG
-                                        ).show()
-                                    }
-                                }
-                            },
-                            onClose = { homeViewModel.closeOverlay() }
-                        )
+                            }
+                        }
+                        EditConfigMenu(actions = editConfigActions)
                     }
 
                     // Untermenü der Animationen – nach dem Edit-Menü komponiert, damit es

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -1,5 +1,8 @@
 package com.example.androidlauncher.ui
 
+import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -16,6 +19,7 @@ import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -28,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.core.net.toUri
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
 import com.composables.icons.lucide.Ban
@@ -68,6 +73,10 @@ import com.example.androidlauncher.isNotificationServiceEnabled
 import com.example.androidlauncher.openAccessibilitySettings
 import com.example.androidlauncher.openNotificationSettings
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
+import com.example.androidlauncher.ui.home.ActiveOverlay
+import com.example.androidlauncher.ui.home.EditConfigActions
+import com.example.androidlauncher.ui.home.EditConfigViewModel
+import com.example.androidlauncher.ui.home.HomeViewModel
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalDesignStyle
@@ -77,44 +86,89 @@ import com.example.androidlauncher.ui.theme.LocalDesignStyle
  */
 @Composable
 fun EditConfigMenu(
-    onOpenHomeLayoutEdit: () -> Unit,
-    onResetHomeLayout: () -> Unit,
-    onOpenIconConfig: () -> Unit,
-    onOpenUninstallApps: () -> Unit,
-    onOpenHiddenApps: () -> Unit,
-    onOpenAppLock: () -> Unit,
-    onOpenDefaultLauncher: () -> Unit,
-    onChangeWallpaper: () -> Unit,
-    onResetWallpaper: () -> Unit,
-    onOpenWallpaperAdjust: () -> Unit,
-    isCustomHomeLayoutSet: Boolean,
-    isCustomWallpaperSet: Boolean,
-    onOpenGesturesConfig: () -> Unit,
-    isSmartSuggestionsEnabled: Boolean,
-    onSmartSuggestionsToggled: (Boolean) -> Unit,
-    isAnimationsEnabled: Boolean,
-    onAnimationsToggled: (Boolean) -> Unit,
-    onOpenAnimationsConfig: () -> Unit,
-    isWeatherWidgetEnabled: Boolean,
-    onWeatherWidgetToggled: (Boolean) -> Unit,
-    isClockWidgetEnabled: Boolean,
-    onClockWidgetToggled: (Boolean) -> Unit,
-    isCalendarWidgetEnabled: Boolean,
-    onCalendarWidgetToggled: (Boolean) -> Unit,
-    isDynamicIslandEnabled: Boolean,
-    onDynamicIslandToggled: (Boolean) -> Unit,
-    islandAnimationStyle: IslandAnimationStyle,
-    onIslandAnimationStyleChange: (IslandAnimationStyle) -> Unit,
-    isEdgeLightingEnabled: Boolean,
-    onOpenEdgeLightingConfig: () -> Unit,
-    appAccessMode: AppAccessMode,
-    onAppAccessModeChange: (AppAccessMode) -> Unit,
-    onClearSearchHistory: () -> Unit,
-    isHapticFeedbackEnabled: Boolean,
-    onHapticFeedbackToggled: (Boolean) -> Unit,
-    onClose: () -> Unit
+    actions: EditConfigActions
 ) {
     val context = LocalContext.current
+
+    // A8-Split: Overlay-Navigation direkt über das HomeViewModel (gleiche Activity-
+    // Instanz wie in der MainActivity), Einstellungen über das EditConfigViewModel
+    // aus den A1-Settings-Stores. Die abgeleiteten Locals tragen die früheren
+    // Parameternamen, damit der Menü-Body unverändert bleibt.
+    val homeViewModel: HomeViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+    val editViewModel: EditConfigViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+
+    val onClose = { homeViewModel.closeOverlay() }
+    val onOpenHomeLayoutEdit = {
+        homeViewModel.closeOverlay()
+        homeViewModel.setHomeEditMode(true)
+    }
+    val onOpenIconConfig = { homeViewModel.openOverlay(ActiveOverlay.IconConfig) }
+    val onOpenUninstallApps = { homeViewModel.openOverlay(ActiveOverlay.UninstallApps) }
+    val onOpenHiddenApps = { homeViewModel.openOverlay(ActiveOverlay.HiddenApps) }
+    val onOpenAppLock = { homeViewModel.openOverlay(ActiveOverlay.AppLock) }
+    val onOpenWallpaperAdjust = { homeViewModel.openOverlay(ActiveOverlay.WallpaperConfig) }
+    val onOpenGesturesConfig = { homeViewModel.openOverlay(ActiveOverlay.GesturesConfig) }
+    val onOpenAnimationsConfig = { homeViewModel.openOverlay(ActiveOverlay.AnimationsConfig) }
+    val onOpenEdgeLightingConfig = { homeViewModel.openOverlay(ActiveOverlay.EdgeLightingConfig) }
+    val onOpenDefaultLauncher = { actions.openDefaultLauncherPrompt() }
+    val onChangeWallpaper = {
+        homeViewModel.closeOverlay()
+        actions.pickWallpaper()
+    }
+
+    val isCustomHomeLayoutSet by editViewModel.isCustomHomeLayoutSet.collectAsState(initial = false)
+    val isCustomWallpaperSet by editViewModel.isCustomWallpaperSet.collectAsState(initial = false)
+    val isSmartSuggestionsEnabled by editViewModel.isSmartSuggestionsEnabled.collectAsState(initial = true)
+    val isAnimationsEnabled by editViewModel.isAnimationsEnabled.collectAsState(initial = true)
+    val isWeatherWidgetEnabled by editViewModel.isWeatherWidgetEnabled.collectAsState(initial = true)
+    val isClockWidgetEnabled by editViewModel.isClockWidgetEnabled.collectAsState(initial = true)
+    val isCalendarWidgetEnabled by editViewModel.isCalendarWidgetEnabled.collectAsState(initial = true)
+    val isDynamicIslandEnabled by editViewModel.isDynamicIslandEnabled.collectAsState(initial = true)
+    val islandAnimationStyle by editViewModel.islandAnimationStyle
+        .collectAsState(initial = IslandAnimationStyle.FROM_NOTCH)
+    val isEdgeLightingEnabled by editViewModel.isEdgeLightingEnabled.collectAsState(initial = false)
+    val appAccessMode by editViewModel.appAccessMode.collectAsState(initial = AppAccessMode.DRAWER_LIST)
+    val isHapticFeedbackEnabled by editViewModel.isHapticFeedbackEnabled.collectAsState(initial = true)
+
+    val onSmartSuggestionsToggled: (Boolean) -> Unit = { editViewModel.setSmartSuggestionsEnabled(it) }
+    val onWeatherWidgetToggled: (Boolean) -> Unit = { editViewModel.setWeatherWidgetEnabled(it) }
+    val onClockWidgetToggled: (Boolean) -> Unit = { editViewModel.setClockWidgetEnabled(it) }
+    val onCalendarWidgetToggled: (Boolean) -> Unit = { editViewModel.setCalendarWidgetEnabled(it) }
+    val onDynamicIslandToggled: (Boolean) -> Unit = { editViewModel.setDynamicIslandEnabled(it) }
+    val onIslandAnimationStyleChange: (IslandAnimationStyle) -> Unit =
+        { editViewModel.setIslandAnimationStyle(it) }
+    val onAppAccessModeChange: (AppAccessMode) -> Unit = { editViewModel.setAppAccessMode(it) }
+    val onResetHomeLayout = {
+        editViewModel.resetHomeLayout()
+        Toast.makeText(context, context.getString(R.string.home_layout_reset), Toast.LENGTH_SHORT).show()
+    }
+    val onResetWallpaper = {
+        editViewModel.resetWallpaper()
+        Toast.makeText(context, context.getString(R.string.wallpaper_removed), Toast.LENGTH_SHORT).show()
+    }
+    val onClearSearchHistory = {
+        editViewModel.clearSearchHistory()
+        Toast.makeText(context, context.getString(R.string.search_history_cleared), Toast.LENGTH_SHORT).show()
+    }
+    // Haptik schreibt zusätzlich das System-Setting → ohne WRITE_SETTINGS-Berechtigung
+    // stattdessen den System-Dialog öffnen (Verhalten wie zuvor in der MainActivity).
+    val onHapticFeedbackToggled: (Boolean) -> Unit = { enabled ->
+        if (Settings.System.canWrite(context)) {
+            editViewModel.setHapticFeedbackEnabled(enabled)
+        } else {
+            val writeSettingsIntent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                data = ("package:" + context.packageName).toUri()
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(writeSettingsIntent)
+            Toast.makeText(
+                context,
+                context.getString(R.string.write_settings_permission_required),
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val designStyle = LocalDesignStyle.current
     val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)

--- a/app/src/main/java/com/example/androidlauncher/ui/home/EditConfigViewModel.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/EditConfigViewModel.kt
@@ -1,0 +1,135 @@
+package com.example.androidlauncher.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.androidlauncher.data.AppAccessMode
+import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.IslandAnimationStyle
+import com.example.androidlauncher.data.SearchSuggestionsManager
+import com.example.androidlauncher.data.settings.AnimationSettings
+import com.example.androidlauncher.data.settings.GestureSettings
+import com.example.androidlauncher.data.settings.HomeLayoutSettings
+import com.example.androidlauncher.data.settings.IslandAndEdgeSettings
+import com.example.androidlauncher.data.settings.PrivacySettings
+import com.example.androidlauncher.data.settings.WallpaperSettings
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import kotlin.math.abs
+
+/**
+ * System-Effekte des Einstellungs-Menüs, die nur die Activity ausführen kann
+ * (ActivityResult-Launcher). Bewusst schmal gehalten – Muster: `GestureActionEffects`.
+ */
+interface EditConfigActions {
+    /** Öffnet den System-Dialog „Standard-Launcher festlegen" (ROLE_HOME). */
+    fun openDefaultLauncherPrompt()
+
+    /** Öffnet den Foto-Picker für ein eigenes Wallpaper (Ergebnis → Crop-Flow der Activity). */
+    fun pickWallpaper()
+}
+
+/**
+ * Versorgt das Einstellungs-Menü (`EditConfigMenu`) direkt aus den A1-Settings-Stores
+ * (A8-Split: ersetzt die frühere 37-Parameter-Callback-Verdrahtung über die MainActivity).
+ * Die Overlay-Navigation läuft separat über das [HomeViewModel].
+ */
+@HiltViewModel
+class EditConfigViewModel @Inject constructor(
+    private val homeLayoutSettings: HomeLayoutSettings,
+    private val wallpaperSettings: WallpaperSettings,
+    private val animationSettings: AnimationSettings,
+    private val islandAndEdgeSettings: IslandAndEdgeSettings,
+    private val gestureSettings: GestureSettings,
+    private val privacySettings: PrivacySettings,
+    private val searchSuggestionsManager: SearchSuggestionsManager,
+) : ViewModel() {
+
+    val isSmartSuggestionsEnabled: Flow<Boolean> = homeLayoutSettings.isSmartSuggestionsEnabled
+    val isWeatherWidgetEnabled: Flow<Boolean> = homeLayoutSettings.isWeatherWidgetEnabled
+    val isClockWidgetEnabled: Flow<Boolean> = homeLayoutSettings.isClockWidgetEnabled
+    val isCalendarWidgetEnabled: Flow<Boolean> = homeLayoutSettings.isCalendarWidgetEnabled
+    val isAnimationsEnabled: Flow<Boolean> = animationSettings.isAnimationsEnabled
+    val isDynamicIslandEnabled: Flow<Boolean> = islandAndEdgeSettings.isDynamicIslandEnabled
+    val islandAnimationStyle: Flow<IslandAnimationStyle> = islandAndEdgeSettings.islandAnimationStyle
+    val isEdgeLightingEnabled: Flow<Boolean> = islandAndEdgeSettings.isEdgeLightingEnabled
+    val appAccessMode: Flow<AppAccessMode> = privacySettings.appAccessMode
+    val isHapticFeedbackEnabled: Flow<Boolean> = gestureSettings.isHapticFeedbackEnabled
+
+    /** Ob mindestens ein Startbildschirm-Element manuell verschoben wurde (→ Reset anbieten). */
+    val isCustomHomeLayoutSet: Flow<Boolean> = homeLayoutSettings.homeLayout.map(::hasCustomOffsets)
+
+    /** Ob ein eigenes Wallpaper gesetzt ist (→ Reset anbieten). */
+    val isCustomWallpaperSet: Flow<Boolean> = wallpaperSettings.customWallpaperUri.map { it != null }
+
+    fun setSmartSuggestionsEnabled(enabled: Boolean) {
+        viewModelScope.launch { homeLayoutSettings.setSmartSuggestionsEnabled(enabled) }
+    }
+
+    fun setWeatherWidgetEnabled(enabled: Boolean) {
+        viewModelScope.launch { homeLayoutSettings.setWeatherWidgetEnabled(enabled) }
+    }
+
+    fun setClockWidgetEnabled(enabled: Boolean) {
+        viewModelScope.launch { homeLayoutSettings.setClockWidgetEnabled(enabled) }
+    }
+
+    fun setCalendarWidgetEnabled(enabled: Boolean) {
+        viewModelScope.launch { homeLayoutSettings.setCalendarWidgetEnabled(enabled) }
+    }
+
+    fun setAnimationsEnabled(enabled: Boolean) {
+        viewModelScope.launch { animationSettings.setAnimationsEnabled(enabled) }
+    }
+
+    fun setDynamicIslandEnabled(enabled: Boolean) {
+        viewModelScope.launch { islandAndEdgeSettings.setDynamicIslandEnabled(enabled) }
+    }
+
+    fun setIslandAnimationStyle(style: IslandAnimationStyle) {
+        viewModelScope.launch { islandAndEdgeSettings.setIslandAnimationStyle(style) }
+    }
+
+    fun setAppAccessMode(mode: AppAccessMode) {
+        viewModelScope.launch { privacySettings.setAppAccessMode(mode) }
+    }
+
+    /** Schreibt die Haptik-Einstellung (System-Sync übernimmt der Store, sofern erlaubt). */
+    fun setHapticFeedbackEnabled(enabled: Boolean) {
+        viewModelScope.launch { gestureSettings.setHapticFeedbackEnabled(enabled) }
+    }
+
+    /** Setzt alle verschobenen Startbildschirm-Elemente auf die Standard-Positionen zurück. */
+    fun resetHomeLayout() {
+        viewModelScope.launch { homeLayoutSettings.setHomeLayout(HomeLayout()) }
+    }
+
+    /** Entfernt das eigene Wallpaper samt Blur/Dim/Zoom (zurück zum System-Wallpaper). */
+    fun resetWallpaper() {
+        viewModelScope.launch {
+            wallpaperSettings.setCustomWallpaperUri(null)
+            wallpaperSettings.setWallpaperBlur(0f)
+            wallpaperSettings.setWallpaperDim(0.1f)
+            wallpaperSettings.setWallpaperZoom(1.0f)
+        }
+    }
+
+    fun clearSearchHistory() {
+        viewModelScope.launch { searchSuggestionsManager.clearWebHistory() }
+    }
+
+    companion object {
+        // Ab diesem Versatz gilt ein Element als manuell verschoben (Sub-Pixel-Rauschen ignorieren).
+        private const val OFFSET_EPSILON = 0.5f
+
+        /** Reine Logik: wurde irgendein Home-Element gegenüber dem Standard verschoben? */
+        fun hasCustomOffsets(layout: HomeLayout): Boolean = listOf(
+            layout.clock,
+            layout.date,
+            layout.weather,
+            layout.favorites,
+        ).any { abs(it.x) > OFFSET_EPSILON || abs(it.y) > OFFSET_EPSILON }
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/ui/home/EditConfigViewModelTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/home/EditConfigViewModelTest.kt
@@ -1,0 +1,27 @@
+package com.example.androidlauncher.ui.home
+
+import androidx.compose.ui.geometry.Offset
+import com.example.androidlauncher.data.HomeLayout
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EditConfigViewModelTest {
+
+    @Test
+    fun `default layout has no custom offsets`() {
+        assertFalse(EditConfigViewModel.hasCustomOffsets(HomeLayout()))
+    }
+
+    @Test
+    fun `sub-pixel noise below the epsilon does not count as custom`() {
+        val layout = HomeLayout(clock = Offset(0.3f, -0.4f), weather = Offset(0.5f, 0f))
+        assertFalse(EditConfigViewModel.hasCustomOffsets(layout))
+    }
+
+    @Test
+    fun `any single moved element counts as custom`() {
+        assertTrue(EditConfigViewModel.hasCustomOffsets(HomeLayout(date = Offset(0f, 12f))))
+        assertTrue(EditConfigViewModel.hasCustomOffsets(HomeLayout(favorites = Offset(-8f, 0f))))
+    }
+}


### PR DESCRIPTION
## Was dieser PR macht

Letztes Plan-Item des MainActivity-Umfelds: Das Einstellungsmenü (`EditConfigMenu`) hängt nicht mehr an einer 37-Parameter-Callback-Verdrahtung durch die MainActivity, sondern versorgt sich selbst (Plan-Item A8).

## Änderungen

- **`EditConfigMenu(actions: EditConfigActions)`** — ein Parameter statt 37. `EditConfigActions` (2 Methoden: Default-Launcher-Dialog, Wallpaper-Picker) kapselt die einzigen Effekte, die wirklich die Activity brauchen (ActivityResult-Launcher). Muster: `GestureActionEffects`.
- **`EditConfigViewModel`** (neu): injiziert die A1-Settings-Stores (HomeLayout/Wallpaper/Animation/IslandAndEdge/Gesture/Privacy) + `SearchSuggestionsManager` und liefert alle Toggles/Flows direkt ans Menü. `isCustomHomeLayoutSet` ist jetzt eine pure, getestete Funktion (`hasCustomOffsets`).
- **Overlay-Navigation** läuft direkt über das `HomeViewModel` (`hiltViewModel()`, gleiche Activity-Instanz) — alle zehn `onOpenX`-Callbacks entfallen.
- Der Haptik-Toggle inkl. WRITE_SETTINGS-Fallback-Dialog lebt jetzt im Menü (Verhalten unverändert).
- Die MainActivity-Aufrufstelle schrumpft von ~110 auf 15 Zeilen. Der schon immer ungenutzte `onAnimationsToggled`-Callback ist ersatzlos entfernt.
- **UI-Tests** (`LauncherComposableUiTest`) auf das neue Muster umgestellt: Zustand wird über den injizierten `HomeLayoutSettings`-Store geseedet statt über Fake-Parameter — testet erstmals den echten Datenfluss. Der bereits vorher ignorierte Reset-Test bleibt `@Ignore` (LazyColumn-Scroll, siehe TODO).

## Für Reviewer

- Der 1000-Zeilen-Menü-Body ist unverändert — abgeleitete Locals mit den früheren Parameternamen (gleiche Technik wie beim A2-Umbau in #114).
- **Manuell testen:** Einstellungsmenü öffnen, alle Untermenüs/Toggles durchklicken (insb. Haptik ohne WRITE_SETTINGS-Berechtigung, Wallpaper ändern/zurücksetzen, Layout zurücksetzen, Standard-Launcher-Dialog).
- Gates lokal grün: `detekt`, `testDebugUnitTest`, `koverVerifyDebug`, `compileDebugAndroidTestKotlin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)