### PR TITLE
refactor: HomeScreen/AppDrawer dekomponiert (A6) – Workstream A komplett

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,11 @@ kover {
                 // Neue extrahierte UI-Dateien
                 classes("com.example.androidlauncher.ui.HomeScreenKt")
                 classes("com.example.androidlauncher.ui.HomeScreenKt\$*")
+                // A6-Split aus HomeScreen.kt (reine Composables; HomeDragStateHolder ist getestet)
+                classes("com.example.androidlauncher.ui.HomeWidgetsKt")
+                classes("com.example.androidlauncher.ui.HomeWidgetsKt\$*")
+                classes("com.example.androidlauncher.ui.FavoriteItemKt")
+                classes("com.example.androidlauncher.ui.FavoriteItemKt\$*")
                 classes("com.example.androidlauncher.ui.FavoritesConfigMenuKt")
                 classes("com.example.androidlauncher.ui.FavoritesConfigMenuKt\$*")
                 classes("com.example.androidlauncher.ui.SystemWallpaperViewKt")

--- a/app/src/main/java/com/example/androidlauncher/LauncherLogic.kt
+++ b/app/src/main/java/com/example/androidlauncher/LauncherLogic.kt
@@ -499,4 +499,51 @@ object LauncherLogic {
         activeNotificationPackages: Set<String>,
         dotsEnabled: Boolean,
     ): Boolean = dotsEnabled && packageName in activeNotificationPackages
+
+    // ── Ordner-Grid (3×3-Pager im App-Drawer) – A6-Split aus AppDrawer.kt ──
+
+    /** Spalten/Zeilen des Ordner-Grids und Apps pro Seite. */
+    const val FOLDER_GRID_COLUMNS = 3
+    const val FOLDER_GRID_ROWS = 3
+    const val FOLDER_ITEMS_PER_PAGE = FOLDER_GRID_COLUMNS * FOLDER_GRID_ROWS
+
+    /** Anzahl der Pager-Seiten für [appCount] Apps (mindestens eine). */
+    fun folderPageCount(appCount: Int): Int =
+        maxOf(1, (appCount + FOLDER_ITEMS_PER_PAGE - 1) / FOLDER_ITEMS_PER_PAGE)
+
+    /**
+     * Globaler Slot-Index (über alle Seiten) unter einer Berührung im 3×3-Grid der
+     * Seite [currentPage], oder `null` bei ungültiger Grid-Größe. Der Slot kann
+     * hinter dem letzten belegten Eintrag liegen – Begrenzung übernimmt der Aufrufer.
+     */
+    fun folderGridSlotAt(
+        touchX: Float,
+        touchY: Float,
+        gridWidthPx: Int,
+        gridHeightPx: Int,
+        currentPage: Int,
+    ): Int? {
+        if (gridWidthPx <= 0 || gridHeightPx <= 0) return null
+        val cellW = gridWidthPx / FOLDER_GRID_COLUMNS.toFloat()
+        val cellH = gridHeightPx / FOLDER_GRID_ROWS.toFloat()
+        val col = (touchX / cellW).toInt().coerceIn(0, FOLDER_GRID_COLUMNS - 1)
+        val row = (touchY / cellH).toInt().coerceIn(0, FOLDER_GRID_ROWS - 1)
+        return currentPage * FOLDER_ITEMS_PER_PAGE + row * FOLDER_GRID_COLUMNS + col
+    }
+
+    /**
+     * Verschiebt [pkg] innerhalb der Ordner-Liste an [targetIdx] (auf gültige Indizes
+     * begrenzt). Liefert `null`, wenn das Paket fehlt oder sich nichts ändert –
+     * dann muss der Aufrufer weder persistieren noch Haptik auslösen.
+     */
+    fun moveFolderApp(packages: List<String>, pkg: String, targetIdx: Int): List<String>? {
+        val fromIdx = packages.indexOf(pkg)
+        if (fromIdx == -1 || packages.isEmpty()) return null
+        val clampedTarget = targetIdx.coerceIn(0, packages.size - 1)
+        if (clampedTarget == fromIdx) return null
+        return packages.toMutableList().apply {
+            removeAt(fromIdx)
+            add(clampedTarget, pkg)
+        }
+    }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -671,8 +671,8 @@ fun AppDrawer(
                             ) { currentActiveFolder.appPackageNames.mapNotNull { pkg -> apps.find { it.packageName == pkg } } }
                             val currentFolderApps by rememberUpdatedState(folderApps)
 
-                            val itemsPerPage = 9
-                            val pages = max(1, (folderApps.size + itemsPerPage - 1) / itemsPerPage)
+                            val itemsPerPage = LauncherLogic.FOLDER_ITEMS_PER_PAGE
+                            val pages = LauncherLogic.folderPageCount(folderApps.size)
                             val pagerState = rememberPagerState(pageCount = { pages })
 
                             LaunchedEffect(draggingItemPkg) {
@@ -712,37 +712,33 @@ fun AppDrawer(
 
                                 fun performReorder(currentTouch: Offset, currentPage: Int) {
                                     val pkg = draggingItemPkg ?: return
-                                    val fromIdx = currentFolderState.appPackageNames.indexOf(pkg)
-                                    if (fromIdx == -1 || gridAreaSize.width <= 0 || gridAreaSize.height <= 0) return
-                                    val cellW = gridAreaSize.width / 3f
-                                    val cellH = gridAreaSize.height / 3f
-                                    val col = (currentTouch.x / cellW).toInt().coerceIn(0, 2)
-                                    val row = (currentTouch.y / cellH).toInt().coerceIn(0, 2)
-                                    val targetIdxInPage = row * 3 + col
-                                    val targetIdx = (currentPage * itemsPerPage + targetIdxInPage).coerceIn(
-                                        0,
-                                        currentFolderState.appPackageNames.size - 1
-                                    )
-                                    if (targetIdx != fromIdx) {
-                                        val newList = currentFolderState.appPackageNames.toMutableList()
-                                        newList.removeAt(fromIdx)
-                                        newList.add(targetIdx, pkg)
-                                        onUpdateFolders(
-                                            currentFoldersState.map {
-                                                if (it.id == currentFolderState.id) {
-                                                    it.copy(
-                                                        appPackageNames = newList
-                                                    )
-                                                } else {
-                                                    it
-                                                }
+                                    // Treffer- und Umsortier-Logik liegt framework-frei in LauncherLogic
+                                    // (unit-getestet); hier bleiben nur Persistenz + Haptik.
+                                    val targetIdx = LauncherLogic.folderGridSlotAt(
+                                        touchX = currentTouch.x,
+                                        touchY = currentTouch.y,
+                                        gridWidthPx = gridAreaSize.width,
+                                        gridHeightPx = gridAreaSize.height,
+                                        currentPage = currentPage,
+                                    ) ?: return
+                                    val newList = LauncherLogic.moveFolderApp(
+                                        packages = currentFolderState.appPackageNames,
+                                        pkg = pkg,
+                                        targetIdx = targetIdx,
+                                    ) ?: return
+                                    onUpdateFolders(
+                                        currentFoldersState.map {
+                                            if (it.id == currentFolderState.id) {
+                                                it.copy(appPackageNames = newList)
+                                            } else {
+                                                it
                                             }
-                                        )
-                                        if (hapticEnabled) {
-                                            haptic.performHapticFeedback(
-                                                HapticFeedbackType.TextHandleMove
-                                            )
                                         }
+                                    )
+                                    if (hapticEnabled) {
+                                        haptic.performHapticFeedback(
+                                            HapticFeedbackType.TextHandleMove
+                                        )
                                     }
                                 }
 
@@ -785,10 +781,13 @@ fun AppDrawer(
                                                 onDragStart = { offset ->
                                                     val cellW = gridAreaSize.width / 3f
                                                     val cellH = gridAreaSize.height / 3f
-                                                    val col = (offset.x / cellW).toInt().coerceIn(0, 2)
-                                                    val row = (offset.y / cellH).toInt().coerceIn(0, 2)
-                                                    val idxInPage = row * 3 + col
-                                                    val globalIdx = pagerState.currentPage * itemsPerPage + idxInPage
+                                                    val globalIdx = LauncherLogic.folderGridSlotAt(
+                                                        touchX = offset.x,
+                                                        touchY = offset.y,
+                                                        gridWidthPx = gridAreaSize.width,
+                                                        gridHeightPx = gridAreaSize.height,
+                                                        currentPage = pagerState.currentPage,
+                                                    ) ?: return@detectDragGesturesAfterLongPress
                                                     val currentApps = currentFolderApps
                                                     if (globalIdx < currentApps.size) {
                                                         appDrawerVm.onDragStart(

--- a/app/src/main/java/com/example/androidlauncher/ui/FavoriteItem.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FavoriteItem.kt
@@ -1,0 +1,229 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.animation.*
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.FavoritesEntranceTracker
+import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.ui.LiquidGlass.designSurface
+import com.example.androidlauncher.ui.theme.*
+import kotlinx.coroutines.delay
+
+/**
+ * Favoriten-Eintrag der Startbildschirm-Leiste + Edit-Steuerknopf
+ * (A6-Split aus HomeScreen.kt; gleiches Paket, keine Aufrufer-Aenderungen).
+ */
+
+@Composable
+internal fun EditControlButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    onClick: () -> Unit,
+    tint: Color,
+    sizeDp: androidx.compose.ui.unit.Dp = 56.dp,
+    containerColor: Color = Color.Transparent,
+    testTag: String? = null
+) {
+    val intSrc = remember { MutableInteractionSource() }
+    val designStyle = LocalDesignStyle.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+
+    Box(
+        modifier = Modifier
+            .size(sizeDp)
+            .then(
+                if (containerColor == Color.Transparent) {
+                    Modifier.designSurface(designStyle, CircleShape, isDarkTextEnabled, surfaceAccent, fillAlpha = 0.1f)
+                } else {
+                    Modifier.background(containerColor, CircleShape)
+                }
+            )
+            .clip(CircleShape)
+            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+            .bounceClick(intSrc)
+            .clickable(interactionSource = intSrc, indication = null, onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(imageVector = icon, contentDescription = null, tint = tint, modifier = Modifier.size(24.dp))
+    }
+}
+
+@Composable
+internal fun FavoriteItem(
+    app: AppInfo,
+    showLabels: Boolean,
+    fontSize: Float,
+    mainTextColor: Color,
+    returnIconPackage: String?,
+    index: Int = 0,
+    isHovered: Boolean = false,
+    onBoundsChanged: (Rect) -> Unit = {},
+    onAppLaunchForReturn: (String, Rect?) -> Unit,
+    onShortcutRequested: (AppInfo, Rect?) -> Unit,
+    isPreview: Boolean = false
+) {
+    val intSrc = remember { MutableInteractionSource() }
+    // Hervorhebung beim Rüberfahren: nur Vergrößerung, kein Hintergrund.
+    // Abschaltbar über die Animationseinstellungen (Favoriten-Leiste).
+    val favoritesAnimationEnabled = LocalFavoritesAnimationEnabled.current
+    val hoverScale by animateFloatAsState(
+        targetValue = if (isHovered && favoritesAnimationEnabled) 1.12f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "FavHoverScale"
+    )
+    val bounceScale by animateFloatAsState(
+        targetValue = if (!LocalAppCloseAnimationEnabled.current) 1f else if (returnIconPackage == app.packageName) 1.2f else 1f,
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "HomeReturnBounce"
+    )
+    val itemBounds = remember(app.packageName) { mutableStateOf<Rect?>(null) }
+    val iconBounds = remember(app.packageName) { mutableStateOf<Rect?>(null) }
+    // Icon-Größe ist (anders als die Icon-Position) unabhängig von der Swipe-Verschiebung
+    // und dient als stabiler Anker für das Shortcut-Menü.
+    var iconSize by remember(app.packageName) { mutableStateOf(IntSize.Zero) }
+
+    var horizontalOffset by remember { mutableFloatStateOf(0f) }
+    val animatedOffset by animateFloatAsState(
+        targetValue = if (!LocalAnimationsEnabled.current) 0f else horizontalOffset,
+        animationSpec = spring(stiffness = Spring.StiffnessLow),
+        label = "SwipeOffset"
+    )
+
+    // Material-3-Expressive: gestaffelter Eingang der Favoriten (federndes Aufpoppen),
+    // einmalig pro Prozess-Lebenszeit beim ersten Erscheinen. Läuft NICHT erneut beim
+    // Zurückkommen aus dem App-Drawer (HomeScreen wird dann neu komponiert).
+    // Respektiert die Favoriten-Animationseinstellung.
+    val playEntrance = favoritesAnimationEnabled && !isPreview &&
+        !FavoritesEntranceTracker.hasAppeared(app.packageName)
+    val appear = remember(app.packageName) { Animatable(if (playEntrance) 0f else 1f) }
+    LaunchedEffect(app.packageName, favoritesAnimationEnabled) {
+        if (playEntrance) {
+            appear.snapTo(0f)
+            delay((index.coerceAtMost(8) * 40).toLong())
+            appear.animateTo(1f, RethroneSprings.spatial())
+            FavoritesEntranceTracker.markAppeared(app.packageName)
+        } else {
+            appear.snapTo(1f)
+        }
+    }
+
+    Surface(
+        color = Color.Transparent,
+        shape = RoundedCornerShape(16.dp),
+        modifier = Modifier
+            .onGloballyPositioned { coordinates ->
+                val b = coordinates.boundsInRoot()
+                itemBounds.value = b
+                onBoundsChanged(b)
+            }
+            .graphicsLayer {
+                translationX = animatedOffset
+                // Eingang (0.9 → 1.0) mit Hover-Scale kombiniert.
+                val entranceScale = 0.9f + 0.1f * appear.value
+                scaleX = hoverScale * entranceScale
+                scaleY = hoverScale * entranceScale
+                alpha = appear.value
+                // Linksbündig vergrößern, damit das Icon nicht zur Seite wandert.
+                transformOrigin = TransformOrigin(0f, 0.5f)
+            }
+            .then(
+                if (!isPreview) {
+                    Modifier
+                        .pointerInput(app.packageName) {
+                            detectHorizontalDragGestures(
+                                onDragEnd = {
+                                    if (horizontalOffset > 150f) {
+                                        // Stabilen Anker nur fürs Icon bauen: Position aus dem
+                                        // (unverschobenen) itemBounds, Breite/Höhe aus der Icon-Größe.
+                                        // So verdeckt das Menü das Logo nicht – egal ob Labels an sind.
+                                        val ib = itemBounds.value
+                                        val anchor = if (ib != null && iconSize.width > 0) {
+                                            Rect(
+                                                left = ib.left,
+                                                top = ib.center.y - iconSize.height / 2f,
+                                                right = ib.left + iconSize.width,
+                                                bottom = ib.center.y + iconSize.height / 2f
+                                            )
+                                        } else {
+                                            ib
+                                        }
+                                        onShortcutRequested(app, anchor)
+                                    }
+                                    horizontalOffset = 0f
+                                },
+                                onDragCancel = { horizontalOffset = 0f },
+                                onHorizontalDrag = { _, dragAmount ->
+                                    horizontalOffset = (horizontalOffset + dragAmount).coerceIn(0f, 300f)
+                                }
+                            )
+                        }
+                        .bounceClick(intSrc)
+                        .clickable(interactionSource = intSrc, indication = null) {
+                            val targetBounds = iconBounds.value ?: itemBounds.value
+                            onAppLaunchForReturn(app.packageName, targetBounds)
+                        }
+                } else {
+                    Modifier
+                }
+            )
+    ) {
+        Row(
+            // Nur vertikaler Innenabstand, damit die Icons links bündig mit Uhr/Datum stehen.
+            modifier = Modifier.padding(vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .graphicsLayer {
+                        scaleX = bounceScale
+                        scaleY = bounceScale
+                    }
+                    .onGloballyPositioned {
+                        iconBounds.value = it.boundsInRoot()
+                        iconSize = it.size
+                    }
+            ) {
+                AppIconView(app, showBadge = true)
+            }
+            if (showLabels) {
+                Text(
+                    text = app.label,
+                    color = mainTextColor,
+                    fontSize = 18.sp * fontSize,
+                    fontWeight = FontWeight.Normal,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
@@ -1,0 +1,75 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import com.example.androidlauncher.data.HomeLayout
+
+/**
+ * Bündelt die transienten Zustände des Edit-Modus auf dem Startbildschirm
+ * (A6-Split aus dem HomeScreen-Composable): Live-Offsets der verschiebbaren
+ * Elemente, Kollisions-/Haptik-Buchführung und die aktuelle Auswahl. Bewusst
+ * `remember`-basiert – der persistierte Stand lebt in `HomeLayoutSettings`,
+ * dieser Holder hält nur die Live-Vorschau während des Bearbeitens.
+ * Geometrie-Entscheidungen bleiben framework-frei in `HomeGeometry.kt`.
+ */
+@Stable
+internal class HomeDragStateHolder(initialLayout: HomeLayout) {
+
+    /** Live-Offsets je Element; im Edit-Modus folgt das Element dem Finger. */
+    val offsets = mutableStateMapOf(
+        HomeEditTarget.CLOCK to initialLayout.clock,
+        HomeEditTarget.DATE to initialLayout.date,
+        HomeEditTarget.WEATHER to initialLayout.weather,
+        HomeEditTarget.FAVORITES to initialLayout.favorites,
+    )
+
+    /** Neutralposition (Bounds ohne Offset) je Element – Basis der Kollisionsprüfung. */
+    val neutralBounds = mutableStateMapOf<HomeEditTarget, Rect>()
+
+    /** Zeitstempel der letzten Blockier-Haptik je Element (Drossel gegen Dauervibration). */
+    val lastBlockedHapticMs = mutableStateMapOf<HomeEditTarget, Long>()
+
+    // Bounds der festen UI-Elemente, mit denen verschobene Elemente kollidieren können.
+    var searchButtonBounds by mutableStateOf<Rect?>(null)
+    var settingsButtonBounds by mutableStateOf<Rect?>(null)
+    var editControlsBounds by mutableStateOf<Rect?>(null)
+
+    var collisionHapticWasTriggered by mutableStateOf(false)
+
+    /** Aktuell ausgewähltes Element im Edit-Modus (oder `null`). */
+    var selectedEditTarget by mutableStateOf<HomeEditTarget?>(null)
+
+    /** `true`, wenn der Nutzer die Auswahl explizit angetippt hat (nicht nur Auto-Auswahl). */
+    var isEditTargetUserPinned by mutableStateOf(false)
+
+    /**
+     * Seedet die Live-Offsets aus dem persistierten Layout – beim Betreten des
+     * Edit-Modus 1:1 übernehmen, Abbrechen revertiert damit automatisch.
+     */
+    fun seedFrom(layout: HomeLayout) {
+        offsets[HomeEditTarget.CLOCK] = layout.clock
+        offsets[HomeEditTarget.DATE] = layout.date
+        offsets[HomeEditTarget.WEATHER] = layout.weather
+        offsets[HomeEditTarget.FAVORITES] = layout.favorites
+    }
+
+    /** Aktuelle Live-Offsets als persistierbares [HomeLayout] (Speichern-Knopf). */
+    fun toHomeLayout(): HomeLayout = HomeLayout(
+        clock = offsets[HomeEditTarget.CLOCK] ?: Offset.Zero,
+        date = offsets[HomeEditTarget.DATE] ?: Offset.Zero,
+        weather = offsets[HomeEditTarget.WEATHER] ?: Offset.Zero,
+        favorites = offsets[HomeEditTarget.FAVORITES] ?: Offset.Zero,
+    )
+}
+
+/** Merkt sich den Holder über Recompositions hinweg (nicht über Config-Wechsel). */
+@Composable
+internal fun rememberHomeDragState(initialLayout: HomeLayout): HomeDragStateHolder =
+    remember { HomeDragStateHolder(initialLayout) }

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -1,22 +1,16 @@
 package com.example.androidlauncher.ui
 
-import android.annotation.SuppressLint
-import android.content.Context
 import android.content.Intent
 import android.os.SystemClock
-import android.provider.AlarmClock
-import android.provider.CalendarContract
 import android.view.HapticFeedbackConstants
 import android.widget.Toast
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -31,8 +25,6 @@ import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.*
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -41,9 +33,7 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -56,11 +46,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalViewConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.PlatformTextStyle
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.LineHeightStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
@@ -69,25 +54,17 @@ import androidx.compose.ui.zIndex
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
-import androidx.lifecycle.repeatOnLifecycle
-import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Sun
-import com.example.androidlauncher.FavoritesEntranceTracker
 import com.example.androidlauncher.R
 import com.example.androidlauncher.data.AppAccessMode
 import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.FavoritesBorderStyle
 import com.example.androidlauncher.data.GestureAction
 import com.example.androidlauncher.data.HomeLayout
-import com.example.androidlauncher.data.WeatherData
-import com.example.androidlauncher.data.WeatherRepository
 import com.example.androidlauncher.launchShortcut
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
 import com.example.androidlauncher.ui.theme.*
 import kotlinx.coroutines.delay
-import java.text.SimpleDateFormat
 import java.util.Calendar
-import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -148,25 +125,17 @@ fun HomeScreen(
     var rootSize by remember { mutableStateOf(IntSize.Zero) }
 
     // --- Bearbeitungs-States (Lokal für Live-Vorschau) ---
-    // Live-Offsets, Neutralpositionen und Haptik-Zeitstempel je verschiebbarem Element.
-    val offsets = remember {
-        mutableStateMapOf(
-            HomeEditTarget.CLOCK to homeLayout.clock,
-            HomeEditTarget.DATE to homeLayout.date,
-            HomeEditTarget.WEATHER to homeLayout.weather,
-            HomeEditTarget.FAVORITES to homeLayout.favorites
-        )
-    }
-    val neutralBounds = remember { mutableStateMapOf<HomeEditTarget, Rect>() }
-    val lastBlockedHapticMs = remember { mutableStateMapOf<HomeEditTarget, Long>() }
+    // A6-Split: gebündelt im HomeDragStateHolder; die Delegates/Aliase darunter
+    // halten die bestehenden Lese-/Schreib-Stellen im Composable stabil.
+    val dragState = rememberHomeDragState(homeLayout)
+    val offsets = dragState.offsets
+    val neutralBounds = dragState.neutralBounds
+    val lastBlockedHapticMs = dragState.lastBlockedHapticMs
 
     // Hält die Live-Offsets außerhalb des Edit-Modus an der gespeicherten Position;
     // beim Betreten des Edit-Modus werden sie 1:1 daraus geseedet, Abbrechen revertiert.
     LaunchedEffect(homeLayout, isEditMode) {
-        offsets[HomeEditTarget.CLOCK] = homeLayout.clock
-        offsets[HomeEditTarget.DATE] = homeLayout.date
-        offsets[HomeEditTarget.WEATHER] = homeLayout.weather
-        offsets[HomeEditTarget.FAVORITES] = homeLayout.favorites
+        dragState.seedFrom(homeLayout)
     }
 
     // Tickt die Uhrzeit für die getrennten Uhr-/Datums-Elemente.
@@ -193,10 +162,10 @@ fun HomeScreen(
         onDispose { clockLifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    var searchButtonBounds by remember { mutableStateOf<Rect?>(null) }
-    var settingsButtonBounds by remember { mutableStateOf<Rect?>(null) }
-    var editControlsBounds by remember { mutableStateOf<Rect?>(null) }
-    var collisionHapticWasTriggered by remember { mutableStateOf(false) }
+    var searchButtonBounds by dragState::searchButtonBounds
+    var settingsButtonBounds by dragState::settingsButtonBounds
+    var editControlsBounds by dragState::editControlsBounds
+    var collisionHapticWasTriggered by dragState::collisionHapticWasTriggered
 
     val favoritesFramePaddingPx = with(density) { 10.dp.toPx() }
     val navCollisionPaddingPx = favoritesFramePaddingPx
@@ -211,8 +180,8 @@ fun HomeScreen(
     val blockedDragHapticMinDeltaPx = 0.25f
     val clockTopLimitPx = with(density) { 32.dp.toPx() }
 
-    var selectedEditTarget by remember { mutableStateOf<HomeEditTarget?>(null) }
-    var isEditTargetUserPinned by remember { mutableStateOf(false) }
+    var selectedEditTarget by dragState::selectedEditTarget
+    var isEditTargetUserPinned by dragState::isEditTargetUserPinned
     var selectedShortcutApp by remember { mutableStateOf<AppInfo?>(null) }
     var shortcutMenuBounds by remember { mutableStateOf<Rect?>(null) }
 
@@ -893,14 +862,7 @@ fun HomeScreen(
                         icon = Icons.Rounded.Check,
                         onClick = {
                             updateCollisionFeedback(false)
-                            onSaveHomeLayout(
-                                HomeLayout(
-                                    clock = offsets[HomeEditTarget.CLOCK] ?: Offset.Zero,
-                                    date = offsets[HomeEditTarget.DATE] ?: Offset.Zero,
-                                    weather = offsets[HomeEditTarget.WEATHER] ?: Offset.Zero,
-                                    favorites = offsets[HomeEditTarget.FAVORITES] ?: Offset.Zero
-                                )
-                            )
+                            onSaveHomeLayout(dragState.toHomeLayout())
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.position_saved),
@@ -1098,535 +1060,6 @@ fun HomeScreen(
                 returnIconPackage = returnIconPackage,
                 modifier = Modifier.zIndex(2500f)
             )
-        }
-    }
-}
-
-@Composable
-private fun EditControlButton(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    onClick: () -> Unit,
-    tint: Color,
-    sizeDp: androidx.compose.ui.unit.Dp = 56.dp,
-    containerColor: Color = Color.Transparent,
-    testTag: String? = null
-) {
-    val intSrc = remember { MutableInteractionSource() }
-    val designStyle = LocalDesignStyle.current
-    val isDarkTextEnabled = LocalDarkTextEnabled.current
-    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
-
-    Box(
-        modifier = Modifier
-            .size(sizeDp)
-            .then(
-                if (containerColor == Color.Transparent) {
-                    Modifier.designSurface(designStyle, CircleShape, isDarkTextEnabled, surfaceAccent, fillAlpha = 0.1f)
-                } else {
-                    Modifier.background(containerColor, CircleShape)
-                }
-            )
-            .clip(CircleShape)
-            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
-            .bounceClick(intSrc)
-            .clickable(interactionSource = intSrc, indication = null, onClick = onClick),
-        contentAlignment = Alignment.Center
-    ) {
-        Icon(imageVector = icon, contentDescription = null, tint = tint, modifier = Modifier.size(24.dp))
-    }
-}
-
-@Composable
-private fun FavoriteItem(
-    app: AppInfo,
-    showLabels: Boolean,
-    fontSize: Float,
-    mainTextColor: Color,
-    returnIconPackage: String?,
-    index: Int = 0,
-    isHovered: Boolean = false,
-    onBoundsChanged: (Rect) -> Unit = {},
-    onAppLaunchForReturn: (String, Rect?) -> Unit,
-    onShortcutRequested: (AppInfo, Rect?) -> Unit,
-    isPreview: Boolean = false
-) {
-    val context = LocalContext.current
-    val intSrc = remember { MutableInteractionSource() }
-    // Hervorhebung beim Rüberfahren: nur Vergrößerung, kein Hintergrund.
-    // Abschaltbar über die Animationseinstellungen (Favoriten-Leiste).
-    val favoritesAnimationEnabled = LocalFavoritesAnimationEnabled.current
-    val hoverScale by animateFloatAsState(
-        targetValue = if (isHovered && favoritesAnimationEnabled) 1.12f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "FavHoverScale"
-    )
-    val bounceScale by animateFloatAsState(
-        targetValue = if (!LocalAppCloseAnimationEnabled.current) 1f else if (returnIconPackage == app.packageName) 1.2f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "HomeReturnBounce"
-    )
-    val itemBounds = remember(app.packageName) { mutableStateOf<Rect?>(null) }
-    val iconBounds = remember(app.packageName) { mutableStateOf<Rect?>(null) }
-    // Icon-Größe ist (anders als die Icon-Position) unabhängig von der Swipe-Verschiebung
-    // und dient als stabiler Anker für das Shortcut-Menü.
-    var iconSize by remember(app.packageName) { mutableStateOf(IntSize.Zero) }
-
-    var horizontalOffset by remember { mutableFloatStateOf(0f) }
-    val animatedOffset by animateFloatAsState(
-        targetValue = if (!LocalAnimationsEnabled.current) 0f else horizontalOffset,
-        animationSpec = spring(stiffness = Spring.StiffnessLow),
-        label = "SwipeOffset"
-    )
-
-    // Material-3-Expressive: gestaffelter Eingang der Favoriten (federndes Aufpoppen),
-    // einmalig pro Prozess-Lebenszeit beim ersten Erscheinen. Läuft NICHT erneut beim
-    // Zurückkommen aus dem App-Drawer (HomeScreen wird dann neu komponiert).
-    // Respektiert die Favoriten-Animationseinstellung.
-    val playEntrance = favoritesAnimationEnabled && !isPreview &&
-        !FavoritesEntranceTracker.hasAppeared(app.packageName)
-    val appear = remember(app.packageName) { Animatable(if (playEntrance) 0f else 1f) }
-    LaunchedEffect(app.packageName, favoritesAnimationEnabled) {
-        if (playEntrance) {
-            appear.snapTo(0f)
-            delay((index.coerceAtMost(8) * 40).toLong())
-            appear.animateTo(1f, RethroneSprings.spatial())
-            FavoritesEntranceTracker.markAppeared(app.packageName)
-        } else {
-            appear.snapTo(1f)
-        }
-    }
-
-    Surface(
-        color = Color.Transparent,
-        shape = RoundedCornerShape(16.dp),
-        modifier = Modifier
-            .onGloballyPositioned { coordinates ->
-                val b = coordinates.boundsInRoot()
-                itemBounds.value = b
-                onBoundsChanged(b)
-            }
-            .graphicsLayer {
-                translationX = animatedOffset
-                // Eingang (0.9 → 1.0) mit Hover-Scale kombiniert.
-                val entranceScale = 0.9f + 0.1f * appear.value
-                scaleX = hoverScale * entranceScale
-                scaleY = hoverScale * entranceScale
-                alpha = appear.value
-                // Linksbündig vergrößern, damit das Icon nicht zur Seite wandert.
-                transformOrigin = TransformOrigin(0f, 0.5f)
-            }
-            .then(
-                if (!isPreview) {
-                    Modifier
-                        .pointerInput(app.packageName) {
-                            detectHorizontalDragGestures(
-                                onDragEnd = {
-                                    if (horizontalOffset > 150f) {
-                                        // Stabilen Anker nur fürs Icon bauen: Position aus dem
-                                        // (unverschobenen) itemBounds, Breite/Höhe aus der Icon-Größe.
-                                        // So verdeckt das Menü das Logo nicht – egal ob Labels an sind.
-                                        val ib = itemBounds.value
-                                        val anchor = if (ib != null && iconSize.width > 0) {
-                                            Rect(
-                                                left = ib.left,
-                                                top = ib.center.y - iconSize.height / 2f,
-                                                right = ib.left + iconSize.width,
-                                                bottom = ib.center.y + iconSize.height / 2f
-                                            )
-                                        } else {
-                                            ib
-                                        }
-                                        onShortcutRequested(app, anchor)
-                                    }
-                                    horizontalOffset = 0f
-                                },
-                                onDragCancel = { horizontalOffset = 0f },
-                                onHorizontalDrag = { _, dragAmount ->
-                                    horizontalOffset = (horizontalOffset + dragAmount).coerceIn(0f, 300f)
-                                }
-                            )
-                        }
-                        .bounceClick(intSrc)
-                        .clickable(interactionSource = intSrc, indication = null) {
-                            val targetBounds = iconBounds.value ?: itemBounds.value
-                            onAppLaunchForReturn(app.packageName, targetBounds)
-                        }
-                } else {
-                    Modifier
-                }
-            )
-    ) {
-        Row(
-            // Nur vertikaler Innenabstand, damit die Icons links bündig mit Uhr/Datum stehen.
-            modifier = Modifier.padding(vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Box(
-                modifier = Modifier
-                    .graphicsLayer {
-                        scaleX = bounceScale
-                        scaleY = bounceScale
-                    }
-                    .onGloballyPositioned {
-                        iconBounds.value = it.boundsInRoot()
-                        iconSize = it.size
-                    }
-            ) {
-                AppIconView(app, showBadge = true)
-            }
-            if (showLabels) {
-                Text(
-                    text = app.label,
-                    color = mainTextColor,
-                    fontSize = 18.sp * fontSize,
-                    fontWeight = FontWeight.Normal,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            }
-        }
-    }
-}
-
-@SuppressLint("WrongConstant")
-internal fun expandNotifications(context: Context) {
-    try {
-        val statusBarService = context.getSystemService("statusbar")
-        val statusBarManager = Class.forName("android.app.StatusBarManager")
-        val method = statusBarManager.getMethod("expandNotificationsPanel")
-        method.invoke(statusBarService)
-    } catch (_: Exception) {
-    }
-}
-
-/**
- * Großes Uhrzeit-Element (eigenständig verschiebbar). [time] wird vom Aufrufer getickt.
- */
-@Composable
-fun ClockText(
-    time: java.util.Date,
-    isPreview: Boolean,
-    returnIconPackage: String?,
-    onAppLaunchForReturn: (String, Rect?) -> Unit
-) {
-    val context = LocalContext.current
-    val fontSize = LocalFontSize.current
-    val appFontWeight = LocalFontWeight.current
-    val mainTextColor = LocalHomeTextColor.current
-
-    val timeFormat = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
-    val intSrcTime = remember { MutableInteractionSource() }
-    val clockBounds = remember { mutableStateOf<Rect?>(null) }
-    var clockPackage by remember { mutableStateOf<String?>(null) }
-
-    val bounceScaleTime by animateFloatAsState(
-        targetValue = if (!LocalAppCloseAnimationEnabled.current) 1f else if (returnIconPackage != null && returnIconPackage == clockPackage) 1.08f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "ClockReturnBounce"
-    )
-
-    // Material-3-Expressive: Minutenwechsel per kurzem Crossfade statt hartem Swap.
-    val animationsEnabled = LocalAnimationsEnabled.current
-    Crossfade(
-        targetState = timeFormat.format(time),
-        animationSpec = tween(if (animationsEnabled) 220 else 0),
-        label = "clockCrossfade",
-        modifier = Modifier
-            .onGloballyPositioned { clockBounds.value = it.boundsInRoot() }
-            .graphicsLayer {
-                scaleX = bounceScaleTime
-                scaleY = bounceScaleTime
-            }
-            .clip(RoundedCornerShape(8.dp))
-            .then(
-                if (!isPreview) {
-                    Modifier
-                        .bounceClick(intSrcTime)
-                        .clickable(interactionSource = intSrcTime, indication = null) {
-                            launchClockApp(context, clockBounds.value, onAppLaunchForReturn) { clockPackage = it }
-                        }
-                } else {
-                    Modifier
-                }
-            )
-    ) { timeStr ->
-        Text(
-            text = timeStr,
-            // Seitliches/vertikales Polster INNERHALB des Clips, damit Glyphen-Überhänge
-            // (kursive/dekorative Fonts, negatives letterSpacing) nicht abgeschnitten werden.
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
-            fontSize = 72.sp * fontSize.scale,
-            fontWeight = appFontWeight.weight,
-            letterSpacing = (-2).sp,
-            lineHeight = 72.sp * fontSize.scale,
-            // Entfernt das zusätzliche Font-Padding (enger Rahmen), behält aber die gewählte
-            // App-Schriftart bei, indem auf den aktuellen LocalTextStyle gemergt wird.
-            // Trim.Both passt die Box an die echten Glyphen an → hohe/dekorative Schriften
-            // werden NICHT vom Clip abgeschnitten.
-            style = LocalTextStyle.current.merge(
-                TextStyle(
-                    platformStyle = PlatformTextStyle(includeFontPadding = false),
-                    lineHeightStyle = LineHeightStyle(
-                        alignment = LineHeightStyle.Alignment.Center,
-                        trim = LineHeightStyle.Trim.Both
-                    )
-                )
-            ),
-            color = mainTextColor
-        )
-    }
-}
-
-/**
- * Datums-Element (eigenständig verschiebbar). [time] wird vom Aufrufer getickt.
- */
-@Composable
-fun DateText(
-    time: java.util.Date,
-    isPreview: Boolean,
-    returnIconPackage: String?,
-    onAppLaunchForReturn: (String, Rect?) -> Unit
-) {
-    val context = LocalContext.current
-    val fontSize = LocalFontSize.current
-    val appFontWeight = LocalFontWeight.current
-    val mainTextColor = LocalHomeTextColor.current
-
-    val dateFormat = remember { SimpleDateFormat("EEEE, d. MMMM", Locale.getDefault()) }
-    val intSrcDate = remember { MutableInteractionSource() }
-    val calendarBounds = remember { mutableStateOf<Rect?>(null) }
-    var calendarPackage by remember { mutableStateOf<String?>(null) }
-
-    val bounceScaleDate by animateFloatAsState(
-        targetValue = if (!LocalAppCloseAnimationEnabled.current) 1f else if (returnIconPackage != null && returnIconPackage == calendarPackage) 1.08f else 1f,
-        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
-        label = "CalendarReturnBounce"
-    )
-
-    // Material-3-Expressive: Datumswechsel (zur Mitternacht) per Crossfade.
-    val animationsEnabled = LocalAnimationsEnabled.current
-    Crossfade(
-        targetState = dateFormat.format(time),
-        animationSpec = tween(if (animationsEnabled) 300 else 0),
-        label = "dateCrossfade",
-        modifier = Modifier
-            .onGloballyPositioned { calendarBounds.value = it.boundsInRoot() }
-            .graphicsLayer {
-                scaleX = bounceScaleDate
-                scaleY = bounceScaleDate
-            }
-            .clip(RoundedCornerShape(8.dp))
-            .then(
-                if (!isPreview) {
-                    Modifier
-                        .bounceClick(intSrcDate)
-                        .clickable(interactionSource = intSrcDate, indication = null) {
-                            launchCalendarApp(
-                                context,
-                                calendarBounds.value,
-                                onAppLaunchForReturn
-                            ) { calendarPackage = it }
-                        }
-                } else {
-                    Modifier
-                }
-            )
-            .padding(horizontal = 4.dp, vertical = 2.dp)
-    ) { dateStr ->
-        Text(
-            text = dateStr,
-            fontSize = 18.sp * fontSize.scale,
-            fontWeight = appFontWeight.weight,
-            lineHeight = 18.sp * fontSize.scale,
-            // Trim.Both passt die Box an die echten Glyphen an (kein Abschneiden).
-            style = LocalTextStyle.current.merge(
-                TextStyle(
-                    platformStyle = PlatformTextStyle(includeFontPadding = false),
-                    lineHeightStyle = LineHeightStyle(
-                        alignment = LineHeightStyle.Alignment.Center,
-                        trim = LineHeightStyle.Trim.Both
-                    )
-                )
-            ),
-            color = mainTextColor.copy(alpha = 0.7f)
-        )
-    }
-}
-
-/**
- * Schmale Wetterzeile unter Uhr/Datum: ein Symbol plus aktuelle Temperatur.
- *
- * Holt den groben Standort über [WeatherRepository] und ruft das Wetter von Open-Meteo ab.
- * Solange kein Standort/keine Daten vorliegen (z. B. Berechtigung noch nicht erteilt),
- * wird in kurzen Abständen erneut versucht; danach im 30-Minuten-Takt aktualisiert.
- * Im Vorschau-/Edit-Modus wird ein statischer Platzhalter gezeigt (kein Netzwerkzugriff).
- */
-@Composable
-fun WeatherRow(isPreview: Boolean = false) {
-    val context = LocalContext.current
-    val fontSize = LocalFontSize.current
-    val appFontWeight = LocalFontWeight.current
-    val mainTextColor = LocalHomeTextColor.current
-
-    // Startwert aus dem prozessweiten Cache: zeigt beim Zurückkehren aus dem App-Drawer
-    // sofort den letzten Wert, statt kurz zu verschwinden.
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val weather by produceState<WeatherData?>(initialValue = WeatherRepository.cached, isPreview) {
-        if (isPreview) return@produceState
-        val repo = WeatherRepository(context)
-        val refreshIntervalMs = 30 * 60_000L
-        // Nur bei sichtbarem Launcher abrufen: im Hintergrund pausiert der Loop und
-        // prüft beim nächsten ON_START zuerst die Drossel (WeatherRepository.shouldRefresh).
-        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-            while (true) {
-                if (WeatherRepository.shouldRefresh(refreshIntervalMs)) {
-                    // GPS nur, falls die Berechtigung ohnehin erteilt ist; sonst grobe Position
-                    // über die IP-Adresse (ohne Standortdienst/Berechtigung).
-                    val location = repo.awaitLocation() ?: repo.ipLocation()
-                    if (location != null) {
-                        repo.fetch(location.first, location.second)?.let { value = it }
-                    }
-                } else {
-                    // Cache noch aktuell – übernehmen, kein erneuter Netzwerkabruf.
-                    value = WeatherRepository.cached
-                }
-                // Schneller erneut versuchen, solange noch keine Daten vorliegen,
-                // sonst regulär alle 30 Minuten aktualisieren.
-                delay(if (value == null) 20_000L else refreshIntervalMs)
-            }
-        }
-    }
-
-    val icon: ImageVector
-    val temperatureText: String
-    if (isPreview) {
-        icon = Lucide.Sun
-        temperatureText = "21°"
-    } else {
-        val data = weather ?: return
-        icon = WeatherRepository.iconFor(data.weatherCode)
-        temperatureText = "${data.temperatureC}°"
-    }
-
-    // Material-3-Expressive: Wetterwert wechselt per Crossfade statt hartem Swap.
-    val animationsEnabled = LocalAnimationsEnabled.current
-    Crossfade(
-        targetState = icon to temperatureText,
-        animationSpec = tween(if (animationsEnabled) 300 else 0),
-        label = "weatherCrossfade",
-        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
-    ) { (stateIcon, stateTemp) ->
-        Row(verticalAlignment = Alignment.CenterVertically) {
-            Icon(
-                imageVector = stateIcon,
-                contentDescription = null,
-                tint = mainTextColor.copy(alpha = 0.7f),
-                modifier = Modifier.size(18.dp * fontSize.scale)
-            )
-            Spacer(modifier = Modifier.width(6.dp))
-            Text(
-                text = stateTemp,
-                fontSize = 18.sp * fontSize.scale,
-                fontWeight = appFontWeight.weight,
-                color = mainTextColor.copy(alpha = 0.7f)
-            )
-        }
-    }
-}
-
-private fun launchClockApp(
-    context: Context,
-    bounds: Rect?,
-    onAppLaunchForReturn: (String, Rect?) -> Unit,
-    onPackageFound: (String) -> Unit
-) {
-    val pm = context.packageManager
-    // Bekannte Uhr-Pakete + Auswahl liegen framework-frei in LauncherLogic (unit-getestet).
-    var foundPkg: String? = com.example.androidlauncher.LauncherLogic.firstLaunchablePackage(
-        com.example.androidlauncher.LauncherLogic.KNOWN_CLOCK_PACKAGES
-    ) { pkg -> pm.getLaunchIntentForPackage(pkg) != null }
-
-    if (foundPkg == null) {
-        try {
-            val stdIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.APP_CLOCK")
-            val res = pm.resolveActivity(stdIntent, 0)
-            if (res != null) foundPkg = res.activityInfo.packageName
-        } catch (_: Exception) {
-        }
-    }
-    if (foundPkg == null) {
-        try {
-            val alarmIntent = Intent(AlarmClock.ACTION_SHOW_ALARMS)
-            val res = pm.resolveActivity(alarmIntent, 0)
-            if (res != null) foundPkg = res.activityInfo.packageName
-        } catch (_: Exception) {
-        }
-    }
-
-    if (foundPkg != null) {
-        onPackageFound(foundPkg)
-        val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
-        if (launchIntent != null) {
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-            onAppLaunchForReturn(foundPkg, bounds)
-            return
-        }
-    }
-
-    try {
-        val intent = Intent(Intent.ACTION_MAIN).apply {
-            addCategory("android.intent.category.APP_CLOCK")
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        context.startActivity(intent)
-    } catch (_: Exception) {
-        Toast.makeText(context, context.getString(R.string.clock_app_not_found), Toast.LENGTH_SHORT).show()
-    }
-}
-
-private fun launchCalendarApp(
-    context: Context,
-    bounds: Rect?,
-    onAppLaunchForReturn: (String, Rect?) -> Unit,
-    onPackageFound: (String) -> Unit
-) {
-    val pm = context.packageManager
-    var calendarIntent = Intent(Intent.ACTION_VIEW).apply {
-        data = CalendarContract.CONTENT_URI.buildUpon()
-            .appendPath("time")
-            .appendPath(System.currentTimeMillis().toString())
-            .build()
-    }
-    val res = pm.resolveActivity(calendarIntent, 0)
-    if (res == null) {
-        calendarIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR)
-    }
-
-    val foundPkg = pm.resolveActivity(calendarIntent, 0)?.activityInfo?.packageName
-    if (foundPkg != null) {
-        onPackageFound(foundPkg)
-        val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
-        if (launchIntent != null) {
-            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-            onAppLaunchForReturn(foundPkg, bounds)
-        } else {
-            calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
-            onAppLaunchForReturn(foundPkg, bounds)
-        }
-        return
-    }
-
-    try {
-        calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        context.startActivity(calendarIntent)
-    } catch (_: Exception) {
-        val selectorIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK
-        }
-        try {
-            context.startActivity(selectorIntent)
-        } catch (_: Exception) {
         }
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeWidgets.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeWidgets.kt
@@ -1,0 +1,399 @@
+package com.example.androidlauncher.ui
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.provider.AlarmClock
+import android.provider.CalendarContract
+import android.widget.Toast
+import androidx.compose.animation.*
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Sun
+import com.example.androidlauncher.R
+import com.example.androidlauncher.data.WeatherData
+import com.example.androidlauncher.data.WeatherRepository
+import com.example.androidlauncher.ui.theme.*
+import kotlinx.coroutines.delay
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+/**
+ * Startbildschirm-Widgets (Uhr, Datum, Wetterzeile) samt zugehoeriger App-Starts
+ * (A6-Split aus HomeScreen.kt; gleiches Paket, keine Aufrufer-Aenderungen).
+ */
+
+@SuppressLint("WrongConstant")
+internal fun expandNotifications(context: Context) {
+    try {
+        val statusBarService = context.getSystemService("statusbar")
+        val statusBarManager = Class.forName("android.app.StatusBarManager")
+        val method = statusBarManager.getMethod("expandNotificationsPanel")
+        method.invoke(statusBarService)
+    } catch (_: Exception) {
+    }
+}
+
+/**
+ * Großes Uhrzeit-Element (eigenständig verschiebbar). [time] wird vom Aufrufer getickt.
+ */
+@Composable
+fun ClockText(
+    time: java.util.Date,
+    isPreview: Boolean,
+    returnIconPackage: String?,
+    onAppLaunchForReturn: (String, Rect?) -> Unit
+) {
+    val context = LocalContext.current
+    val fontSize = LocalFontSize.current
+    val appFontWeight = LocalFontWeight.current
+    val mainTextColor = LocalHomeTextColor.current
+
+    val timeFormat = remember { SimpleDateFormat("HH:mm", Locale.getDefault()) }
+    val intSrcTime = remember { MutableInteractionSource() }
+    val clockBounds = remember { mutableStateOf<Rect?>(null) }
+    var clockPackage by remember { mutableStateOf<String?>(null) }
+
+    val bounceScaleTime by animateFloatAsState(
+        targetValue = when {
+            !LocalAppCloseAnimationEnabled.current -> 1f
+            returnIconPackage != null && returnIconPackage == clockPackage -> 1.08f
+            else -> 1f
+        },
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "ClockReturnBounce"
+    )
+
+    // Material-3-Expressive: Minutenwechsel per kurzem Crossfade statt hartem Swap.
+    val animationsEnabled = LocalAnimationsEnabled.current
+    Crossfade(
+        targetState = timeFormat.format(time),
+        animationSpec = tween(if (animationsEnabled) 220 else 0),
+        label = "clockCrossfade",
+        modifier = Modifier
+            .onGloballyPositioned { clockBounds.value = it.boundsInRoot() }
+            .graphicsLayer {
+                scaleX = bounceScaleTime
+                scaleY = bounceScaleTime
+            }
+            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (!isPreview) {
+                    Modifier
+                        .bounceClick(intSrcTime)
+                        .clickable(interactionSource = intSrcTime, indication = null) {
+                            launchClockApp(context, clockBounds.value, onAppLaunchForReturn) { clockPackage = it }
+                        }
+                } else {
+                    Modifier
+                }
+            )
+    ) { timeStr ->
+        Text(
+            text = timeStr,
+            // Seitliches/vertikales Polster INNERHALB des Clips, damit Glyphen-Überhänge
+            // (kursive/dekorative Fonts, negatives letterSpacing) nicht abgeschnitten werden.
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+            fontSize = 72.sp * fontSize.scale,
+            fontWeight = appFontWeight.weight,
+            letterSpacing = (-2).sp,
+            lineHeight = 72.sp * fontSize.scale,
+            // Entfernt das zusätzliche Font-Padding (enger Rahmen), behält aber die gewählte
+            // App-Schriftart bei, indem auf den aktuellen LocalTextStyle gemergt wird.
+            // Trim.Both passt die Box an die echten Glyphen an → hohe/dekorative Schriften
+            // werden NICHT vom Clip abgeschnitten.
+            style = LocalTextStyle.current.merge(
+                TextStyle(
+                    platformStyle = PlatformTextStyle(includeFontPadding = false),
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Center,
+                        trim = LineHeightStyle.Trim.Both
+                    )
+                )
+            ),
+            color = mainTextColor
+        )
+    }
+}
+
+/**
+ * Datums-Element (eigenständig verschiebbar). [time] wird vom Aufrufer getickt.
+ */
+@Composable
+fun DateText(
+    time: java.util.Date,
+    isPreview: Boolean,
+    returnIconPackage: String?,
+    onAppLaunchForReturn: (String, Rect?) -> Unit
+) {
+    val context = LocalContext.current
+    val fontSize = LocalFontSize.current
+    val appFontWeight = LocalFontWeight.current
+    val mainTextColor = LocalHomeTextColor.current
+
+    val dateFormat = remember { SimpleDateFormat("EEEE, d. MMMM", Locale.getDefault()) }
+    val intSrcDate = remember { MutableInteractionSource() }
+    val calendarBounds = remember { mutableStateOf<Rect?>(null) }
+    var calendarPackage by remember { mutableStateOf<String?>(null) }
+
+    val bounceScaleDate by animateFloatAsState(
+        targetValue = when {
+            !LocalAppCloseAnimationEnabled.current -> 1f
+            returnIconPackage != null && returnIconPackage == calendarPackage -> 1.08f
+            else -> 1f
+        },
+        animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessMedium),
+        label = "CalendarReturnBounce"
+    )
+
+    // Material-3-Expressive: Datumswechsel (zur Mitternacht) per Crossfade.
+    val animationsEnabled = LocalAnimationsEnabled.current
+    Crossfade(
+        targetState = dateFormat.format(time),
+        animationSpec = tween(if (animationsEnabled) 300 else 0),
+        label = "dateCrossfade",
+        modifier = Modifier
+            .onGloballyPositioned { calendarBounds.value = it.boundsInRoot() }
+            .graphicsLayer {
+                scaleX = bounceScaleDate
+                scaleY = bounceScaleDate
+            }
+            .clip(RoundedCornerShape(8.dp))
+            .then(
+                if (!isPreview) {
+                    Modifier
+                        .bounceClick(intSrcDate)
+                        .clickable(interactionSource = intSrcDate, indication = null) {
+                            launchCalendarApp(
+                                context,
+                                calendarBounds.value,
+                                onAppLaunchForReturn
+                            ) { calendarPackage = it }
+                        }
+                } else {
+                    Modifier
+                }
+            )
+            .padding(horizontal = 4.dp, vertical = 2.dp)
+    ) { dateStr ->
+        Text(
+            text = dateStr,
+            fontSize = 18.sp * fontSize.scale,
+            fontWeight = appFontWeight.weight,
+            lineHeight = 18.sp * fontSize.scale,
+            // Trim.Both passt die Box an die echten Glyphen an (kein Abschneiden).
+            style = LocalTextStyle.current.merge(
+                TextStyle(
+                    platformStyle = PlatformTextStyle(includeFontPadding = false),
+                    lineHeightStyle = LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Center,
+                        trim = LineHeightStyle.Trim.Both
+                    )
+                )
+            ),
+            color = mainTextColor.copy(alpha = 0.7f)
+        )
+    }
+}
+
+/**
+ * Schmale Wetterzeile unter Uhr/Datum: ein Symbol plus aktuelle Temperatur.
+ *
+ * Holt den groben Standort über [WeatherRepository] und ruft das Wetter von Open-Meteo ab.
+ * Solange kein Standort/keine Daten vorliegen (z. B. Berechtigung noch nicht erteilt),
+ * wird in kurzen Abständen erneut versucht; danach im 30-Minuten-Takt aktualisiert.
+ * Im Vorschau-/Edit-Modus wird ein statischer Platzhalter gezeigt (kein Netzwerkzugriff).
+ */
+@Composable
+fun WeatherRow(isPreview: Boolean = false) {
+    val context = LocalContext.current
+    val fontSize = LocalFontSize.current
+    val appFontWeight = LocalFontWeight.current
+    val mainTextColor = LocalHomeTextColor.current
+
+    // Startwert aus dem prozessweiten Cache: zeigt beim Zurückkehren aus dem App-Drawer
+    // sofort den letzten Wert, statt kurz zu verschwinden.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val weather by produceState<WeatherData?>(initialValue = WeatherRepository.cached, isPreview) {
+        if (isPreview) return@produceState
+        val repo = WeatherRepository(context)
+        val refreshIntervalMs = 30 * 60_000L
+        // Nur bei sichtbarem Launcher abrufen: im Hintergrund pausiert der Loop und
+        // prüft beim nächsten ON_START zuerst die Drossel (WeatherRepository.shouldRefresh).
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            while (true) {
+                if (WeatherRepository.shouldRefresh(refreshIntervalMs)) {
+                    // GPS nur, falls die Berechtigung ohnehin erteilt ist; sonst grobe Position
+                    // über die IP-Adresse (ohne Standortdienst/Berechtigung).
+                    val location = repo.awaitLocation() ?: repo.ipLocation()
+                    if (location != null) {
+                        repo.fetch(location.first, location.second)?.let { value = it }
+                    }
+                } else {
+                    // Cache noch aktuell – übernehmen, kein erneuter Netzwerkabruf.
+                    value = WeatherRepository.cached
+                }
+                // Schneller erneut versuchen, solange noch keine Daten vorliegen,
+                // sonst regulär alle 30 Minuten aktualisieren.
+                delay(if (value == null) 20_000L else refreshIntervalMs)
+            }
+        }
+    }
+
+    val icon: ImageVector
+    val temperatureText: String
+    if (isPreview) {
+        icon = Lucide.Sun
+        temperatureText = "21°"
+    } else {
+        val data = weather ?: return
+        icon = WeatherRepository.iconFor(data.weatherCode)
+        temperatureText = "${data.temperatureC}°"
+    }
+
+    // Material-3-Expressive: Wetterwert wechselt per Crossfade statt hartem Swap.
+    val animationsEnabled = LocalAnimationsEnabled.current
+    Crossfade(
+        targetState = icon to temperatureText,
+        animationSpec = tween(if (animationsEnabled) 300 else 0),
+        label = "weatherCrossfade",
+        modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp)
+    ) { (stateIcon, stateTemp) ->
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = stateIcon,
+                contentDescription = null,
+                tint = mainTextColor.copy(alpha = 0.7f),
+                modifier = Modifier.size(18.dp * fontSize.scale)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                text = stateTemp,
+                fontSize = 18.sp * fontSize.scale,
+                fontWeight = appFontWeight.weight,
+                color = mainTextColor.copy(alpha = 0.7f)
+            )
+        }
+    }
+}
+
+private fun launchClockApp(
+    context: Context,
+    bounds: Rect?,
+    onAppLaunchForReturn: (String, Rect?) -> Unit,
+    onPackageFound: (String) -> Unit
+) {
+    val pm = context.packageManager
+    // Bekannte Uhr-Pakete + Auswahl liegen framework-frei in LauncherLogic (unit-getestet).
+    var foundPkg: String? = com.example.androidlauncher.LauncherLogic.firstLaunchablePackage(
+        com.example.androidlauncher.LauncherLogic.KNOWN_CLOCK_PACKAGES
+    ) { pkg -> pm.getLaunchIntentForPackage(pkg) != null }
+
+    if (foundPkg == null) {
+        try {
+            val stdIntent = Intent(Intent.ACTION_MAIN).addCategory("android.intent.category.APP_CLOCK")
+            val res = pm.resolveActivity(stdIntent, 0)
+            if (res != null) foundPkg = res.activityInfo.packageName
+        } catch (_: Exception) {
+        }
+    }
+    if (foundPkg == null) {
+        try {
+            val alarmIntent = Intent(AlarmClock.ACTION_SHOW_ALARMS)
+            val res = pm.resolveActivity(alarmIntent, 0)
+            if (res != null) foundPkg = res.activityInfo.packageName
+        } catch (_: Exception) {
+        }
+    }
+
+    if (foundPkg != null) {
+        onPackageFound(foundPkg)
+        val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
+        if (launchIntent != null) {
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+            onAppLaunchForReturn(foundPkg, bounds)
+            return
+        }
+    }
+
+    try {
+        val intent = Intent(Intent.ACTION_MAIN).apply {
+            addCategory("android.intent.category.APP_CLOCK")
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        context.startActivity(intent)
+    } catch (_: Exception) {
+        Toast.makeText(context, context.getString(R.string.clock_app_not_found), Toast.LENGTH_SHORT).show()
+    }
+}
+
+private fun launchCalendarApp(
+    context: Context,
+    bounds: Rect?,
+    onAppLaunchForReturn: (String, Rect?) -> Unit,
+    onPackageFound: (String) -> Unit
+) {
+    val pm = context.packageManager
+    var calendarIntent = Intent(Intent.ACTION_VIEW).apply {
+        data = CalendarContract.CONTENT_URI.buildUpon()
+            .appendPath("time")
+            .appendPath(System.currentTimeMillis().toString())
+            .build()
+    }
+    val res = pm.resolveActivity(calendarIntent, 0)
+    if (res == null) {
+        calendarIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR)
+    }
+
+    val foundPkg = pm.resolveActivity(calendarIntent, 0)?.activityInfo?.packageName
+    if (foundPkg != null) {
+        onPackageFound(foundPkg)
+        val launchIntent = pm.getLaunchIntentForPackage(foundPkg)
+        if (launchIntent != null) {
+            launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+            onAppLaunchForReturn(foundPkg, bounds)
+        } else {
+            calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_RESET_TASK_IF_NEEDED)
+            onAppLaunchForReturn(foundPkg, bounds)
+        }
+        return
+    }
+
+    try {
+        calendarIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        context.startActivity(calendarIntent)
+    } catch (_: Exception) {
+        val selectorIntent = Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_CALENDAR).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+        }
+        try {
+            context.startActivity(selectorIntent)
+        } catch (_: Exception) {
+        }
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/LauncherLogicTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/LauncherLogicTest.kt
@@ -836,4 +836,48 @@ class LauncherLogicTest {
             )
         )
     }
+
+    // --- Ordner-Grid (3×3-Pager) ---
+
+    @Test
+    fun `folderPageCount rounds up and never drops below one page`() {
+        assertEquals(1, LauncherLogic.folderPageCount(0))
+        assertEquals(1, LauncherLogic.folderPageCount(9))
+        assertEquals(2, LauncherLogic.folderPageCount(10))
+        assertEquals(3, LauncherLogic.folderPageCount(19))
+    }
+
+    @Test
+    fun `folderGridSlotAt maps touch to cell and page offset`() {
+        // 300×300-Grid → Zellen à 100×100; Mitte der mittleren Zelle = Slot 4.
+        assertEquals(4, LauncherLogic.folderGridSlotAt(150f, 150f, 300, 300, currentPage = 0))
+        // Gleiche Zelle auf Seite 2 → +9 Slots.
+        assertEquals(13, LauncherLogic.folderGridSlotAt(150f, 150f, 300, 300, currentPage = 1))
+        // Berührung außerhalb wird auf die Randzelle begrenzt (unten rechts = Slot 8).
+        assertEquals(8, LauncherLogic.folderGridSlotAt(999f, 999f, 300, 300, currentPage = 0))
+    }
+
+    @Test
+    fun `folderGridSlotAt returns null for an unmeasured grid`() {
+        assertNull(LauncherLogic.folderGridSlotAt(10f, 10f, 0, 300, currentPage = 0))
+        assertNull(LauncherLogic.folderGridSlotAt(10f, 10f, 300, 0, currentPage = 0))
+    }
+
+    @Test
+    fun `moveFolderApp reorders and clamps the target index`() {
+        val packages = listOf("a", "b", "c", "d")
+
+        assertEquals(listOf("b", "c", "a", "d"), LauncherLogic.moveFolderApp(packages, "a", 2))
+        // Ziel hinter dem Listenende wird auf den letzten Platz begrenzt.
+        assertEquals(listOf("b", "c", "d", "a"), LauncherLogic.moveFolderApp(packages, "a", 99))
+    }
+
+    @Test
+    fun `moveFolderApp returns null when nothing changes or the app is missing`() {
+        val packages = listOf("a", "b", "c")
+
+        assertNull(LauncherLogic.moveFolderApp(packages, "b", 1))
+        assertNull(LauncherLogic.moveFolderApp(packages, "zz", 0))
+        assertNull(LauncherLogic.moveFolderApp(emptyList(), "a", 0))
+    }
 }

--- a/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
@@ -1,0 +1,50 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.ui.geometry.Offset
+import com.example.androidlauncher.data.HomeLayout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Absicherung des A6-Splits: der Holder seedet aus dem persistierten Layout und
+ * liefert die Live-Offsets als speicherbares HomeLayout zurück (Roundtrip).
+ */
+class HomeDragStateHolderTest {
+
+    @Test
+    fun `initial state mirrors the given layout and has no selection`() {
+        val layout = HomeLayout(clock = Offset(10f, 20f), favorites = Offset(-4f, 8f))
+        val holder = HomeDragStateHolder(layout)
+
+        assertEquals(layout, holder.toHomeLayout())
+        assertNull(holder.selectedEditTarget)
+        assertFalse(holder.isEditTargetUserPinned)
+        assertFalse(holder.collisionHapticWasTriggered)
+    }
+
+    @Test
+    fun `live edits roundtrip into a persistable layout`() {
+        val holder = HomeDragStateHolder(HomeLayout())
+
+        holder.offsets[HomeEditTarget.CLOCK] = Offset(42f, -12f)
+        holder.offsets[HomeEditTarget.WEATHER] = Offset(0f, 30f)
+
+        assertEquals(
+            HomeLayout(clock = Offset(42f, -12f), weather = Offset(0f, 30f)),
+            holder.toHomeLayout()
+        )
+    }
+
+    @Test
+    fun `seedFrom reverts live offsets to the stored layout`() {
+        val stored = HomeLayout(date = Offset(5f, 5f))
+        val holder = HomeDragStateHolder(stored)
+
+        holder.offsets[HomeEditTarget.DATE] = Offset(99f, 99f)
+        holder.seedFrom(stored)
+
+        assertEquals(stored, holder.toHomeLayout())
+    }
+}


### PR DESCRIPTION
## Was dieser PR macht

Letztes Refactoring-Item des Verbesserungsplans (A6): HomeScreen und AppDrawer werden entflochten. Damit ist **Workstream A (A1–A8) vollständig** — und die Vorarbeit für den AppWidgetHost-Support (B1) steht.

## Änderungen

**HomeScreen.kt: 1.632 → 1.065 Zeilen**
- `ui/HomeWidgets.kt`: ClockText/DateText/WeatherRow + zugehörige App-Starts + `expandNotifications` — reine Datei-Moves im selben Paket, keine Aufrufer-Änderungen.
- `ui/FavoriteItem.kt`: Favoriten-Eintrag + Edit-Steuerknopf.
- `ui/HomeDragStateHolder.kt` (neu, getestet): bündelt die neun Edit-Modus-Zustände (Live-Offsets, Neutral-Bounds, Kollisions-/Haptik-Buchführung, Auswahl) mit `seedFrom`/`toHomeLayout`-Roundtrip. HomeScreen delegiert per Property-Delegation — der Composable-Body blieb unangetastet. **B1 (AppWidgetHost) setzt hier auf:** platzierte Widgets nutzen später denselben Drag-Mechanismus wie Uhr/Wetter.

**AppDrawer**
- Die dreifach duplizierte 3×3-Ordner-Grid-Rechnung (Seitenanzahl, Touch→Slot, Umsortieren mit Clamping) ist jetzt framework-frei in `LauncherLogic` (`folderPageCount`/`folderGridSlotAt`/`moveFolderApp`) — im Composable bleiben nur Persistenz + Haptik.

**Sonstiges**
- Neue Tests: Folder-Grid (Rundung, Zell-Mapping, Rand-Clamping, No-Op-Fälle) + HomeDragStateHolder (Seed/Roundtrip).
- Zwei vorher baselinierte MaxLineLength-Verstöße beim Verschieben echt gefixt.
- Kover-Excludes für die neuen reinen UI-Dateien.

## Für Reviewer

- Signaturen von `HomeScreen`/`AppDrawer` sind unverändert — MainActivity und UI-Tests kompilieren ohne Anpassung.
- **Manuell testen:** Edit-Modus (Uhr/Datum/Wetter/Favoriten verschieben, Kollisions-Haptik, Speichern/Abbrechen), Ordner im Drawer umsortieren (auch über Seitengrenzen ziehen).
- Gates lokal grün: `detekt`, `testDebugUnitTest`, `koverVerifyDebug`, `compileDebugAndroidTestKotlin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)