### PR TITLE
feat(B1): Widget-Picker + Bind-/Configure-Orchestrierung

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,6 +188,9 @@ kover {
                 classes("com.example.androidlauncher.ui.HybridSearchKt\$*")
                 classes("com.example.androidlauncher.ui.InfoDialogKt")
                 classes("com.example.androidlauncher.ui.InfoDialogKt\$*")
+                // B1: Widget-Picker (reines Composable; Datenschicht ist getestet)
+                classes("com.example.androidlauncher.ui.WidgetPickerSheetKt")
+                classes("com.example.androidlauncher.ui.WidgetPickerSheetKt\$*")
                 // Hinweis: data.AppRepository, data.IconManager und data.FavoritesManager sind
                 // bewusst NICHT mehr ausgeschlossen – fuer sie existieren Unit-Tests
                 // (AppRepositoryTest, IconManagerTest, FavoritesManagerTest), die jetzt ehrlich

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -3,6 +3,8 @@ package com.example.androidlauncher
 import android.Manifest
 import android.app.ActivityManager
 import android.app.role.RoleManager
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProviderInfo
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -25,6 +27,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Animatable
@@ -73,6 +76,7 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.IntOffset
@@ -82,6 +86,7 @@ import androidx.compose.ui.zIndex
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.example.androidlauncher.data.AppAccessMode
 import com.example.androidlauncher.data.AppFont
@@ -99,13 +104,20 @@ import com.example.androidlauncher.data.FontSize
 import com.example.androidlauncher.data.FontWeightLevel
 import com.example.androidlauncher.data.GestureAction
 import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.HostedWidget
 import com.example.androidlauncher.data.IconManager
 import com.example.androidlauncher.data.IconQualityEvaluator
 import com.example.androidlauncher.data.IconSize
 import com.example.androidlauncher.data.IslandAnimationStyle
 import com.example.androidlauncher.data.IslandContent
+import com.example.androidlauncher.data.PendingWidgetBind
 import com.example.androidlauncher.data.SearchSuggestionsManager
 import com.example.androidlauncher.data.ThemeManager
+import com.example.androidlauncher.data.WidgetBindFlow
+import com.example.androidlauncher.data.WidgetBindStep
+import com.example.androidlauncher.data.WidgetHostManager
+import com.example.androidlauncher.data.WidgetSizeDp
+import com.example.androidlauncher.data.defaultWidgetSizeDp
 import com.example.androidlauncher.gesture.GestureActionEffects
 import com.example.androidlauncher.gesture.GestureActionHandler
 import com.example.androidlauncher.ui.AnimationsConfigMenu
@@ -137,6 +149,7 @@ import com.example.androidlauncher.ui.ThemeSelectionMenu
 import com.example.androidlauncher.ui.UninstallAppsMenu
 import com.example.androidlauncher.ui.WallpaperConfigMenu
 import com.example.androidlauncher.ui.WallpaperCropScreen
+import com.example.androidlauncher.ui.WidgetPickerSheet
 import com.example.androidlauncher.ui.expandNotifications
 import com.example.androidlauncher.ui.home.ActiveOverlay
 import com.example.androidlauncher.ui.home.EditConfigActions
@@ -174,6 +187,14 @@ class MainActivity : ComponentActivity() {
         // Begrenzter vertikaler Verschiebebereich der Dynamic Island (dp) im Layout-Edit-Modus.
         private const val DYNAMIC_ISLAND_MIN_OFFSET_DP = -12f
         private const val DYNAMIC_ISLAND_MAX_OFFSET_DP = 40f
+
+        // B1: Request-Code der Widget-Configure-Activity. Muss über den deprecated
+        // onActivityResult-Pfad laufen – startAppWidgetConfigureActivityForResult hat
+        // keinen ActivityResult-Contract (Launcher3 macht dasselbe).
+        private const val REQUEST_CONFIGURE_WIDGET = 4201
+
+        // Fallback, falls beim Commit keine berechnete Widget-Größe mehr vorliegt.
+        private val FALLBACK_WIDGET_SIZE = WidgetSizeDp(widthDp = 180, heightDp = 110)
     }
 
     // Von Hilt bereitgestellte Datenschicht-Singletons (siehe di/DataModule).
@@ -200,6 +221,19 @@ class MainActivity : ComponentActivity() {
 
     @javax.inject.Inject
     lateinit var dynamicIslandManager: com.example.androidlauncher.data.DynamicIslandManager
+
+    @javax.inject.Inject
+    lateinit var widgetHostManager: WidgetHostManager
+
+    // B1: laufender Widget-Bind-Flow. Übersteht bewusst keinen Prozess-Tod –
+    // geleakte Widget-IDs räumt cleanupOrphans beim nächsten Start ab.
+    private var pendingWidgetBind: PendingWidgetBind? = null
+    private var pendingWidgetSize: WidgetSizeDp? = null
+
+    // Gleiche Instanz wie hiltViewModel() in setContent (gemeinsamer ViewModelStore der
+    // Activity) – als Feld, damit der Widget-Bind-Commit außerhalb der Composition
+    // (onActivityResult-Pfad) in den Edit-Modus wechseln kann.
+    private val activityHomeViewModel: HomeViewModel by viewModels()
 
     private lateinit var backCallback: OnBackPressedCallback
     private var lastDefaultLauncherPackage: String? = null
@@ -470,6 +504,51 @@ class MainActivity : ComponentActivity() {
                 openDefaultLauncherSettings(context)
             }
 
+            // B1: System-Consent-Dialog für das Widget-Binden (ACTION_APPWIDGET_BIND).
+            val appWidgetBindLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.StartActivityForResult()
+            ) { result ->
+                pendingWidgetBind?.let { pending ->
+                    handleWidgetBindStep(
+                        WidgetBindFlow.afterBindPermission(pending, granted = result.resultCode == RESULT_OK)
+                    )
+                }
+            }
+
+            val configuration = LocalConfiguration.current
+
+            // Startet den Bind-Flow für ein im Picker gewähltes Widget; die Schrittfolge
+            // entscheidet die pure State-Machine WidgetBindFlow.
+            fun startWidgetBind(info: AppWidgetProviderInfo) {
+                val appWidgetId = widgetHostManager.allocateWidgetId()
+                val pending = PendingWidgetBind(
+                    appWidgetId = appWidgetId,
+                    provider = info.provider.flattenToString(),
+                    needsConfigure = info.configure != null,
+                )
+                pendingWidgetBind = pending
+                pendingWidgetSize = defaultWidgetSizeDp(
+                    targetCellWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.targetCellWidth else 0,
+                    targetCellHeight = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.targetCellHeight else 0,
+                    minWidthDp = info.minWidth,
+                    minHeightDp = info.minHeight,
+                    screenWidthDp = configuration.screenWidthDp,
+                    screenHeightDp = configuration.screenHeightDp,
+                )
+                homeViewModel.closeOverlay()
+                val bound = widgetHostManager.bindIfAllowed(appWidgetId, info.provider)
+                when (val step = WidgetBindFlow.afterAllocate(pending, bound)) {
+                    is WidgetBindStep.RequestBindPermission -> runCatching {
+                        appWidgetBindLauncher.launch(
+                            Intent(AppWidgetManager.ACTION_APPWIDGET_BIND)
+                                .putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                                .putExtra(AppWidgetManager.EXTRA_APPWIDGET_PROVIDER, info.provider)
+                        )
+                    }.onFailure { abortWidgetBind(appWidgetId, showError = true) }
+                    else -> handleWidgetBindStep(step)
+                }
+            }
+
             // Geräte-/System-Aktionen einer Geste werden an den testbaren GestureActionHandler
             // delegiert. Launcher-interne Aktionen (App-Drawer/Suche/Benachrichtigungen) setzen
             // UI-State und werden weiterhin im inneren dispatchGestureAction behandelt.
@@ -581,6 +660,7 @@ class MainActivity : ComponentActivity() {
                 val isAppLockOpen = activeOverlay is ActiveOverlay.AppLock
                 val isWallpaperConfigOpen = activeOverlay is ActiveOverlay.WallpaperConfig
                 val isInfoOpen = activeOverlay is ActiveOverlay.Info
+                val isWidgetPickerOpen = activeOverlay is ActiveOverlay.WidgetPicker
                 val selectedFolderForConfig = (activeOverlay as? ActiveOverlay.FolderConfig)?.folder
                 var selectedFolderForConfigSnapshot by remember { mutableStateOf<FolderInfo?>(null) }
                 val folderConfigExitHoldMs = 320L
@@ -697,6 +777,27 @@ class MainActivity : ComponentActivity() {
                     }
                     lifecycleOwner.lifecycle.addObserver(observer)
                     onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+                }
+
+                // B1: Widget-Host lauscht zwischen ON_START und ON_STOP auf RemoteViews-Updates
+                // (Updates unter Dialogen laufen weiter; verpasste spielt das Framework nach).
+                // Orphan-Cleanup nur ohne laufenden Bind-Flow – die Rückkehr aus Bind-/Configure-
+                // Dialogen durchläuft ON_START, bevor onActivityResult eintrifft.
+                DisposableEffect(lifecycleOwner) {
+                    val widgetHostObserver = LifecycleEventObserver { _, event ->
+                        when (event) {
+                            Lifecycle.Event.ON_START -> {
+                                widgetHostManager.startListening()
+                                if (pendingWidgetBind == null) {
+                                    lifecycleScope.launch { widgetHostManager.cleanupOrphans() }
+                                }
+                            }
+                            Lifecycle.Event.ON_STOP -> widgetHostManager.stopListening()
+                            else -> Unit
+                        }
+                    }
+                    lifecycleOwner.lifecycle.addObserver(widgetHostObserver)
+                    onDispose { lifecycleOwner.lifecycle.removeObserver(widgetHostObserver) }
                 }
 
                 DisposableEffect(isLauncherResumed, isShakeGesturesEnabled) {
@@ -1521,6 +1622,19 @@ class MainActivity : ComponentActivity() {
                         EditConfigMenu(actions = editConfigActions)
                     }
 
+                    // B1: Widget-Auswahl – nach dem Edit-Menü komponiert, damit sie darüber
+                    // liegt (öffnet aus dessen "Widget hinzufügen"-Eintrag).
+                    MenuOverlay(
+                        visible = isWidgetPickerOpen,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() }
+                    ) {
+                        WidgetPickerSheet(
+                            onWidgetChosen = { startWidgetBind(it) },
+                            onClose = { homeViewModel.closeOverlay() }
+                        )
+                    }
+
                     // Untermenü der Animationen – nach dem Edit-Menü komponiert, damit es
                     // darüber liegt (das Edit-Menü bleibt geöffnet im Hintergrund).
                     MenuOverlay(
@@ -1874,6 +1988,66 @@ class MainActivity : ComponentActivity() {
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Führt den nächsten Schritt des Widget-Bind-Flows aus (B1, Entscheidungen:
+     * [WidgetBindFlow]). `RequestBindPermission` wird hier bewusst nicht behandelt –
+     * der Schritt kann nur direkt nach `afterAllocate` auftreten und braucht den
+     * Compose-ActivityResult-Launcher (siehe `startWidgetBind` in setContent).
+     */
+    private fun handleWidgetBindStep(step: WidgetBindStep) {
+        when (step) {
+            is WidgetBindStep.RequestBindPermission -> Unit
+            is WidgetBindStep.LaunchConfigure -> {
+                val started = widgetHostManager.startConfigureActivity(
+                    this,
+                    step.pending.appWidgetId,
+                    REQUEST_CONFIGURE_WIDGET
+                )
+                if (!started) abortWidgetBind(step.pending.appWidgetId, showError = true)
+            }
+            is WidgetBindStep.Commit -> commitWidgetBind(step.pending)
+            is WidgetBindStep.Abort -> abortWidgetBind(step.appWidgetId)
+        }
+    }
+
+    /** Persistiert das fertig gebundene Widget und wechselt zum Positionieren in den Edit-Modus. */
+    private fun commitWidgetBind(pending: PendingWidgetBind) {
+        val size = pendingWidgetSize ?: FALLBACK_WIDGET_SIZE
+        pendingWidgetBind = null
+        pendingWidgetSize = null
+        lifecycleScope.launch {
+            widgetHostManager.addWidget(
+                HostedWidget(
+                    appWidgetId = pending.appWidgetId,
+                    provider = pending.provider,
+                    widthDp = size.widthDp,
+                    heightDp = size.heightDp,
+                )
+            )
+            activityHomeViewModel.setHomeEditMode(true)
+        }
+    }
+
+    /** Bricht den Bind-Flow ab und gibt die allokierte Widget-ID wieder frei. */
+    private fun abortWidgetBind(appWidgetId: Int, showError: Boolean = false) {
+        pendingWidgetBind = null
+        pendingWidgetSize = null
+        widgetHostManager.deleteWidgetId(appWidgetId)
+        if (showError) {
+            Toast.makeText(this, getString(R.string.widget_bind_failed), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        @Suppress("DEPRECATION")
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == REQUEST_CONFIGURE_WIDGET) {
+            val pending = pendingWidgetBind ?: return
+            handleWidgetBindStep(WidgetBindFlow.afterConfigure(pending, resultOk = resultCode == RESULT_OK))
         }
     }
 

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
@@ -1,5 +1,6 @@
 package com.example.androidlauncher.data
 
+import android.app.Activity
 import android.appwidget.AppWidgetHost
 import android.appwidget.AppWidgetHostView
 import android.appwidget.AppWidgetManager
@@ -73,6 +74,18 @@ class WidgetHostManager(
 
     fun providerInfo(appWidgetId: Int): AppWidgetProviderInfo? =
         runCatching { appWidgetManager.getAppWidgetInfo(appWidgetId) }.getOrNull()
+
+    /**
+     * Startet die Configure-Activity des Providers ueber den Host – die einzige auf
+     * Android 12+ zulaessige Variante fuer nicht-exportierte Configure-Activities
+     * (der Host vergibt eine temporaere Start-Berechtigung). `false` bei Startfehlern
+     * (ActivityNotFound/SecurityException), der Aufrufer bricht den Flow dann ab.
+     */
+    fun startConfigureActivity(activity: Activity, appWidgetId: Int, requestCode: Int): Boolean =
+        runCatching {
+            host.startAppWidgetConfigureActivityForResult(activity, appWidgetId, 0, requestCode, null)
+            true
+        }.getOrDefault(false)
 
     /**
      * Liefert die (gecachte) Host-View fuer ein gebundenes Widget oder `null`,

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -102,6 +102,7 @@ fun EditConfigMenu(
         homeViewModel.closeOverlay()
         homeViewModel.setHomeEditMode(true)
     }
+    val onOpenWidgetPicker = { homeViewModel.openOverlay(ActiveOverlay.WidgetPicker) }
     val onOpenIconConfig = { homeViewModel.openOverlay(ActiveOverlay.IconConfig) }
     val onOpenUninstallApps = { homeViewModel.openOverlay(ActiveOverlay.UninstallApps) }
     val onOpenHiddenApps = { homeViewModel.openOverlay(ActiveOverlay.HiddenApps) }
@@ -392,6 +393,19 @@ fun EditConfigMenu(
                             )
                         }
                     }
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.LayoutGrid,
+                    label = stringResource(R.string.add_widget),
+                    onClick = onOpenWidgetPicker,
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "add_widget_item"
                 )
             }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/WidgetPickerSheet.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/WidgetPickerSheet.kt
@@ -1,0 +1,335 @@
+package com.example.androidlauncher.ui
+
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProviderInfo
+import android.content.Context
+import android.graphics.drawable.Drawable
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.KeyboardArrowDown
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.graphics.drawable.toBitmap
+import com.example.androidlauncher.R
+import com.example.androidlauncher.ui.LiquidGlass.designSurface
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalDesignStyle
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/** Ein anbietbares Widget eines Providers (Label vorab geladen, Preview lazy pro Zeile). */
+internal data class WidgetPickerEntry(
+    val info: AppWidgetProviderInfo,
+    val label: String,
+)
+
+/** Alle Widgets einer App, gruppiert für die aufklappbare Listendarstellung. */
+internal data class WidgetPickerGroup(
+    val packageName: String,
+    val appLabel: String,
+    val entries: List<WidgetPickerEntry>,
+)
+
+/** Lädt alle Homescreen-Widget-Provider, gruppiert nach App und alphabetisch sortiert. */
+internal fun loadWidgetPickerGroups(context: Context): List<WidgetPickerGroup> {
+    val pm = context.packageManager
+    val providers = runCatching {
+        AppWidgetManager.getInstance(context).installedProviders
+    }.getOrDefault(emptyList())
+    return providers
+        .filter { it.widgetCategory and AppWidgetProviderInfo.WIDGET_CATEGORY_HOME_SCREEN != 0 }
+        .groupBy { it.provider.packageName }
+        .map { (packageName, infos) ->
+            val appLabel = runCatching {
+                pm.getApplicationLabel(pm.getApplicationInfo(packageName, 0)).toString()
+            }.getOrDefault(packageName)
+            WidgetPickerGroup(
+                packageName = packageName,
+                appLabel = appLabel,
+                entries = infos
+                    .map { info ->
+                        WidgetPickerEntry(
+                            info = info,
+                            label = runCatching { info.loadLabel(pm) }.getOrNull() ?: appLabel,
+                        )
+                    }
+                    .sortedBy { it.label.lowercase() },
+            )
+        }
+        .sortedBy { it.appLabel.lowercase() }
+}
+
+/**
+ * Widget-Auswahl (B1): listet alle installierten Homescreen-Widget-Provider,
+ * gruppiert nach App; ein Tap auf ein Widget startet den Bind-Flow in der
+ * MainActivity. Wird über das `WidgetPicker`-Overlay im MenuOverlay gerendert.
+ */
+@Composable
+fun WidgetPickerSheet(
+    onWidgetChosen: (AppWidgetProviderInfo) -> Unit,
+    onClose: () -> Unit,
+) {
+    val context = LocalContext.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    // Provider-Liste einmal pro Öffnen off-main laden; null = noch am Laden.
+    val groups by produceState<List<WidgetPickerGroup>?>(initialValue = null, context) {
+        value = withContext(Dispatchers.Default) { loadWidgetPickerGroups(context) }
+    }
+    var expandedPackage by remember { mutableStateOf<String?>(null) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.widget_picker_title),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = onClose) {
+                Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.cd_close), tint = mainTextColor)
+            }
+        }
+
+        when {
+            groups == null -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = mainTextColor.copy(alpha = 0.6f))
+            }
+
+            groups.orEmpty().isEmpty() -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(top = 32.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    stringResource(R.string.widget_picker_empty),
+                    color = mainTextColor.copy(alpha = 0.7f),
+                    fontSize = 16.sp
+                )
+            }
+
+            else -> LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
+            ) {
+                items(groups.orEmpty(), key = { it.packageName }) { group ->
+                    WidgetPickerAppRow(
+                        group = group,
+                        expanded = expandedPackage == group.packageName,
+                        onToggle = {
+                            expandedPackage =
+                                if (expandedPackage == group.packageName) null else group.packageName
+                        },
+                        onWidgetChosen = onWidgetChosen,
+                        mainTextColor = mainTextColor,
+                        surfaceAccent = surfaceAccent,
+                        isDarkTextEnabled = isDarkTextEnabled,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetPickerAppRow(
+    group: WidgetPickerGroup,
+    expanded: Boolean,
+    onToggle: () -> Unit,
+    onWidgetChosen: (AppWidgetProviderInfo) -> Unit,
+    mainTextColor: Color,
+    surfaceAccent: Color,
+    isDarkTextEnabled: Boolean,
+) {
+    val context = LocalContext.current
+    val designStyle = LocalDesignStyle.current
+    val backgroundModifier = Modifier.designSurface(
+        designStyle, RoundedCornerShape(20.dp), isDarkTextEnabled, surfaceAccent,
+        fillAlpha = 0.05f, glassStartAlpha = 0.10f, glassEndAlpha = 0.03f,
+        borderWidth = 1.dp, borderStartAlpha = if (isDarkTextEnabled) 0.2f else 0.25f, borderEndAlpha = 0.05f
+    )
+    val appIcon by produceState<ImageBitmap?>(initialValue = null, group.packageName) {
+        value = withContext(Dispatchers.IO) {
+            runCatching { context.packageManager.getApplicationIcon(group.packageName) }
+                .getOrNull()
+                ?.toSafeImageBitmap()
+        }
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .then(backgroundModifier)
+            .testTag("widget_picker_app_${group.packageName}"),
+        color = Color.Transparent
+    ) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onToggle() }
+                    .padding(vertical = 16.dp, horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                appIcon?.let {
+                    Image(bitmap = it, contentDescription = null, modifier = Modifier.size(32.dp))
+                    Spacer(modifier = Modifier.width(16.dp))
+                }
+                Text(
+                    text = group.appLabel,
+                    color = mainTextColor,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Normal,
+                    modifier = Modifier.weight(1f)
+                )
+                Text(
+                    text = group.entries.size.toString(),
+                    color = mainTextColor.copy(alpha = 0.5f),
+                    fontSize = 14.sp
+                )
+                Icon(
+                    imageVector = if (expanded) {
+                        Icons.Rounded.KeyboardArrowDown
+                    } else {
+                        Icons.AutoMirrored.Rounded.KeyboardArrowRight
+                    },
+                    contentDescription = null,
+                    tint = mainTextColor.copy(alpha = 0.4f)
+                )
+            }
+
+            if (expanded) {
+                group.entries.forEach { entry ->
+                    WidgetPickerWidgetRow(
+                        entry = entry,
+                        onClick = { onWidgetChosen(entry.info) },
+                        mainTextColor = mainTextColor,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun WidgetPickerWidgetRow(
+    entry: WidgetPickerEntry,
+    onClick: () -> Unit,
+    mainTextColor: Color,
+) {
+    val context = LocalContext.current
+    val preview by produceState<ImageBitmap?>(initialValue = null, entry.info) {
+        value = withContext(Dispatchers.IO) {
+            runCatching { entry.info.loadPreviewImage(context, 0) }
+                .getOrNull()
+                ?.toSafeImageBitmap()
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .testTag("widget_picker_entry_${entry.info.provider.flattenToString()}")
+    ) {
+        Text(
+            text = entry.label,
+            color = mainTextColor,
+            fontSize = 16.sp,
+            fontWeight = FontWeight.Normal
+        )
+        Text(
+            text = "${entry.info.minWidth} × ${entry.info.minHeight} dp",
+            color = mainTextColor.copy(alpha = 0.5f),
+            fontSize = 13.sp
+        )
+        preview?.let {
+            Spacer(modifier = Modifier.height(8.dp))
+            Image(
+                bitmap = it,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 140.dp),
+                contentScale = ContentScale.Fit,
+                alignment = Alignment.CenterStart
+            )
+        }
+    }
+}
+
+/** Drawable → ImageBitmap; Drawables ohne intrinsische Größe liefern null statt zu werfen. */
+private fun Drawable.toSafeImageBitmap(): ImageBitmap? =
+    if (intrinsicWidth > 0 && intrinsicHeight > 0) {
+        runCatching { toBitmap().asImageBitmap() }.getOrNull()
+    } else {
+        null
+    }

--- a/app/src/main/java/com/example/androidlauncher/ui/home/ActiveOverlay.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/ActiveOverlay.kt
@@ -33,6 +33,9 @@ sealed interface ActiveOverlay {
     data object WallpaperConfig : ActiveOverlay
     data object Info : ActiveOverlay
 
+    /** Auswahl eines System-Widgets für den Startbildschirm (B1, AppWidgetHost). */
+    data object WidgetPicker : ActiveOverlay
+
     /** Konfiguration eines konkreten Ordners (früher `selectedFolderForConfig`). */
     data class FolderConfig(val folder: FolderInfo) : ActiveOverlay
 }

--- a/app/src/main/java/com/example/androidlauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/HomeViewModel.kt
@@ -145,6 +145,7 @@ class HomeViewModel @Inject constructor() : ViewModel() {
             ActiveOverlay.HiddenApps,
             ActiveOverlay.AppLock,
             ActiveOverlay.IconConfig,
+            ActiveOverlay.WidgetPicker,
         )
     }
 }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -136,6 +136,10 @@
     <string name="edge_thickness_label">Stärke: %1$s×</string>
     <string name="app_access_label">App-Zugriff</string>
     <string name="edit_home_layout">Startbildschirm-Layout anpassen</string>
+    <string name="add_widget">Widget hinzufügen</string>
+    <string name="widget_picker_title">Widgets</string>
+    <string name="widget_picker_empty">Keine Widgets gefunden</string>
+    <string name="widget_bind_failed">Widget konnte nicht hinzugefügt werden</string>
     <string name="edit_app_icons">App-Icons anpassen</string>
     <string name="change_wallpaper">Wallpaper ändern</string>
     <string name="adjust_wallpaper">Hintergrund anpassen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -121,6 +121,10 @@
     <string name="weather_widget_desc">Muestra un icono y la temperatura bajo el reloj</string>
     <string name="app_access_label">Acceso a apps</string>
     <string name="edit_home_layout">Personalizar el diseño de inicio</string>
+    <string name="add_widget">Añadir widget</string>
+    <string name="widget_picker_title">Widgets</string>
+    <string name="widget_picker_empty">No se encontraron widgets</string>
+    <string name="widget_bind_failed">No se pudo añadir el widget</string>
     <string name="edit_app_icons">Personalizar iconos de apps</string>
     <string name="change_wallpaper">Cambiar fondo de pantalla</string>
     <string name="adjust_wallpaper">Ajustar fondo de pantalla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -121,6 +121,10 @@
     <string name="weather_widget_desc">Affiche une icône et la température sous l\'horloge</string>
     <string name="app_access_label">Accès aux apps</string>
     <string name="edit_home_layout">Personnaliser la disposition d\'accueil</string>
+    <string name="add_widget">Ajouter un widget</string>
+    <string name="widget_picker_title">Widgets</string>
+    <string name="widget_picker_empty">Aucun widget trouvé</string>
+    <string name="widget_bind_failed">Impossible d\'ajouter le widget</string>
     <string name="edit_app_icons">Personnaliser les icônes d\'apps</string>
     <string name="change_wallpaper">Changer le fond d\'écran</string>
     <string name="adjust_wallpaper">Ajuster le fond d\'écran</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -121,6 +121,10 @@
     <string name="weather_widget_desc">Mostra un\'icona e la temperatura sotto l\'orologio</string>
     <string name="app_access_label">Accesso alle app</string>
     <string name="edit_home_layout">Personalizza il layout della Home</string>
+    <string name="add_widget">Aggiungi widget</string>
+    <string name="widget_picker_title">Widget</string>
+    <string name="widget_picker_empty">Nessun widget trovato</string>
+    <string name="widget_bind_failed">Impossibile aggiungere il widget</string>
     <string name="edit_app_icons">Personalizza le icone delle app</string>
     <string name="change_wallpaper">Cambia sfondo</string>
     <string name="adjust_wallpaper">Regola lo sfondo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -136,6 +136,10 @@
     <string name="edge_thickness_label">Thickness: %1$s×</string>
     <string name="app_access_label">App access</string>
     <string name="edit_home_layout">Customize home screen layout</string>
+    <string name="add_widget">Add widget</string>
+    <string name="widget_picker_title">Widgets</string>
+    <string name="widget_picker_empty">No widgets found</string>
+    <string name="widget_bind_failed">Widget could not be added</string>
     <string name="edit_app_icons">Customize app icons</string>
     <string name="change_wallpaper">Change wallpaper</string>
     <string name="adjust_wallpaper">Adjust wallpaper</string>

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
@@ -131,6 +131,24 @@ class WidgetHostManagerTest {
     }
 
     @Test
+    fun `startConfigureActivity reports launch failures as false`() {
+        val activity = mockk<android.app.Activity>()
+        every {
+            host.startAppWidgetConfigureActivityForResult(activity, 7, 0, 99, null)
+        } throws SecurityException("not exported")
+
+        assertFalse(manager.startConfigureActivity(activity, 7, requestCode = 99))
+    }
+
+    @Test
+    fun `startConfigureActivity returns true when host launches`() {
+        val activity = mockk<android.app.Activity>()
+        every { host.startAppWidgetConfigureActivityForResult(activity, 7, 0, 99, null) } just Runs
+
+        assertTrue(manager.startConfigureActivity(activity, 7, requestCode = 99))
+    }
+
+    @Test
     fun `createView returns null when provider info is missing`() {
         every { appWidgetManager.getAppWidgetInfo(9) } returns null
 

--- a/app/src/test/java/com/example/androidlauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/home/HomeViewModelTest.kt
@@ -105,6 +105,17 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `back closes the widget picker before the drawer`() {
+        // Der Widget-Picker ist ein inneres Menü (öffnet aus dem Einstellungs-Menü heraus).
+        vm.setDrawerOpen(true)
+        vm.openOverlay(ActiveOverlay.WidgetPicker)
+
+        vm.onBack()
+        assertEquals(ActiveOverlay.None, state.activeOverlay)
+        assertTrue(state.isDrawerOpen)
+    }
+
+    @Test
     fun `back on empty state changes nothing and modal detection matches`() {
         assertFalse(state.hasModalSurface)
         vm.onBack()


### PR DESCRIPTION
## Zusammenfassung

PR 2/3 des AppWidgetHost-Supports, baut auf #118 auf (Basis-Branch `feature/b1-widget-host-data` – nach dessen Merge auf `main` umbasen):

- **`ActiveOverlay.WidgetPicker`** + Aufnahme in `HomeViewModel.INNER_MENUS` (Back schließt den Picker vor dem Drawer)
- **`ui/WidgetPickerSheet.kt`** – installierte Homescreen-Widget-Provider, gruppiert nach App (aufklappbar), Labels vorab off-main geladen, Preview-Bilder lazy pro Zeile; Kover-Exclude
- **EditConfigMenu** – neuer Eintrag „Widget hinzufügen" (Lucide.LayoutGrid) neben „Startbildschirm-Layout anpassen"
- **MainActivity – Bind-Orchestrierung** (Entscheidungen trifft die pure `WidgetBindFlow`-State-Machine aus #118):
  1. `allocateAppWidgetId` → `bindAppWidgetIdIfAllowed`
  2. falls verweigert: `ACTION_APPWIDGET_BIND` über einen ActivityResult-Launcher (System-Consent, daher keine `BIND_APPWIDGET`-Permission)
  3. falls Configure-Activity deklariert: `host.startAppWidgetConfigureActivityForResult` – der einzige auf Android 12+ zulässige Weg für nicht-exportierte Configure-Activities; läuft über einen deprecated `onActivityResult`-Override (`REQUEST_CONFIGURE_WIDGET = 4201`, wie Launcher3)
  4. Commit persistiert das Widget mit berechneter Default-Größe und wechselt direkt in den Edit-Modus; jeder Abbruch gibt die ID frei
- **Host-Lifecycle**: `startListening`/`stopListening` an ON_START/ON_STOP; Orphan-Cleanup beim Start wird übersprungen, solange ein Bind-Flow läuft (die Rückkehr aus den System-Dialogen durchläuft ON_START vor `onActivityResult`)
- Strings in allen 5 Sprachen (en/de/fr/es/it)

## Tests

- `HomeViewModelTest` – Back-Priorität des neuen Overlays
- `WidgetHostManagerTest` – `startConfigureActivity`-Erfolgs-/Fehlerpfad

`./gradlew detekt testDebugUnitTest koverVerifyDebug` lokal grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)