### PR TITLE
feat(B1): Widget-Host-Datenschicht – HostedWidget, Serializer, Bind-Flow, WidgetHostManager

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/data/HostedWidget.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/HostedWidget.kt
@@ -1,0 +1,24 @@
+package com.example.androidlauncher.data
+
+import android.content.ComponentName
+
+/**
+ * Ein auf dem Startbildschirm platziertes System-Widget (AppWidgetHost, B1).
+ *
+ * Wird als JSON-Liste in den HomeLayoutSettings persistiert (siehe [WidgetSerializer]);
+ * die Offsets liegen bewusst mit im Eintrag, damit Hinzufuegen/Verschieben/Entfernen
+ * ein einziger atomarer DataStore-Write ist.
+ */
+data class HostedWidget(
+    /** Vom AppWidgetHost allokierte, systemweite Widget-ID. */
+    val appWidgetId: Int,
+    /** Provider als `ComponentName.flattenToString()` – JSON-freundlich. */
+    val provider: String,
+    val widthDp: Int,
+    val heightDp: Int,
+    /** Verschiebung in px relativ zur natuerlichen Ankerposition (gleiche Semantik wie HomeLayout). */
+    val offsetX: Float = 0f,
+    val offsetY: Float = 0f,
+) {
+    fun providerComponent(): ComponentName? = ComponentName.unflattenFromString(provider)
+}

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
@@ -1,0 +1,121 @@
+package com.example.androidlauncher.data
+
+/**
+ * Framework-freie Entscheidungslogik rund um das Binden und Aufraeumen gehosteter
+ * System-Widgets (B1). Die Seiteneffekte (AppWidgetHost-/AppWidgetManager-Aufrufe,
+ * Activity-Ergebnisse) liegen in [WidgetHostManager] bzw. der MainActivity – hier
+ * werden nur IDs und Booleans in den naechsten Schritt uebersetzt, damit der
+ * komplette Flow als Unit-Test abgedeckt werden kann.
+ */
+
+/** Ein laufender Bind-Vorgang: ID ist bereits allokiert, aber noch nicht persistiert. */
+data class PendingWidgetBind(
+    val appWidgetId: Int,
+    /** Provider als `ComponentName.flattenToString()`. */
+    val provider: String,
+    /** Ob der Provider eine Configure-Activity deklariert (`AppWidgetProviderInfo.configure`). */
+    val needsConfigure: Boolean,
+)
+
+/** Naechster Schritt im Bind-Flow. */
+sealed interface WidgetBindStep {
+    /** Bind wurde verweigert – System-Consent-Dialog (`ACTION_APPWIDGET_BIND`) starten. */
+    data class RequestBindPermission(val pending: PendingWidgetBind) : WidgetBindStep
+
+    /** Configure-Activity des Providers starten (via `startAppWidgetConfigureActivityForResult`). */
+    data class LaunchConfigure(val pending: PendingWidgetBind) : WidgetBindStep
+
+    /** Widget persistieren und anzeigen – der Flow ist erfolgreich abgeschlossen. */
+    data class Commit(val pending: PendingWidgetBind) : WidgetBindStep
+
+    /** Abbruch: die allokierte ID muss wieder freigegeben werden (`deleteAppWidgetId`). */
+    data class Abort(val appWidgetId: Int) : WidgetBindStep
+}
+
+/** Zustandsmaschine des Bind-/Configure-Flows – ein Schritt pro Activity-Ergebnis. */
+object WidgetBindFlow {
+
+    /** Nach `allocateAppWidgetId` + `bindAppWidgetIdIfAllowed`. */
+    fun afterAllocate(pending: PendingWidgetBind, bindSucceeded: Boolean): WidgetBindStep = when {
+        !bindSucceeded -> WidgetBindStep.RequestBindPermission(pending)
+        pending.needsConfigure -> WidgetBindStep.LaunchConfigure(pending)
+        else -> WidgetBindStep.Commit(pending)
+    }
+
+    /** Nach dem System-Consent-Dialog (`ACTION_APPWIDGET_BIND`). */
+    fun afterBindPermission(pending: PendingWidgetBind, granted: Boolean): WidgetBindStep = when {
+        !granted -> WidgetBindStep.Abort(pending.appWidgetId)
+        pending.needsConfigure -> WidgetBindStep.LaunchConfigure(pending)
+        else -> WidgetBindStep.Commit(pending)
+    }
+
+    /** Nach der Configure-Activity des Providers. */
+    fun afterConfigure(pending: PendingWidgetBind, resultOk: Boolean): WidgetBindStep =
+        if (resultOk) WidgetBindStep.Commit(pending) else WidgetBindStep.Abort(pending.appWidgetId)
+}
+
+/**
+ * Ergebnis des Orphan-Cleanups beim Start: [idsToDelete] werden im Host freigegeben,
+ * [idsToRemoveFromPersistence] zusaetzlich aus dem persistierten Bestand entfernt.
+ */
+data class WidgetCleanup(
+    val idsToDelete: List<Int>,
+    val idsToRemoveFromPersistence: List<Int>,
+)
+
+/**
+ * Gleicht persistierte Widgets mit den im Host allokierten IDs ab:
+ * - allokiert, aber nicht persistiert → geleakte ID (Prozess-Tod mitten im Bind-Flow) → freigeben;
+ * - persistiert, aber Provider existiert nicht mehr (deinstalliert) → freigeben + aus Bestand entfernen.
+ */
+fun resolveWidgetCleanup(
+    persistedIds: List<Int>,
+    allocatedIds: List<Int>,
+    infoExists: (Int) -> Boolean,
+): WidgetCleanup {
+    val leaked = allocatedIds.filterNot { it in persistedIds }
+    val stale = persistedIds.filterNot(infoExists)
+    return WidgetCleanup(
+        idsToDelete = leaked + stale,
+        idsToRemoveFromPersistence = stale,
+    )
+}
+
+/** Anzeigegroesse eines gehosteten Widgets in dp. */
+data class WidgetSizeDp(val widthDp: Int, val heightDp: Int)
+
+/** Rastergroesse einer Launcher-Zelle, mit der `targetCellWidth/Height` multipliziert wird. */
+private const val WIDGET_CELL_SIZE_DP = 70
+
+/** Untergrenzen, damit auch "0dp"-Provider-Angaben ein greifbares Widget ergeben. */
+private const val MIN_WIDGET_WIDTH_DP = 110
+private const val MIN_WIDGET_HEIGHT_DP = 40
+
+/** Seitenrand, den ein Widget in der Breite nie ueberdecken darf. */
+private const val SCREEN_EDGE_MARGIN_DP = 48
+
+/** Hoehen-Kappung, damit ein einzelnes Widget nicht den ganzen Screen einnimmt. */
+private const val MAX_HEIGHT_SCREEN_FRACTION = 0.6f
+
+/**
+ * Default-Groesse beim Binden (MVP ohne Resize): bevorzugt die Zell-Angaben des Providers
+ * (API 31+, `targetCellWidth/Height`, 0 = nicht gesetzt), sonst `minWidth/minHeight` –
+ * geclampt auf sinnvolle Unter-/Obergrenzen relativ zur Screen-Groesse.
+ */
+fun defaultWidgetSizeDp(
+    targetCellWidth: Int,
+    targetCellHeight: Int,
+    minWidthDp: Int,
+    minHeightDp: Int,
+    screenWidthDp: Int,
+    screenHeightDp: Int,
+): WidgetSizeDp {
+    val rawWidth = if (targetCellWidth > 0) targetCellWidth * WIDGET_CELL_SIZE_DP else minWidthDp
+    val rawHeight = if (targetCellHeight > 0) targetCellHeight * WIDGET_CELL_SIZE_DP else minHeightDp
+    val maxWidth = (screenWidthDp - SCREEN_EDGE_MARGIN_DP).coerceAtLeast(MIN_WIDGET_WIDTH_DP)
+    val maxHeight = (screenHeightDp * MAX_HEIGHT_SCREEN_FRACTION).toInt().coerceAtLeast(MIN_WIDGET_HEIGHT_DP)
+    return WidgetSizeDp(
+        widthDp = rawWidth.coerceIn(MIN_WIDGET_WIDTH_DP, maxWidth),
+        heightDp = rawHeight.coerceIn(MIN_WIDGET_HEIGHT_DP, maxHeight),
+    )
+}

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
@@ -1,0 +1,133 @@
+package com.example.androidlauncher.data
+
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetHostView
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProviderInfo
+import android.content.ComponentName
+import android.content.Context
+import androidx.compose.ui.geometry.Offset
+import com.example.androidlauncher.data.settings.HomeLayoutSettings
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+
+/**
+ * Besitzt den prozessweiten [AppWidgetHost] fuer gehostete System-Widgets (B1):
+ * ID-Allokation/-Freigabe, Bind-Versuche, Lifecycle (start/stopListening – von der
+ * MainActivity an ON_START/ON_STOP gebunden), View-Cache sowie die Persistenz der
+ * platzierten Widgets ueber [HomeLayoutSettings].
+ *
+ * System-Aufrufe sind in `runCatching` gekapselt: einzelne OEMs werfen aus
+ * AppWidget-APIs SecurityExceptions, die hier als "nicht moeglich" behandelt werden.
+ */
+class WidgetHostManager(
+    private val appContext: Context,
+    private val host: AppWidgetHost,
+    private val appWidgetManager: AppWidgetManager,
+    private val settings: HomeLayoutSettings,
+) {
+
+    /** Produktiv-Konstruktor; der Test-Konstruktor injiziert Host/Manager/Settings direkt. */
+    constructor(context: Context, settings: HomeLayoutSettings) : this(
+        context.applicationContext,
+        AppWidgetHost(context.applicationContext, WIDGET_HOST_ID),
+        AppWidgetManager.getInstance(context.applicationContext),
+        settings,
+    )
+
+    companion object {
+        /** Feste Host-ID: muss nur ueber App-Starts stabil sein (Namensraum ist per-Package). */
+        const val WIDGET_HOST_ID = 0x5254
+    }
+
+    /**
+     * Cache der erzeugten Host-Views (eine pro Widget-ID): Recomposition und
+     * Edit-Mode-Toggles duerfen die View nie neu erzeugen, sonst verliert das
+     * Widget seinen internen Zustand (z. B. Scroll-Position).
+     */
+    private val hostViews = mutableMapOf<Int, AppWidgetHostView>()
+
+    /** Persistierte, platzierte Widgets. */
+    val widgets: Flow<List<HostedWidget>> get() = settings.hostedWidgets
+
+    fun allocateWidgetId(): Int = host.allocateAppWidgetId()
+
+    /** `true`, wenn der Bind ohne User-Consent gelang; Exceptions zaehlen als "nicht gebunden". */
+    fun bindIfAllowed(appWidgetId: Int, provider: ComponentName): Boolean =
+        runCatching { appWidgetManager.bindAppWidgetIdIfAllowed(appWidgetId, provider) }
+            .getOrDefault(false)
+
+    /** Gibt die ID im Host frei und verwirft eine evtl. gecachte View. */
+    fun deleteWidgetId(appWidgetId: Int) {
+        hostViews.remove(appWidgetId)
+        runCatching { host.deleteAppWidgetId(appWidgetId) }
+    }
+
+    fun startListening() {
+        runCatching { host.startListening() }
+    }
+
+    fun stopListening() {
+        runCatching { host.stopListening() }
+    }
+
+    fun providerInfo(appWidgetId: Int): AppWidgetProviderInfo? =
+        runCatching { appWidgetManager.getAppWidgetInfo(appWidgetId) }.getOrNull()
+
+    /**
+     * Liefert die (gecachte) Host-View fuer ein gebundenes Widget oder `null`,
+     * wenn der Provider nicht mehr existiert. Erzeugt bewusst mit dem
+     * Application-Context, damit keine Activity geleakt wird.
+     */
+    fun createView(appWidgetId: Int): AppWidgetHostView? {
+        hostViews[appWidgetId]?.let { return it }
+        val info = providerInfo(appWidgetId) ?: return null
+        return runCatching { host.createView(appContext, appWidgetId, info) }
+            .getOrNull()
+            ?.also { hostViews[appWidgetId] = it }
+    }
+
+    /** Haengt ein fertig gebundenes/konfiguriertes Widget an den persistierten Bestand an. */
+    suspend fun addWidget(widget: HostedWidget) {
+        settings.setHostedWidgets(settings.hostedWidgets.first() + widget)
+    }
+
+    /** Entfernt ein Widget vollstaendig: Host-ID freigeben + aus der Persistenz loeschen. */
+    suspend fun removeWidget(appWidgetId: Int) {
+        deleteWidgetId(appWidgetId)
+        settings.setHostedWidgets(
+            settings.hostedWidgets.first().filterNot { it.appWidgetId == appWidgetId }
+        )
+    }
+
+    /** Persistiert neue Edit-Mode-Offsets (ein atomarer Write fuer alle Widgets). */
+    suspend fun updateOffsets(offsets: Map<Int, Offset>) {
+        if (offsets.isEmpty()) return
+        val updated = settings.hostedWidgets.first().map { widget ->
+            offsets[widget.appWidgetId]
+                ?.let { widget.copy(offsetX = it.x, offsetY = it.y) }
+                ?: widget
+        }
+        settings.setHostedWidgets(updated)
+    }
+
+    /**
+     * Raeumt beim Start Leichen auf (siehe [resolveWidgetCleanup]): geleakte IDs aus
+     * abgebrochenen Bind-Flows und Widgets deinstallierter Provider.
+     */
+    suspend fun cleanupOrphans() {
+        val persisted = settings.hostedWidgets.first()
+        val allocated = runCatching { host.appWidgetIds.toList() }.getOrDefault(emptyList())
+        val cleanup = resolveWidgetCleanup(
+            persistedIds = persisted.map { it.appWidgetId },
+            allocatedIds = allocated,
+            infoExists = { providerInfo(it) != null },
+        )
+        cleanup.idsToDelete.forEach(::deleteWidgetId)
+        if (cleanup.idsToRemoveFromPersistence.isNotEmpty()) {
+            settings.setHostedWidgets(
+                persisted.filterNot { it.appWidgetId in cleanup.idsToRemoveFromPersistence }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetSerializer.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetSerializer.kt
@@ -1,0 +1,58 @@
+package com.example.androidlauncher.data
+
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+/**
+ * Serialisiert die Liste der gehosteten System-Widgets nach/aus JSON
+ * (Muster: [FolderSerializer]). Korrupte Eingaben liefern eine leere Liste –
+ * ein halb geparster Widget-Bestand waere inkonsistent zum AppWidgetHost.
+ */
+object WidgetSerializer {
+
+    private const val KEY_APP_WIDGET_ID = "appWidgetId"
+    private const val KEY_PROVIDER = "provider"
+    private const val KEY_WIDTH_DP = "widthDp"
+    private const val KEY_HEIGHT_DP = "heightDp"
+    private const val KEY_OFFSET_X = "offsetX"
+    private const val KEY_OFFSET_Y = "offsetY"
+
+    fun parseWidgets(jsonString: String): List<HostedWidget> {
+        val list = mutableListOf<HostedWidget>()
+        try {
+            val jsonArray = JSONArray(jsonString)
+            for (i in 0 until jsonArray.length()) {
+                val obj = jsonArray.getJSONObject(i)
+                list.add(
+                    HostedWidget(
+                        appWidgetId = obj.getInt(KEY_APP_WIDGET_ID),
+                        provider = obj.getString(KEY_PROVIDER),
+                        widthDp = obj.getInt(KEY_WIDTH_DP),
+                        heightDp = obj.getInt(KEY_HEIGHT_DP),
+                        offsetX = obj.optDouble(KEY_OFFSET_X, 0.0).toFloat(),
+                        offsetY = obj.optDouble(KEY_OFFSET_Y, 0.0).toFloat(),
+                    )
+                )
+            }
+        } catch (_: JSONException) {
+            return emptyList()
+        }
+        return list
+    }
+
+    fun serializeWidgets(widgets: List<HostedWidget>): String {
+        val jsonArray = JSONArray()
+        widgets.forEach { widget ->
+            val obj = JSONObject()
+            obj.put(KEY_APP_WIDGET_ID, widget.appWidgetId)
+            obj.put(KEY_PROVIDER, widget.provider)
+            obj.put(KEY_WIDTH_DP, widget.widthDp)
+            obj.put(KEY_HEIGHT_DP, widget.heightDp)
+            obj.put(KEY_OFFSET_X, widget.offsetX.toDouble())
+            obj.put(KEY_OFFSET_Y, widget.offsetY.toDouble())
+            jsonArray.put(obj)
+        }
+        return jsonArray.toString()
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/data/settings/HomeLayoutSettings.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/settings/HomeLayoutSettings.kt
@@ -10,6 +10,8 @@ import androidx.datastore.preferences.core.floatPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.example.androidlauncher.data.FavoritesBorderStyle
 import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.HostedWidget
+import com.example.androidlauncher.data.WidgetSerializer
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -50,6 +52,10 @@ class HomeLayoutSettings(private val dataStore: DataStore<Preferences>) {
         private val DATE_OFFSET_Y_KEY = floatPreferencesKey("date_offset_y")
         private val WEATHER_OFFSET_X_KEY = floatPreferencesKey("weather_offset_x")
         private val WEATHER_OFFSET_Y_KEY = floatPreferencesKey("weather_offset_y")
+
+        // Gehostete System-Widgets (B1) als JSON-Liste – variable Laenge passt nicht
+        // zu festen Float-Key-Paaren, daher ein einzelner String-Key.
+        private val HOSTED_WIDGETS_KEY = stringPreferencesKey("hosted_widgets")
     }
 
     val showFavoriteLabels: Flow<Boolean> = dataStore.data
@@ -82,6 +88,10 @@ class HomeLayoutSettings(private val dataStore: DataStore<Preferences>) {
     /** Ob das Erststart-Onboarding bereits abgeschlossen wurde. Default: false. */
     val isOnboardingCompleted: Flow<Boolean> = dataStore.data
         .map { it[ONBOARDING_COMPLETED_KEY] ?: false }
+
+    /** Gehostete System-Widgets (AppWidgetHost, B1); korrupte Daten ergeben eine leere Liste. */
+    val hostedWidgets: Flow<List<HostedWidget>> = dataStore.data
+        .map { WidgetSerializer.parseWidgets(it[HOSTED_WIDGETS_KEY] ?: "[]") }
 
     // Positionen aller unabhängig verschiebbaren Startbildschirm-Elemente.
     val homeLayout: Flow<HomeLayout> = dataStore.data
@@ -125,6 +135,11 @@ class HomeLayoutSettings(private val dataStore: DataStore<Preferences>) {
     /** Markiert das Erststart-Onboarding als abgeschlossen (oder setzt es zurück). */
     suspend fun setOnboardingCompleted(completed: Boolean) {
         dataStore.edit { it[ONBOARDING_COMPLETED_KEY] = completed }
+    }
+
+    /** Ersetzt den kompletten Bestand gehosteter Widgets (ein atomarer Write). */
+    suspend fun setHostedWidgets(widgets: List<HostedWidget>) {
+        dataStore.edit { it[HOSTED_WIDGETS_KEY] = WidgetSerializer.serializeWidgets(widgets) }
     }
 
     // Persistiert die Positionen aller verschiebbaren Startbildschirm-Elemente.

--- a/app/src/main/java/com/example/androidlauncher/di/DataModule.kt
+++ b/app/src/main/java/com/example/androidlauncher/di/DataModule.kt
@@ -11,6 +11,7 @@ import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.data.NotificationStateStore
 import com.example.androidlauncher.data.SearchSuggestionsManager
 import com.example.androidlauncher.data.ThemeManager
+import com.example.androidlauncher.data.WidgetHostManager
 import com.example.androidlauncher.data.settings.AnimationSettings
 import com.example.androidlauncher.data.settings.AppearanceSettings
 import com.example.androidlauncher.data.settings.GestureSettings
@@ -122,4 +123,11 @@ object DataModule {
     @Singleton
     fun provideHomeLayoutSettings(@ApplicationContext context: Context): HomeLayoutSettings =
         HomeLayoutSettings(context)
+
+    @Provides
+    @Singleton
+    fun provideWidgetHostManager(
+        @ApplicationContext context: Context,
+        homeLayoutSettings: HomeLayoutSettings,
+    ): WidgetHostManager = WidgetHostManager(context, homeLayoutSettings)
 }

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetBindFlowTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetBindFlowTest.kt
@@ -1,0 +1,159 @@
+package com.example.androidlauncher.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class WidgetBindFlowTest {
+
+    private val plain = PendingWidgetBind(appWidgetId = 5, provider = "a/b", needsConfigure = false)
+    private val withConfigure = plain.copy(needsConfigure = true)
+
+    // --- afterAllocate ---
+
+    @Test
+    fun `bind succeeded without configure commits directly`() {
+        assertEquals(WidgetBindStep.Commit(plain), WidgetBindFlow.afterAllocate(plain, bindSucceeded = true))
+    }
+
+    @Test
+    fun `bind succeeded with configure launches configure`() {
+        assertEquals(
+            WidgetBindStep.LaunchConfigure(withConfigure),
+            WidgetBindFlow.afterAllocate(withConfigure, bindSucceeded = true)
+        )
+    }
+
+    @Test
+    fun `bind denied requests permission regardless of configure`() {
+        assertEquals(
+            WidgetBindStep.RequestBindPermission(plain),
+            WidgetBindFlow.afterAllocate(plain, bindSucceeded = false)
+        )
+        assertEquals(
+            WidgetBindStep.RequestBindPermission(withConfigure),
+            WidgetBindFlow.afterAllocate(withConfigure, bindSucceeded = false)
+        )
+    }
+
+    // --- afterBindPermission ---
+
+    @Test
+    fun `granted permission without configure commits`() {
+        assertEquals(WidgetBindStep.Commit(plain), WidgetBindFlow.afterBindPermission(plain, granted = true))
+    }
+
+    @Test
+    fun `granted permission with configure launches configure`() {
+        assertEquals(
+            WidgetBindStep.LaunchConfigure(withConfigure),
+            WidgetBindFlow.afterBindPermission(withConfigure, granted = true)
+        )
+    }
+
+    @Test
+    fun `denied permission aborts with the allocated id`() {
+        assertEquals(WidgetBindStep.Abort(5), WidgetBindFlow.afterBindPermission(plain, granted = false))
+    }
+
+    // --- afterConfigure ---
+
+    @Test
+    fun `configure ok commits, cancel aborts`() {
+        assertEquals(
+            WidgetBindStep.Commit(withConfigure),
+            WidgetBindFlow.afterConfigure(withConfigure, resultOk = true)
+        )
+        assertEquals(
+            WidgetBindStep.Abort(5),
+            WidgetBindFlow.afterConfigure(withConfigure, resultOk = false)
+        )
+    }
+
+    // --- resolveWidgetCleanup ---
+
+    @Test
+    fun `cleanup with consistent state is empty`() {
+        val cleanup = resolveWidgetCleanup(
+            persistedIds = listOf(1, 2),
+            allocatedIds = listOf(1, 2),
+            infoExists = { true },
+        )
+        assertEquals(emptyList<Int>(), cleanup.idsToDelete)
+        assertEquals(emptyList<Int>(), cleanup.idsToRemoveFromPersistence)
+    }
+
+    @Test
+    fun `allocated but unpersisted ids are deleted only`() {
+        val cleanup = resolveWidgetCleanup(
+            persistedIds = listOf(1),
+            allocatedIds = listOf(1, 9),
+            infoExists = { true },
+        )
+        assertEquals(listOf(9), cleanup.idsToDelete)
+        assertEquals(emptyList<Int>(), cleanup.idsToRemoveFromPersistence)
+    }
+
+    @Test
+    fun `persisted ids without provider info are deleted and unpersisted`() {
+        val cleanup = resolveWidgetCleanup(
+            persistedIds = listOf(1, 2),
+            allocatedIds = listOf(1, 2),
+            infoExists = { it == 1 },
+        )
+        assertEquals(listOf(2), cleanup.idsToDelete)
+        assertEquals(listOf(2), cleanup.idsToRemoveFromPersistence)
+    }
+
+    @Test
+    fun `leaked and stale ids combine`() {
+        val cleanup = resolveWidgetCleanup(
+            persistedIds = listOf(1, 2),
+            allocatedIds = listOf(1, 2, 3),
+            infoExists = { it == 1 },
+        )
+        assertEquals(listOf(3, 2), cleanup.idsToDelete)
+        assertEquals(listOf(2), cleanup.idsToRemoveFromPersistence)
+    }
+
+    // --- defaultWidgetSizeDp ---
+
+    @Test
+    fun `target cells take precedence over min sizes`() {
+        val size = defaultWidgetSizeDp(
+            targetCellWidth = 4,
+            targetCellHeight = 2,
+            minWidthDp = 50,
+            minHeightDp = 50,
+            screenWidthDp = 400,
+            screenHeightDp = 800,
+        )
+        assertEquals(WidgetSizeDp(280, 140), size)
+    }
+
+    @Test
+    fun `without target cells min sizes are used and floored`() {
+        val size = defaultWidgetSizeDp(
+            targetCellWidth = 0,
+            targetCellHeight = 0,
+            minWidthDp = 60,
+            minHeightDp = 20,
+            screenWidthDp = 400,
+            screenHeightDp = 800,
+        )
+        // Untergrenzen: 110dp Breite, 40dp Hoehe.
+        assertEquals(WidgetSizeDp(110, 40), size)
+    }
+
+    @Test
+    fun `width is capped by screen minus margin and height by screen fraction`() {
+        val size = defaultWidgetSizeDp(
+            targetCellWidth = 0,
+            targetCellHeight = 0,
+            minWidthDp = 999,
+            minHeightDp = 999,
+            screenWidthDp = 400,
+            screenHeightDp = 800,
+        )
+        assertEquals(WidgetSizeDp(400 - 48, (800 * 0.6f).toInt()), size)
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
@@ -1,0 +1,139 @@
+package com.example.androidlauncher.data
+
+import android.appwidget.AppWidgetHost
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import androidx.compose.ui.geometry.Offset
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.example.androidlauncher.data.settings.HomeLayoutSettings
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WidgetHostManagerTest {
+
+    private lateinit var testFile: File
+    private lateinit var settings: HomeLayoutSettings
+    private lateinit var host: AppWidgetHost
+    private lateinit var appWidgetManager: AppWidgetManager
+    private lateinit var manager: WidgetHostManager
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    @Before
+    fun setup() {
+        testFile = File.createTempFile("widget_host_manager_test", ".preferences_pb")
+        val testDataStore = PreferenceDataStoreFactory.create(
+            scope = testScope.backgroundScope,
+            produceFile = { testFile }
+        )
+        settings = HomeLayoutSettings(testDataStore)
+        host = mockk(relaxed = true)
+        appWidgetManager = mockk(relaxed = true)
+        manager = WidgetHostManager(mockk<Context>(relaxed = true), host, appWidgetManager, settings)
+    }
+
+    @After
+    fun tearDown() {
+        testFile.delete()
+    }
+
+    private fun widget(id: Int) = HostedWidget(
+        appWidgetId = id,
+        provider = "com.example/$id",
+        widthDp = 200,
+        heightDp = 100,
+    )
+
+    @Test
+    fun `allocateWidgetId delegates to host`() {
+        every { host.allocateAppWidgetId() } returns 42
+
+        assertEquals(42, manager.allocateWidgetId())
+    }
+
+    @Test
+    fun `bindIfAllowed returns manager result and treats exceptions as not bound`() {
+        val provider = mockk<ComponentName>()
+        every { appWidgetManager.bindAppWidgetIdIfAllowed(1, provider) } returns true
+        every { appWidgetManager.bindAppWidgetIdIfAllowed(2, provider) } throws SecurityException("OEM")
+
+        assertTrue(manager.bindIfAllowed(1, provider))
+        assertFalse(manager.bindIfAllowed(2, provider))
+    }
+
+    @Test
+    fun `addWidget appends to persisted list`() = testScope.runTest {
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+
+        assertEquals(listOf(widget(1), widget(2)), manager.widgets.first())
+    }
+
+    @Test
+    fun `removeWidget deletes host id and removes from persistence`() = testScope.runTest {
+        every { host.deleteAppWidgetId(any()) } just Runs
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+
+        manager.removeWidget(1)
+
+        assertEquals(listOf(widget(2)), manager.widgets.first())
+        verify { host.deleteAppWidgetId(1) }
+    }
+
+    @Test
+    fun `updateOffsets rewrites only matching entries`() = testScope.runTest {
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+
+        manager.updateOffsets(mapOf(1 to Offset(15f, -25f)))
+
+        val result = manager.widgets.first()
+        assertEquals(widget(1).copy(offsetX = 15f, offsetY = -25f), result.first { it.appWidgetId == 1 })
+        assertEquals(widget(2), result.first { it.appWidgetId == 2 })
+    }
+
+    @Test
+    fun `cleanupOrphans deletes leaked ids and prunes uninstalled providers`() = testScope.runTest {
+        every { host.deleteAppWidgetId(any()) } just Runs
+        // Persistiert: 1 (Provider vorhanden) und 2 (Provider deinstalliert); im Host geleakt: 3.
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+        every { host.appWidgetIds } returns intArrayOf(1, 2, 3)
+        every { appWidgetManager.getAppWidgetInfo(1) } returns mockk()
+        every { appWidgetManager.getAppWidgetInfo(2) } returns null
+
+        manager.cleanupOrphans()
+
+        assertEquals(listOf(widget(1)), manager.widgets.first())
+        verify { host.deleteAppWidgetId(3) }
+        verify { host.deleteAppWidgetId(2) }
+        verify(exactly = 0) { host.deleteAppWidgetId(1) }
+    }
+
+    @Test
+    fun `createView returns null when provider info is missing`() {
+        every { appWidgetManager.getAppWidgetInfo(9) } returns null
+
+        assertNull(manager.createView(9))
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetSerializerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetSerializerTest.kt
@@ -1,0 +1,63 @@
+package com.example.androidlauncher.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidgetSerializerTest {
+
+    private val widgets = listOf(
+        HostedWidget(
+            appWidgetId = 42,
+            provider = "com.example.app/com.example.app.ClockWidgetProvider",
+            widthDp = 280,
+            heightDp = 140,
+            offsetX = 12.5f,
+            offsetY = -30f,
+        ),
+        HostedWidget(
+            appWidgetId = 7,
+            provider = "com.other.app/com.other.app.Widget",
+            widthDp = 110,
+            heightDp = 40,
+        ),
+    )
+
+    @Test
+    fun `roundtrip preserves all fields`() {
+        val json = WidgetSerializer.serializeWidgets(widgets)
+        val parsed = WidgetSerializer.parseWidgets(json)
+
+        assertEquals(widgets, parsed)
+    }
+
+    @Test
+    fun `empty list roundtrips to empty list`() {
+        val json = WidgetSerializer.serializeWidgets(emptyList())
+        assertTrue(WidgetSerializer.parseWidgets(json).isEmpty())
+    }
+
+    @Test
+    fun `corrupt json returns empty list`() {
+        assertTrue(WidgetSerializer.parseWidgets("not json at all").isEmpty())
+        assertTrue(WidgetSerializer.parseWidgets("{\"kein\":\"array\"}").isEmpty())
+        assertTrue(WidgetSerializer.parseWidgets("").isEmpty())
+    }
+
+    @Test
+    fun `entry with missing required field returns empty list`() {
+        // widthDp fehlt – ein halb geparster Bestand waere inkonsistent, also alles verwerfen.
+        val json = """[{"appWidgetId":1,"provider":"a/b","heightDp":100}]"""
+        assertTrue(WidgetSerializer.parseWidgets(json).isEmpty())
+    }
+
+    @Test
+    fun `missing offsets default to zero`() {
+        val json = """[{"appWidgetId":1,"provider":"a/b","widthDp":100,"heightDp":50}]"""
+        val parsed = WidgetSerializer.parseWidgets(json)
+
+        assertEquals(1, parsed.size)
+        assertEquals(0f, parsed.first().offsetX, 0f)
+        assertEquals(0f, parsed.first().offsetY, 0f)
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/settings/HomeLayoutSettingsTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/settings/HomeLayoutSettingsTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.example.androidlauncher.data.FavoritesBorderStyle
 import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.HostedWidget
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
@@ -78,6 +79,19 @@ class HomeLayoutSettingsTest {
         assertFalse(settings.isCalendarWidgetEnabled.first())
         assertFalse(settings.isSmartSuggestionsEnabled.first())
         assertTrue(settings.isOnboardingCompleted.first())
+    }
+
+    @Test
+    fun `hosted widgets default to empty and roundtrip`() = testScope.runTest {
+        assertTrue(settings.hostedWidgets.first().isEmpty())
+
+        val widgets = listOf(
+            HostedWidget(appWidgetId = 1, provider = "a/b", widthDp = 200, heightDp = 100, offsetX = 4f, offsetY = -6f),
+            HostedWidget(appWidgetId = 2, provider = "c/d", widthDp = 110, heightDp = 40),
+        )
+        settings.setHostedWidgets(widgets)
+
+        assertEquals(widgets, settings.hostedWidgets.first())
     }
 
     @Test


### PR DESCRIPTION
## Zusammenfassung

PR 1/3 des AppWidgetHost-Supports (B1, Flaggschiff-Feature aus dem Verbesserungsplan) – die komplette Datenschicht, noch ohne UI:

- **`data/HostedWidget.kt`** – platziertes System-Widget (appWidgetId, Provider als flattenToString, Größe in dp, Offset in px analog `HomeLayout`)
- **`data/WidgetSerializer.kt`** – JSON-Roundtrip nach dem `FolderSerializer`-Muster; korrupte Eingaben liefern eine leere Liste
- **`data/settings/HomeLayoutSettings.kt`** – neuer `hosted_widgets`-Key (`hostedWidgets`-Flow + `setHostedWidgets`); ein atomarer DataStore-Write für Add/Move/Remove
- **`data/WidgetBindFlow.kt`** – pure, framework-freie Entscheidungslogik: Bind-/Configure-State-Machine (`afterAllocate/afterBindPermission/afterConfigure`), `resolveWidgetCleanup` (geleakte + verwaiste IDs) und `defaultWidgetSizeDp` (targetCell*/minWidth-Heuristik mit Screen-Clamps)
- **`data/WidgetHostManager.kt`** – @Singleton im DataModule: besitzt den `AppWidgetHost` (feste Host-ID `0x5254`), ID-Allokation/-Freigabe, `bindIfAllowed` (OEM-SecurityExceptions → „nicht gebunden"), start/stopListening, Host-View-Cache (eine View pro ID, appContext → kein Activity-Leak), `addWidget/removeWidget/updateOffsets/cleanupOrphans`

Kein Manifest-Change, keine neuen Dependencies.

## Tests

- `WidgetSerializerTest` – Roundtrip, leer, korrupt, fehlende Pflichtfelder, Offset-Defaults
- `WidgetBindFlowTest` – alle State-Machine-Transitionen + Cleanup- und Sizing-Logik
- `WidgetHostManagerTest` – MockK-Host/-Manager mit echtem Test-DataStore: allocate/bind/add/remove/updateOffsets/cleanupOrphans
- `HomeLayoutSettingsTest` – hostedWidgets Default + Roundtrip

`./gradlew detekt testDebugUnitTest koverVerifyDebug` lokal grün.

Folge-PRs: #2 Picker + Bind-Orchestrierung, #3 Homescreen-Integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)