### PR TITLE
feat(B1): System-Widgets auf dem Startbildschirm – Rendering, Drag, Entfernen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -188,9 +188,12 @@ kover {
                 classes("com.example.androidlauncher.ui.HybridSearchKt\$*")
                 classes("com.example.androidlauncher.ui.InfoDialogKt")
                 classes("com.example.androidlauncher.ui.InfoDialogKt\$*")
-                // B1: Widget-Picker (reines Composable; Datenschicht ist getestet)
+                // B1: Widget-Picker + Host-View-Wrapper (reine Composables; Datenschicht ist getestet)
                 classes("com.example.androidlauncher.ui.WidgetPickerSheetKt")
                 classes("com.example.androidlauncher.ui.WidgetPickerSheetKt\$*")
+                classes("com.example.androidlauncher.ui.HostedWidgetViewKt")
+                classes("com.example.androidlauncher.ui.HostedWidgetViewKt\$*")
+                classes("com.example.androidlauncher.ui.BlockableFrameLayout")
                 // Hinweis: data.AppRepository, data.IconManager und data.FavoritesManager sind
                 // bewusst NICHT mehr ausgeschlossen – fuer sie existieren Unit-Tests
                 // (AppRepositoryTest, IconManagerTest, FavoritesManagerTest), die jetzt ehrlich

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -376,6 +376,9 @@ class MainActivity : ComponentActivity() {
             // Positionen der unabhängig verschiebbaren Startbildschirm-Elemente.
             val homeLayout by themeManager.homeLayout.collectAsState(initial = HomeLayout())
 
+            // B1: platzierte System-Widgets (AppWidgetHost).
+            val hostedWidgets by widgetHostManager.widgets.collectAsState(initial = emptyList())
+
             val folders by folderManager.folders.collectAsState(initial = emptyList())
             val customIcons by iconManager.customIcons.collectAsState(initial = emptyMap())
             val autoIconFallbacks by iconManager.autoIconFallbacks.collectAsState(initial = emptyMap())
@@ -1295,6 +1298,14 @@ class MainActivity : ComponentActivity() {
                                 searchButtonBounceToken = searchButtonBounceToken,
                                 onSearchButtonBoundsChanged = { bounds ->
                                     homeSearchButtonBounds = bounds
+                                },
+                                hostedWidgets = hostedWidgets,
+                                widgetViewProvider = { id -> widgetHostManager.createView(id) },
+                                onSaveWidgetOffsets = { widgetOffsets ->
+                                    scope.launch { widgetHostManager.updateOffsets(widgetOffsets) }
+                                },
+                                onRemoveWidget = { id ->
+                                    scope.launch { widgetHostManager.removeWidget(id) }
                                 }
                             )
                         }

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.HostedWidget
 
 /**
  * Bündelt die transienten Zustände des Edit-Modus auf dem Startbildschirm
@@ -18,17 +19,27 @@ import com.example.androidlauncher.data.HomeLayout
  * `remember`-basiert – der persistierte Stand lebt in `HomeLayoutSettings`,
  * dieser Holder hält nur die Live-Vorschau während des Bearbeitens.
  * Geometrie-Entscheidungen bleiben framework-frei in `HomeGeometry.kt`.
+ *
+ * Neben den vier eingebauten Elementen verwaltet der Holder auch die Offsets
+ * gehosteter System-Widgets (B1) – gleiche Drag-Mechanik, dynamische Targets.
  */
 @Stable
-internal class HomeDragStateHolder(initialLayout: HomeLayout) {
+internal class HomeDragStateHolder(
+    initialLayout: HomeLayout,
+    initialWidgets: List<HostedWidget> = emptyList(),
+) {
 
     /** Live-Offsets je Element; im Edit-Modus folgt das Element dem Finger. */
     val offsets = mutableStateMapOf(
-        HomeEditTarget.CLOCK to initialLayout.clock,
-        HomeEditTarget.DATE to initialLayout.date,
-        HomeEditTarget.WEATHER to initialLayout.weather,
-        HomeEditTarget.FAVORITES to initialLayout.favorites,
-    )
+        HomeEditTarget.Clock to initialLayout.clock,
+        HomeEditTarget.Date to initialLayout.date,
+        HomeEditTarget.Weather to initialLayout.weather,
+        HomeEditTarget.Favorites to initialLayout.favorites,
+    ).apply {
+        initialWidgets.forEach {
+            put(HomeEditTarget.Widget(it.appWidgetId), Offset(it.offsetX, it.offsetY))
+        }
+    }
 
     /** Neutralposition (Bounds ohne Offset) je Element – Basis der Kollisionsprüfung. */
     val neutralBounds = mutableStateMapOf<HomeEditTarget, Rect>()
@@ -50,26 +61,53 @@ internal class HomeDragStateHolder(initialLayout: HomeLayout) {
     var isEditTargetUserPinned by mutableStateOf(false)
 
     /**
-     * Seedet die Live-Offsets aus dem persistierten Layout – beim Betreten des
+     * Seedet die Live-Offsets aus dem persistierten Stand – beim Betreten des
      * Edit-Modus 1:1 übernehmen, Abbrechen revertiert damit automatisch.
+     * Widget-Einträge werden synchronisiert: entfernte Widgets verschwinden
+     * mitsamt Buchführung (und ggf. Auswahl) aus dem Holder.
      */
-    fun seedFrom(layout: HomeLayout) {
-        offsets[HomeEditTarget.CLOCK] = layout.clock
-        offsets[HomeEditTarget.DATE] = layout.date
-        offsets[HomeEditTarget.WEATHER] = layout.weather
-        offsets[HomeEditTarget.FAVORITES] = layout.favorites
+    fun seedFrom(layout: HomeLayout, widgets: List<HostedWidget> = emptyList()) {
+        offsets[HomeEditTarget.Clock] = layout.clock
+        offsets[HomeEditTarget.Date] = layout.date
+        offsets[HomeEditTarget.Weather] = layout.weather
+        offsets[HomeEditTarget.Favorites] = layout.favorites
+
+        val widgetTargets = widgets.map { HomeEditTarget.Widget(it.appWidgetId) }.toSet()
+        offsets.keys.filterIsInstance<HomeEditTarget.Widget>()
+            .filterNot { it in widgetTargets }
+            .forEach { stale ->
+                offsets.remove(stale)
+                neutralBounds.remove(stale)
+                lastBlockedHapticMs.remove(stale)
+                if (selectedEditTarget == stale) {
+                    selectedEditTarget = null
+                    isEditTargetUserPinned = false
+                }
+            }
+        widgets.forEach {
+            offsets[HomeEditTarget.Widget(it.appWidgetId)] = Offset(it.offsetX, it.offsetY)
+        }
     }
 
     /** Aktuelle Live-Offsets als persistierbares [HomeLayout] (Speichern-Knopf). */
     fun toHomeLayout(): HomeLayout = HomeLayout(
-        clock = offsets[HomeEditTarget.CLOCK] ?: Offset.Zero,
-        date = offsets[HomeEditTarget.DATE] ?: Offset.Zero,
-        weather = offsets[HomeEditTarget.WEATHER] ?: Offset.Zero,
-        favorites = offsets[HomeEditTarget.FAVORITES] ?: Offset.Zero,
+        clock = offsets[HomeEditTarget.Clock] ?: Offset.Zero,
+        date = offsets[HomeEditTarget.Date] ?: Offset.Zero,
+        weather = offsets[HomeEditTarget.Weather] ?: Offset.Zero,
+        favorites = offsets[HomeEditTarget.Favorites] ?: Offset.Zero,
     )
+
+    /** Aktuelle Live-Offsets der gehosteten Widgets, keyed per appWidgetId (Speichern-Knopf). */
+    fun toWidgetOffsets(): Map<Int, Offset> = offsets.entries
+        .mapNotNull { (target, offset) ->
+            (target as? HomeEditTarget.Widget)?.let { it.appWidgetId to offset }
+        }
+        .toMap()
 }
 
 /** Merkt sich den Holder über Recompositions hinweg (nicht über Config-Wechsel). */
 @Composable
-internal fun rememberHomeDragState(initialLayout: HomeLayout): HomeDragStateHolder =
-    remember { HomeDragStateHolder(initialLayout) }
+internal fun rememberHomeDragState(
+    initialLayout: HomeLayout,
+    initialWidgets: List<HostedWidget> = emptyList(),
+): HomeDragStateHolder = remember { HomeDragStateHolder(initialLayout, initialWidgets) }

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.example.androidlauncher.ui
 
+import android.appwidget.AppWidgetHostView
 import android.content.Intent
 import android.os.SystemClock
 import android.view.HapticFeedbackConstants
@@ -60,6 +61,7 @@ import com.example.androidlauncher.data.AppInfo
 import com.example.androidlauncher.data.FavoritesBorderStyle
 import com.example.androidlauncher.data.GestureAction
 import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.HostedWidget
 import com.example.androidlauncher.launchShortcut
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
 import com.example.androidlauncher.ui.theme.*
@@ -68,11 +70,19 @@ import java.util.Calendar
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
-internal enum class HomeEditTarget {
-    CLOCK,
-    DATE,
-    WEATHER,
-    FAVORITES
+/**
+ * Verschiebbares Element auf dem Startbildschirm. Sealed statt Enum, damit gehostete
+ * System-Widgets (B1) mit ihrer dynamischen ID als gleichberechtigte Drag-Targets
+ * durch dieselbe Mechanik (Offsets, Clamping, Hit-Test, Edit-Rahmen) laufen.
+ */
+internal sealed interface HomeEditTarget {
+    data object Clock : HomeEditTarget
+    data object Date : HomeEditTarget
+    data object Weather : HomeEditTarget
+    data object Favorites : HomeEditTarget
+
+    /** Gehostetes System-Widget, identifiziert über seine AppWidget-ID. */
+    data class Widget(val appWidgetId: Int) : HomeEditTarget
 }
 
 /**
@@ -104,7 +114,12 @@ fun HomeScreen(
     returnIconPackage: String?,
     searchButtonBounceToken: Int = 0,
     onSearchButtonBoundsChanged: (Rect?) -> Unit = {},
-    isPreview: Boolean = false
+    isPreview: Boolean = false,
+    // B1: gehostete System-Widgets als frei verschiebbare Home-Objekte.
+    hostedWidgets: List<HostedWidget> = emptyList(),
+    widgetViewProvider: (Int) -> AppWidgetHostView? = { null },
+    onSaveWidgetOffsets: (Map<Int, Offset>) -> Unit = {},
+    onRemoveWidget: (Int) -> Unit = {}
 ) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
@@ -127,15 +142,15 @@ fun HomeScreen(
     // --- Bearbeitungs-States (Lokal für Live-Vorschau) ---
     // A6-Split: gebündelt im HomeDragStateHolder; die Delegates/Aliase darunter
     // halten die bestehenden Lese-/Schreib-Stellen im Composable stabil.
-    val dragState = rememberHomeDragState(homeLayout)
+    val dragState = rememberHomeDragState(homeLayout, hostedWidgets)
     val offsets = dragState.offsets
     val neutralBounds = dragState.neutralBounds
     val lastBlockedHapticMs = dragState.lastBlockedHapticMs
 
     // Hält die Live-Offsets außerhalb des Edit-Modus an der gespeicherten Position;
     // beim Betreten des Edit-Modus werden sie 1:1 daraus geseedet, Abbrechen revertiert.
-    LaunchedEffect(homeLayout, isEditMode) {
-        dragState.seedFrom(homeLayout)
+    LaunchedEffect(homeLayout, hostedWidgets, isEditMode) {
+        dragState.seedFrom(homeLayout, hostedWidgets)
     }
 
     // Tickt die Uhrzeit für die getrennten Uhr-/Datums-Elemente.
@@ -194,7 +209,7 @@ fun HomeScreen(
     // Sammel-Padding je Element: Favoriten behalten ihren Rahmenabstand, Text-Elemente
     // (Uhr/Datum/Wetter) liegen im Neutralzustand bündig gestapelt → kein Inter-Padding.
     fun framePadding(target: HomeEditTarget): Float =
-        if (target == HomeEditTarget.FAVORITES) favoritesFramePaddingPx else 0f
+        if (target == HomeEditTarget.Favorites) favoritesFramePaddingPx else 0f
 
     fun baseRect(target: HomeEditTarget, o: Offset): Rect? =
         neutralBounds[target]?.let { translateRect(it, o.x, o.y) }
@@ -204,7 +219,7 @@ fun HomeScreen(
 
     fun clampOffset(target: HomeEditTarget, x: Float, y: Float): Offset {
         val bounds = neutralBounds[target] ?: return Offset(x, y)
-        val topLimit = if (target == HomeEditTarget.CLOCK) clockTopLimitPx else 0f
+        val topLimit = if (target == HomeEditTarget.Clock) clockTopLimitPx else 0f
         // Reine Clamping-Mathematik liegt in HomeGeometry.kt (unit-getestet); die
         // target->bounds/topLimit-Aufloesung bleibt hier (haengt am neutralBounds-State).
         return clampOffsetToBounds(
@@ -360,10 +375,19 @@ fun HomeScreen(
     }
 
     fun testTagFor(target: HomeEditTarget): String = when (target) {
-        HomeEditTarget.CLOCK -> "home_edit_target_clock"
-        HomeEditTarget.DATE -> "home_edit_target_date"
-        HomeEditTarget.WEATHER -> "home_edit_target_weather"
-        HomeEditTarget.FAVORITES -> "home_edit_target_favorites"
+        HomeEditTarget.Clock -> "home_edit_target_clock"
+        HomeEditTarget.Date -> "home_edit_target_date"
+        HomeEditTarget.Weather -> "home_edit_target_weather"
+        HomeEditTarget.Favorites -> "home_edit_target_favorites"
+        is HomeEditTarget.Widget -> "home_edit_target_widget_${target.appWidgetId}"
+    }
+
+    // Wackel-Richtung im Edit-Modus: benachbarte Elemente rotieren gegenläufig
+    // (früher `ordinal % 2`; Widgets alternieren über ihre AppWidget-ID).
+    fun wiggleSign(target: HomeEditTarget): Float = when (target) {
+        HomeEditTarget.Clock, HomeEditTarget.Weather -> 1f
+        HomeEditTarget.Date, HomeEditTarget.Favorites -> -1f
+        is HomeEditTarget.Widget -> if (target.appWidgetId % 2 == 0) 1f else -1f
     }
 
     // Material-3-Expressive: dezentes „Jiggle" der bewegbaren Home-Elemente im Edit-Modus,
@@ -405,7 +429,7 @@ fun HomeScreen(
                         scaleX = 1.04f
                         scaleY = 1.04f
                     } else if (showFrame) {
-                        rotationZ = editWiggleAngle * if (target.ordinal % 2 == 0) 1f else -1f
+                        rotationZ = editWiggleAngle * wiggleSign(target)
                     }
                 }
             }
@@ -538,7 +562,8 @@ fun HomeScreen(
                             detectTapGestures(
                                 onTap = { tapOffset ->
                                     if (isEditMode && selectedEditTarget != null) {
-                                        val hitTarget = HomeEditTarget.entries.any { target ->
+                                        // Alle gemessenen Targets (eingebaute + Widgets) prüfen.
+                                        val hitTarget = neutralBounds.keys.toList().any { target ->
                                             val rect = neutralBounds[target]?.let {
                                                 translateRect(it, offsets[target]?.x ?: 0f, offsets[target]?.y ?: 0f)
                                             } ?: return@any false
@@ -596,8 +621,8 @@ fun HomeScreen(
                     Box(
                         modifier = Modifier
                             .wrapContentWidth(Alignment.Start)
-                            .targetLayout(HomeEditTarget.CLOCK)
-                            .targetEditModifier(HomeEditTarget.CLOCK)
+                            .targetLayout(HomeEditTarget.Clock)
+                            .targetEditModifier(HomeEditTarget.Clock)
                     ) {
                         ClockText(
                             time = currentTime,
@@ -618,8 +643,8 @@ fun HomeScreen(
                     modifier = Modifier
                         .align(Alignment.TopStart)
                         .padding(top = dateTopAnchor)
-                        .targetLayout(HomeEditTarget.DATE)
-                        .targetEditModifier(HomeEditTarget.DATE)
+                        .targetLayout(HomeEditTarget.Date)
+                        .targetEditModifier(HomeEditTarget.Date)
                 ) {
                     DateText(
                         time = currentTime,
@@ -638,10 +663,59 @@ fun HomeScreen(
                     modifier = Modifier
                         .align(Alignment.TopEnd)
                         .padding(top = 30.dp)
-                        .targetLayout(HomeEditTarget.WEATHER)
-                        .targetEditModifier(HomeEditTarget.WEATHER)
+                        .targetLayout(HomeEditTarget.Weather)
+                        .targetEditModifier(HomeEditTarget.Weather)
                 ) {
                     WeatherRow(isPreview = isPreview || isEditMode)
+                }
+            }
+
+            // 5. Gehostete System-Widgets (B1): frei verschiebbar wie die eingebauten
+            // Elemente. Natürliche Ankerposition unterhalb der Uhr-Zone, pro Widget leicht
+            // gestaffelt, damit neu hinzugefügte nicht exakt übereinander liegen.
+            hostedWidgets.forEachIndexed { index, widget ->
+                key(widget.appWidgetId) {
+                    val widgetTarget = HomeEditTarget.Widget(widget.appWidgetId)
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.TopStart)
+                            .padding(top = 160.dp + (index * 24).dp)
+                            .targetLayout(widgetTarget)
+                            .targetEditModifier(widgetTarget)
+                    ) {
+                        HostedWidgetView(
+                            widget = widget,
+                            hostView = if (isPreview) null else widgetViewProvider(widget.appWidgetId),
+                            isEditMode = isEditMode,
+                        )
+                        // Entfernen-Badge am ausgewählten Widget (nur im Edit-Modus).
+                        if (isEditMode && selectedEditTarget == widgetTarget) {
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.TopEnd)
+                                    .zIndex(10f)
+                                    .size(28.dp)
+                                    .clip(CircleShape)
+                                    .designSurface(
+                                        designStyle,
+                                        CircleShape,
+                                        isDarkTextEnabled,
+                                        surfaceAccent,
+                                        fillAlpha = 0.5f
+                                    )
+                                    .clickable { onRemoveWidget(widget.appWidgetId) }
+                                    .testTag("home_widget_remove_${widget.appWidgetId}"),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Close,
+                                    contentDescription = stringResource(R.string.cd_remove_widget),
+                                    tint = mainTextColor,
+                                    modifier = Modifier.size(18.dp)
+                                )
+                            }
+                        }
+                    }
                 }
             }
 
@@ -655,8 +729,8 @@ fun HomeScreen(
                 Box(
                     modifier = Modifier
                         .wrapContentWidth(Alignment.Start)
-                        .targetLayout(HomeEditTarget.FAVORITES)
-                        .targetEditModifier(HomeEditTarget.FAVORITES)
+                        .targetLayout(HomeEditTarget.Favorites)
+                        .targetEditModifier(HomeEditTarget.Favorites)
                 ) {
                     // Optionale Umrandung der Favoriten-Box (reiner Umriss, innen transparent).
                     val favoritesBorderColor = when (LocalFavoritesBorderStyle.current) {
@@ -843,11 +917,8 @@ fun HomeScreen(
                     EditControlButton(
                         icon = Icons.Rounded.Close,
                         onClick = {
-                            // Abbrechen: Live-Offsets auf gespeicherten Stand zurücksetzen.
-                            offsets[HomeEditTarget.CLOCK] = homeLayout.clock
-                            offsets[HomeEditTarget.DATE] = homeLayout.date
-                            offsets[HomeEditTarget.WEATHER] = homeLayout.weather
-                            offsets[HomeEditTarget.FAVORITES] = homeLayout.favorites
+                            // Abbrechen: Live-Offsets (inkl. Widgets) auf gespeicherten Stand zurücksetzen.
+                            dragState.seedFrom(homeLayout, hostedWidgets)
                             selectedEditTarget = null
                             isEditTargetUserPinned = false
                             updateCollisionFeedback(false)
@@ -863,6 +934,7 @@ fun HomeScreen(
                         onClick = {
                             updateCollisionFeedback(false)
                             onSaveHomeLayout(dragState.toHomeLayout())
+                            onSaveWidgetOffsets(dragState.toWidgetOffsets())
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.position_saved),

--- a/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
@@ -1,0 +1,87 @@
+package com.example.androidlauncher.ui
+
+import android.annotation.SuppressLint
+import android.appwidget.AppWidgetHostView
+import android.content.Context
+import android.os.Build
+import android.os.Bundle
+import android.util.SizeF
+import android.view.MotionEvent
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.example.androidlauncher.data.HostedWidget
+
+/**
+ * Compose-Wrapper um eine [AppWidgetHostView] (B1). Die Host-View kommt gecacht aus
+ * dem WidgetHostManager und wird hier nur in einen [BlockableFrameLayout] eingehängt –
+ * im Edit-Modus fängt der Rahmen alle Touches ab, damit die Drag-Gesten des
+ * umgebenden Home-Elements gewinnen; im Normalmodus bleibt das Widget voll interaktiv.
+ */
+@Composable
+fun HostedWidgetView(
+    widget: HostedWidget,
+    hostView: AppWidgetHostView?,
+    isEditMode: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    // Provider deinstalliert oder View (noch) nicht erzeugbar → nichts rendern;
+    // der Orphan-Cleanup räumt den Eintrag beim nächsten Start weg.
+    if (hostView == null) return
+
+    AndroidView(
+        factory = { context ->
+            BlockableFrameLayout(context).apply {
+                // Die gecachte Host-View kann noch am alten Rahmen hängen
+                // (Composable wurde zwischenzeitlich disposed) – erst lösen.
+                (hostView.parent as? ViewGroup)?.removeView(hostView)
+                addView(
+                    hostView,
+                    FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                    )
+                )
+            }
+        },
+        update = { frame ->
+            frame.blockTouches = isEditMode
+            updateAppWidgetSizeCompat(hostView, widget.widthDp, widget.heightDp)
+        },
+        modifier = modifier.size(widget.widthDp.dp, widget.heightDp.dp)
+    )
+}
+
+/** Meldet dem Provider die Anzeigegröße, damit er das passende RemoteViews-Layout liefert. */
+private fun updateAppWidgetSizeCompat(hostView: AppWidgetHostView, widthDp: Int, heightDp: Int) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        hostView.updateAppWidgetSize(
+            Bundle(),
+            listOf(SizeF(widthDp.toFloat(), heightDp.toFloat()))
+        )
+    } else {
+        @Suppress("DEPRECATION")
+        hostView.updateAppWidgetSize(null, widthDp, heightDp, widthDp, heightDp)
+    }
+}
+
+/**
+ * FrameLayout, das bei gesetztem [blockTouches] alle Touch-Events abfängt und NICHT
+ * behandelt – die Events gelten damit für Compose als unkonsumiert und erreichen die
+ * Drag-Gesten des umgebenden Edit-Targets (Muster: Launcher-Edit-Modi).
+ */
+private class BlockableFrameLayout(context: Context) : FrameLayout(context) {
+
+    var blockTouches = false
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean =
+        blockTouches || super.onInterceptTouchEvent(ev)
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent?): Boolean =
+        if (blockTouches) false else super.onTouchEvent(event)
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -140,6 +140,7 @@
     <string name="widget_picker_title">Widgets</string>
     <string name="widget_picker_empty">Keine Widgets gefunden</string>
     <string name="widget_bind_failed">Widget konnte nicht hinzugefügt werden</string>
+    <string name="cd_remove_widget">Widget entfernen</string>
     <string name="edit_app_icons">App-Icons anpassen</string>
     <string name="change_wallpaper">Wallpaper ändern</string>
     <string name="adjust_wallpaper">Hintergrund anpassen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -125,6 +125,7 @@
     <string name="widget_picker_title">Widgets</string>
     <string name="widget_picker_empty">No se encontraron widgets</string>
     <string name="widget_bind_failed">No se pudo añadir el widget</string>
+    <string name="cd_remove_widget">Quitar el widget</string>
     <string name="edit_app_icons">Personalizar iconos de apps</string>
     <string name="change_wallpaper">Cambiar fondo de pantalla</string>
     <string name="adjust_wallpaper">Ajustar fondo de pantalla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -125,6 +125,7 @@
     <string name="widget_picker_title">Widgets</string>
     <string name="widget_picker_empty">Aucun widget trouvé</string>
     <string name="widget_bind_failed">Impossible d\'ajouter le widget</string>
+    <string name="cd_remove_widget">Retirer le widget</string>
     <string name="edit_app_icons">Personnaliser les icônes d\'apps</string>
     <string name="change_wallpaper">Changer le fond d\'écran</string>
     <string name="adjust_wallpaper">Ajuster le fond d\'écran</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -125,6 +125,7 @@
     <string name="widget_picker_title">Widget</string>
     <string name="widget_picker_empty">Nessun widget trovato</string>
     <string name="widget_bind_failed">Impossibile aggiungere il widget</string>
+    <string name="cd_remove_widget">Rimuovi widget</string>
     <string name="edit_app_icons">Personalizza le icone delle app</string>
     <string name="change_wallpaper">Cambia sfondo</string>
     <string name="adjust_wallpaper">Regola lo sfondo</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="widget_picker_title">Widgets</string>
     <string name="widget_picker_empty">No widgets found</string>
     <string name="widget_bind_failed">Widget could not be added</string>
+    <string name="cd_remove_widget">Remove widget</string>
     <string name="edit_app_icons">Customize app icons</string>
     <string name="change_wallpaper">Change wallpaper</string>
     <string name="adjust_wallpaper">Adjust wallpaper</string>

--- a/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
@@ -2,16 +2,28 @@ package com.example.androidlauncher.ui
 
 import androidx.compose.ui.geometry.Offset
 import com.example.androidlauncher.data.HomeLayout
+import com.example.androidlauncher.data.HostedWidget
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
  * Absicherung des A6-Splits: der Holder seedet aus dem persistierten Layout und
  * liefert die Live-Offsets als speicherbares HomeLayout zurück (Roundtrip).
+ * Seit B1 zusätzlich: gehostete System-Widgets als dynamische Drag-Targets.
  */
 class HomeDragStateHolderTest {
+
+    private fun widget(id: Int, x: Float = 0f, y: Float = 0f) = HostedWidget(
+        appWidgetId = id,
+        provider = "com.example/$id",
+        widthDp = 200,
+        heightDp = 100,
+        offsetX = x,
+        offsetY = y,
+    )
 
     @Test
     fun `initial state mirrors the given layout and has no selection`() {
@@ -28,8 +40,8 @@ class HomeDragStateHolderTest {
     fun `live edits roundtrip into a persistable layout`() {
         val holder = HomeDragStateHolder(HomeLayout())
 
-        holder.offsets[HomeEditTarget.CLOCK] = Offset(42f, -12f)
-        holder.offsets[HomeEditTarget.WEATHER] = Offset(0f, 30f)
+        holder.offsets[HomeEditTarget.Clock] = Offset(42f, -12f)
+        holder.offsets[HomeEditTarget.Weather] = Offset(0f, 30f)
 
         assertEquals(
             HomeLayout(clock = Offset(42f, -12f), weather = Offset(0f, 30f)),
@@ -42,9 +54,51 @@ class HomeDragStateHolderTest {
         val stored = HomeLayout(date = Offset(5f, 5f))
         val holder = HomeDragStateHolder(stored)
 
-        holder.offsets[HomeEditTarget.DATE] = Offset(99f, 99f)
+        holder.offsets[HomeEditTarget.Date] = Offset(99f, 99f)
         holder.seedFrom(stored)
 
         assertEquals(stored, holder.toHomeLayout())
+    }
+
+    // --- B1: gehostete Widgets ---
+
+    @Test
+    fun `widget offsets seed from persisted entries and roundtrip`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(7, x = 12f, y = -8f)))
+
+        assertEquals(mapOf(7 to Offset(12f, -8f)), holder.toWidgetOffsets())
+
+        holder.offsets[HomeEditTarget.Widget(7)] = Offset(30f, 40f)
+        assertEquals(mapOf(7 to Offset(30f, 40f)), holder.toWidgetOffsets())
+
+        // Abbrechen: seedFrom revertiert auch die Widget-Offsets.
+        holder.seedFrom(HomeLayout(), listOf(widget(7, x = 12f, y = -8f)))
+        assertEquals(mapOf(7 to Offset(12f, -8f)), holder.toWidgetOffsets())
+    }
+
+    @Test
+    fun `removed widgets drop their map entries and selection`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1), widget(2)))
+        holder.selectedEditTarget = HomeEditTarget.Widget(2)
+        holder.isEditTargetUserPinned = true
+        holder.lastBlockedHapticMs[HomeEditTarget.Widget(2)] = 123L
+
+        holder.seedFrom(HomeLayout(), listOf(widget(1)))
+
+        assertEquals(mapOf(1 to Offset.Zero), holder.toWidgetOffsets())
+        assertFalse(holder.offsets.containsKey(HomeEditTarget.Widget(2)))
+        assertFalse(holder.lastBlockedHapticMs.containsKey(HomeEditTarget.Widget(2)))
+        assertNull(holder.selectedEditTarget)
+        assertFalse(holder.isEditTargetUserPinned)
+    }
+
+    @Test
+    fun `new widgets join the drag state via seedFrom`() {
+        val holder = HomeDragStateHolder(HomeLayout())
+
+        holder.seedFrom(HomeLayout(), listOf(widget(5, x = 3f, y = 4f)))
+
+        assertTrue(holder.offsets.containsKey(HomeEditTarget.Widget(5)))
+        assertEquals(mapOf(5 to Offset(3f, 4f)), holder.toWidgetOffsets())
     }
 }


### PR DESCRIPTION
## Zusammenfassung

PR 3/3 des AppWidgetHost-Supports, baut auf #119 auf (Basis-Branch `feature/b1-widget-picker-bind` – nach dessen Merge auf `main` umbasen). Macht die gebundenen Widgets auf dem Startbildschirm sichtbar, verschiebbar und entfernbar:

- **`HomeEditTarget`: Enum → sealed interface** (`Clock/Date/Weather/Favorites` + `Widget(appWidgetId)`). Alle Drag-Maps und Helfer (`applyDrag`, Clamping, Hit-Test, `targetLayout`/`targetEditModifier`, zIndex) sind über `HomeEditTarget` gekeyt und funktionieren damit unverändert für Widgets – keine parallele Mechanik. Hit-Test läuft jetzt über die gemessenen `neutralBounds.keys`; Wiggle-Richtung über `wiggleSign()` (ersetzt `ordinal % 2`)
- **`HomeDragStateHolder`** – verwaltet Widget-Offsets mit: Seed aus persistiertem Stand (Cancel revertiert automatisch), `toWidgetOffsets()` für den Save-Knopf, entfernte Widgets räumen ihre Map-Einträge und ggf. die Auswahl ab
- **`ui/HostedWidgetView.kt`** – `AndroidView` um die manager-gecachte `AppWidgetHostView` (nie neu erzeugt → Widget-Zustand bleibt erhalten); Größe via `updateAppWidgetSize`-Compat (SizeF-Liste auf API 31+). Ein `BlockableFrameLayout` fängt im Edit-Modus alle Touches ab, ohne sie zu behandeln – die Compose-Drag-Geste gewinnt, im Normalmodus bleibt das Widget voll interaktiv; Kover-Exclude
- **HomeScreen** – rendert die Widgets als frei verschiebbare Home-Objekte (natürlicher Anker unter der Uhr-Zone, pro Widget gestaffelt); ausgewählte Widgets zeigen ein X-Badge zum Entfernen; Save persistiert Layout- und Widget-Offsets zusammen
- **MainActivity** – `widgets`-Flow, `widgetViewProvider`, Save-/Remove-Callbacks

## Tests

- `HomeDragStateHolderTest` – Widget-Offsets: Seed/Roundtrip/Revert, Entfernen räumt Einträge + Auswahl, neue Widgets via `seedFrom`

`./gradlew detekt testDebugUnitTest koverVerifyDebug` und `compileDebugAndroidTestKotlin` lokal grün.

## Gerätetest nach Merge (Checkliste aus dem Plan)

- [ ] Widget ohne Configure hinzufügen (z. B. Uhr) und mit Configure + Bind-Dialog
- [ ] Cancel in jedem Schritt → kein Geister-Widget, keine geleakte ID (`adb shell dumpsys appwidget`)
- [ ] Verschieben + Save/Cancel (Revert), Entfernen über das X-Badge
- [ ] Widget-Klicks im Normalmodus, Persistenz nach Launcher-Neustart
- [ ] Widget-App deinstallieren → Eintrag verschwindet nach Neustart

🤖 Generated with [Claude Code](https://claude.com/claude-code)