### PR TITLE
feat(B5): Settings-Backup/Restore – Export/Import als versionierte JSON-Datei

### DIFF
--- a/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
+++ b/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
@@ -176,5 +176,7 @@ class LauncherComposableUiTest {
     private object NoopEditConfigActions : EditConfigActions {
         override fun openDefaultLauncherPrompt() = Unit
         override fun pickWallpaper() = Unit
+        override fun exportBackup() = Unit
+        override fun importBackup() = Unit
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -117,6 +117,8 @@ import com.example.androidlauncher.data.WidgetBindFlow
 import com.example.androidlauncher.data.WidgetBindStep
 import com.example.androidlauncher.data.WidgetHostManager
 import com.example.androidlauncher.data.WidgetSizeDp
+import com.example.androidlauncher.data.backup.BackupSerializer
+import com.example.androidlauncher.data.backup.RestoreResult
 import com.example.androidlauncher.data.defaultWidgetSizeDp
 import com.example.androidlauncher.gesture.GestureActionEffects
 import com.example.androidlauncher.gesture.GestureActionHandler
@@ -228,6 +230,9 @@ class MainActivity : ComponentActivity() {
 
     @javax.inject.Inject
     lateinit var iconPackRepository: com.example.androidlauncher.data.IconPackRepository
+
+    @javax.inject.Inject
+    lateinit var backupManager: com.example.androidlauncher.data.backup.BackupManager
 
     // B1: laufender Widget-Bind-Flow. Übersteht bewusst keinen Prozess-Tod –
     // geleakte Widget-IDs räumt cleanupOrphans beim nächsten Start ab.
@@ -411,6 +416,20 @@ class MainActivity : ComponentActivity() {
                     pendingWallpaperUri = sourceUri
                     isWallpaperCropOpen = true
                 }
+            }
+
+            // B5: SAF-Dialoge für Backup-Export/-Import; die eigentliche Arbeit
+            // (Streams + BackupManager) übernehmen die Activity-Helfer auf Dispatchers.IO.
+            val backupExportLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.CreateDocument("application/json")
+            ) { uri: Uri? ->
+                uri?.let { exportBackupTo(it) }
+            }
+
+            val backupImportLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.OpenDocument()
+            ) { uri: Uri? ->
+                uri?.let { importBackupFrom(it) }
             }
 
             val cameraPermissionLauncher = rememberLauncherForActivityResult(
@@ -1658,6 +1677,16 @@ class MainActivity : ComponentActivity() {
                                         PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
                                     )
                                 }
+
+                                override fun exportBackup() {
+                                    backupExportLauncher.launch(suggestedBackupFileName())
+                                }
+
+                                override fun importBackup() {
+                                    backupImportLauncher.launch(
+                                        arrayOf("application/json", "application/octet-stream")
+                                    )
+                                }
                             }
                         }
                         EditConfigMenu(actions = editConfigActions)
@@ -2089,6 +2118,52 @@ class MainActivity : ComponentActivity() {
         widgetHostManager.deleteWidgetId(appWidgetId)
         if (showError) {
             Toast.makeText(this, getString(R.string.widget_bind_failed), Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    /** Vorschlags-Dateiname für den SAF-Dialog, z. B. `rethrone-backup-20260706.json`. */
+    private fun suggestedBackupFileName(): String {
+        val date = java.text.SimpleDateFormat("yyyyMMdd", java.util.Locale.US).format(java.util.Date())
+        return "rethrone-backup-$date.json"
+    }
+
+    /** B5: schreibt den aktuellen Konfigurations-Snapshot als JSON an die gewählte URI. */
+    private fun exportBackupTo(uri: Uri) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val result = runCatching {
+                val snapshot = backupManager.createSnapshot(BuildConfig.VERSION_CODE.toLong())
+                val json = BackupSerializer.serialize(snapshot)
+                contentResolver.openOutputStream(uri)?.use { stream ->
+                    stream.write(json.toByteArray(Charsets.UTF_8))
+                } ?: error("OutputStream konnte nicht geöffnet werden")
+            }
+            withContext(Dispatchers.Main) {
+                val messageRes = if (result.isSuccess) {
+                    R.string.backup_export_success
+                } else {
+                    R.string.backup_export_error
+                }
+                Toast.makeText(this@MainActivity, getString(messageRes), Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    /** B5: liest und validiert eine Backup-Datei und spielt sie ein (Overwrite-all). */
+    private fun importBackupFrom(uri: Uri) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val messageRes = runCatching {
+                val json = contentResolver.openInputStream(uri)?.use { stream ->
+                    stream.readBytes().toString(Charsets.UTF_8)
+                } ?: return@runCatching R.string.backup_import_error
+                val snapshot = BackupSerializer.parse(json) ?: return@runCatching R.string.backup_import_error
+                when (backupManager.restore(snapshot)) {
+                    RestoreResult.APPLIED -> R.string.backup_import_success
+                    RestoreResult.UNSUPPORTED_VERSION -> R.string.backup_import_unsupported
+                }
+            }.getOrDefault(R.string.backup_import_error)
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@MainActivity, getString(messageRes), Toast.LENGTH_LONG).show()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/IconManager.kt
@@ -7,7 +7,8 @@ import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
-private val Context.iconDataStore by preferencesDataStore(name = "icon_mappings")
+// `internal` statt `private`: der BackupManager (B5) erfasst diese DataStore-Datei mit.
+internal val Context.iconDataStore by preferencesDataStore(name = "icon_mappings")
 private const val AUTO_FALLBACK_PREFIX = "auto_fallback__"
 private const val AUTO_RULE_PREFIX = "auto_rule__"
 

--- a/app/src/main/java/com/example/androidlauncher/data/backup/BackupManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/backup/BackupManager.kt
@@ -1,0 +1,170 @@
+package com.example.androidlauncher.data.backup
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import com.example.androidlauncher.data.CryptoManager
+import com.example.androidlauncher.data.WidgetSerializer
+import com.example.androidlauncher.data.favoritesDataStore
+import com.example.androidlauncher.data.folderDataStore
+import com.example.androidlauncher.data.iconDataStore
+import com.example.androidlauncher.data.settings.settingsDataStore
+import kotlinx.coroutines.flow.first
+
+/** Ergebnis eines Restore-Versuchs. */
+enum class RestoreResult {
+    APPLIED,
+
+    /** Die Datei stammt aus einer neueren App-Version (backupVersion > CURRENT_VERSION). */
+    UNSUPPORTED_VERSION,
+}
+
+/**
+ * Erstellt und spielt Backups der Launcher-Konfiguration ein (B5).
+ *
+ * Erfasst die vier Preference-DataStores (settings/favorites/folders/icon_mappings)
+ * gemäß [BackupSpec]; der `search_suggestions`-Store bleibt bewusst außen vor
+ * (Web-Suchhistorie). Restore ist Overwrite-all pro Store in je einem atomaren
+ * Edit; die per [BackupSpec.EXCLUDED_SETTINGS_KEYS] geschützten Werte (App-Lock,
+ * Wallpaper-URI, Widget-Bestand) überleben den Import unverändert.
+ */
+class BackupManager(
+    private val settingsStore: DataStore<Preferences>,
+    private val favoritesStore: DataStore<Preferences>,
+    private val foldersStore: DataStore<Preferences>,
+    private val iconStore: DataStore<Preferences>,
+) {
+
+    /** Produktiv-Konstruktor: löst die vier geteilten DataStore-Instanzen auf. */
+    constructor(context: Context) : this(
+        settingsStore = context.settingsDataStore,
+        favoritesStore = context.favoritesDataStore,
+        foldersStore = context.folderDataStore,
+        iconStore = context.iconDataStore,
+    )
+
+    /** Liest alle vier Stores und baut den exportierbaren Snapshot. */
+    suspend fun createSnapshot(
+        appVersionCode: Long,
+        nowMs: Long = System.currentTimeMillis(),
+    ): BackupSnapshot {
+        val settingsPrefs = settingsStore.data.first()
+        val stores = mapOf(
+            BackupSpec.STORE_SETTINGS to snapshotEntries(
+                prefs = settingsPrefs,
+                excludedKeys = BackupSpec.EXCLUDED_SETTINGS_KEYS,
+                encryptedKeys = BackupSpec.ENCRYPTED_SETTINGS_KEYS,
+            ),
+            BackupSpec.STORE_FAVORITES to snapshotEntries(favoritesStore.data.first()),
+            BackupSpec.STORE_FOLDERS to snapshotEntries(foldersStore.data.first()),
+            BackupSpec.STORE_ICON_MAPPINGS to snapshotEntries(iconStore.data.first()),
+        )
+        return BackupSnapshot(
+            backupVersion = BackupSpec.CURRENT_VERSION,
+            appVersionCode = appVersionCode,
+            exportedAtMs = nowMs,
+            stores = stores,
+            widgets = snapshotWidgets(settingsPrefs),
+        )
+    }
+
+    /**
+     * Spielt einen Snapshot ein. Kein App-Restart nötig – alle Konsumenten
+     * collecten die DataStore-Flows reaktiv.
+     */
+    suspend fun restore(snapshot: BackupSnapshot): RestoreResult {
+        if (snapshot.backupVersion > BackupSpec.CURRENT_VERSION) return RestoreResult.UNSUPPORTED_VERSION
+
+        restoreSettings(snapshot.stores[BackupSpec.STORE_SETTINGS].orEmpty())
+        restorePlainStore(favoritesStore, snapshot.stores[BackupSpec.STORE_FAVORITES].orEmpty())
+        restorePlainStore(foldersStore, snapshot.stores[BackupSpec.STORE_FOLDERS].orEmpty())
+        restorePlainStore(iconStore, snapshot.stores[BackupSpec.STORE_ICON_MAPPINGS].orEmpty())
+        return RestoreResult.APPLIED
+    }
+
+    private fun snapshotEntries(
+        prefs: Preferences,
+        excludedKeys: Set<String> = emptySet(),
+        encryptedKeys: Set<String> = emptySet(),
+    ): List<BackupEntry> = prefs.asMap().mapNotNull { (key, value) ->
+        if (key.name in excludedKeys) return@mapNotNull null
+        val plainValue = if (key.name in encryptedKeys) {
+            CryptoManager.decryptOrLegacy(value as? String)
+        } else {
+            value
+        }
+        val type = BackupValueType.fromValue(plainValue) ?: return@mapNotNull null
+        BackupEntry(key.name, type, plainValue)
+    }
+
+    /** Widgets id-los exportieren – appWidgetIds sind gerätespezifisch (v1: kein Re-Bind beim Import). */
+    private fun snapshotWidgets(settingsPrefs: Preferences): List<WidgetBackup> {
+        val json = settingsPrefs[stringPreferencesKey(HOSTED_WIDGETS_KEY)] ?: return emptyList()
+        return WidgetSerializer.parseWidgets(json).map {
+            WidgetBackup(
+                provider = it.provider,
+                widthDp = it.widthDp,
+                heightDp = it.heightDp,
+                offsetX = it.offsetX,
+                offsetY = it.offsetY,
+            )
+        }
+    }
+
+    private suspend fun restoreSettings(entries: List<BackupEntry>) {
+        settingsStore.edit { prefs ->
+            val preserved = prefs.asMap().filterKeys { it.name in BackupSpec.EXCLUDED_SETTINGS_KEYS }
+            prefs.clear()
+            preserved.forEach { (key, value) ->
+                @Suppress("UNCHECKED_CAST")
+                prefs[key as Preferences.Key<Any>] = value
+            }
+            entries.forEach { entry ->
+                // Geschützte Keys nie aus einer Import-Datei übernehmen (Defense in Depth).
+                if (entry.key in BackupSpec.EXCLUDED_SETTINGS_KEYS) return@forEach
+                if (entry.key in BackupSpec.ENCRYPTED_SETTINGS_KEYS) {
+                    val plain = entry.value as? String ?: return@forEach
+                    prefs[stringPreferencesKey(entry.key)] = CryptoManager.encrypt(plain)
+                } else {
+                    applyEntry(prefs, entry)
+                }
+            }
+        }
+    }
+
+    private suspend fun restorePlainStore(store: DataStore<Preferences>, entries: List<BackupEntry>) {
+        store.edit { prefs ->
+            prefs.clear()
+            entries.forEach { applyEntry(prefs, it) }
+        }
+    }
+
+    /** Rekonstruiert den exakt typisierten Preferences-Key aus dem Typ-Tag. */
+    private fun applyEntry(prefs: MutablePreferences, entry: BackupEntry) {
+        when (entry.type) {
+            BackupValueType.STRING -> prefs[stringPreferencesKey(entry.key)] = entry.value as String
+            BackupValueType.BOOLEAN -> prefs[booleanPreferencesKey(entry.key)] = entry.value as Boolean
+            BackupValueType.INT -> prefs[intPreferencesKey(entry.key)] = entry.value as Int
+            BackupValueType.LONG -> prefs[longPreferencesKey(entry.key)] = entry.value as Long
+            BackupValueType.FLOAT -> prefs[floatPreferencesKey(entry.key)] = entry.value as Float
+            BackupValueType.DOUBLE -> prefs[doublePreferencesKey(entry.key)] = entry.value as Double
+            BackupValueType.STRING_SET ->
+                prefs[stringSetPreferencesKey(entry.key)] =
+                    (entry.value as Set<*>).map { it.toString() }.toSet()
+        }
+    }
+
+    private companion object {
+        // Muss dem Key in HomeLayoutSettings entsprechen (dort private).
+        const val HOSTED_WIDGETS_KEY = "hosted_widgets"
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/data/backup/BackupSerializer.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/backup/BackupSerializer.kt
@@ -1,0 +1,193 @@
+package com.example.androidlauncher.data.backup
+
+import org.json.JSONArray
+import org.json.JSONException
+import org.json.JSONObject
+
+/** Ein einzelner Preference-Eintrag mit Typ-Tag (siehe [BackupValueType]). */
+data class BackupEntry(
+    val key: String,
+    val type: BackupValueType,
+    val value: Any,
+)
+
+/**
+ * Typ-Tag eines [BackupEntry]. Pflicht, weil `Preferences.asMap()` untypisiert ist
+ * und der Restore den exakt typisierten Preferences-Key rekonstruieren muss –
+ * ein Int-Wert unter einem Long-Key (oder Float unter Double) würde alle Reads
+ * still shadowen.
+ */
+enum class BackupValueType(val tag: String) {
+    STRING("string"),
+    BOOLEAN("boolean"),
+    INT("int"),
+    LONG("long"),
+    FLOAT("float"),
+    DOUBLE("double"),
+    STRING_SET("stringSet"),
+    ;
+
+    companion object {
+        fun fromTag(tag: String): BackupValueType? = entries.firstOrNull { it.tag == tag }
+
+        /** Leitet das Tag aus der Runtime-Klasse eines DataStore-Werts ab; unbekannte Typen → null. */
+        fun fromValue(value: Any): BackupValueType? = when (value) {
+            is String -> STRING
+            is Boolean -> BOOLEAN
+            is Int -> INT
+            is Long -> LONG
+            is Float -> FLOAT
+            is Double -> DOUBLE
+            is Set<*> -> STRING_SET
+            else -> null // z. B. ByteArray – im Projekt ungenutzt, bewusst nicht unterstützt.
+        }
+    }
+}
+
+/** Ein exportiertes Widget – bewusst ohne appWidgetId (gerätespezifisch). */
+data class WidgetBackup(
+    val provider: String,
+    val widthDp: Int,
+    val heightDp: Int,
+    val offsetX: Float,
+    val offsetY: Float,
+)
+
+/** Vollständiger Inhalt einer Backup-Datei. */
+data class BackupSnapshot(
+    val backupVersion: Int,
+    val appVersionCode: Long,
+    val exportedAtMs: Long,
+    val stores: Map<String, List<BackupEntry>>,
+    val widgets: List<WidgetBackup>,
+)
+
+/**
+ * Serialisiert einen [BackupSnapshot] nach/aus JSON (Muster: WidgetSerializer).
+ * Korrupte Eingaben liefern `null`; unbekannte Keys/Typen/Sektionen werden beim
+ * Parsen still übersprungen (forward-tolerant). Die Versionsprüfung übernimmt
+ * der BackupManager beim Restore.
+ */
+object BackupSerializer {
+
+    private const val KEY_VERSION = "backupVersion"
+    private const val KEY_APP_VERSION = "appVersionCode"
+    private const val KEY_EXPORTED_AT = "exportedAtMs"
+    private const val KEY_STORES = "stores"
+    private const val KEY_WIDGETS = "widgets"
+    private const val KEY_ENTRY_KEY = "k"
+    private const val KEY_ENTRY_TYPE = "t"
+    private const val KEY_ENTRY_VALUE = "v"
+    private const val KEY_WIDGET_PROVIDER = "provider"
+    private const val KEY_WIDGET_WIDTH = "widthDp"
+    private const val KEY_WIDGET_HEIGHT = "heightDp"
+    private const val KEY_WIDGET_OFFSET_X = "offsetX"
+    private const val KEY_WIDGET_OFFSET_Y = "offsetY"
+
+    fun serialize(snapshot: BackupSnapshot): String {
+        val root = JSONObject()
+        root.put(KEY_VERSION, snapshot.backupVersion)
+        root.put(KEY_APP_VERSION, snapshot.appVersionCode)
+        root.put(KEY_EXPORTED_AT, snapshot.exportedAtMs)
+        val stores = JSONObject()
+        snapshot.stores.forEach { (name, entries) ->
+            val array = JSONArray()
+            entries.forEach { array.put(serializeEntry(it)) }
+            stores.put(name, array)
+        }
+        root.put(KEY_STORES, stores)
+        val widgets = JSONArray()
+        snapshot.widgets.forEach { widgets.put(serializeWidget(it)) }
+        root.put(KEY_WIDGETS, widgets)
+        return root.toString()
+    }
+
+    fun parse(jsonString: String): BackupSnapshot? {
+        return try {
+            val root = JSONObject(jsonString)
+            val storesJson = root.optJSONObject(KEY_STORES) ?: JSONObject()
+            val stores = mutableMapOf<String, List<BackupEntry>>()
+            storesJson.keys().forEach { name ->
+                val array = storesJson.optJSONArray(name) ?: return@forEach
+                stores[name] = parseEntries(array)
+            }
+            BackupSnapshot(
+                backupVersion = root.getInt(KEY_VERSION),
+                appVersionCode = root.optLong(KEY_APP_VERSION, 0L),
+                exportedAtMs = root.optLong(KEY_EXPORTED_AT, 0L),
+                stores = stores,
+                widgets = parseWidgets(root.optJSONArray(KEY_WIDGETS) ?: JSONArray()),
+            )
+        } catch (_: JSONException) {
+            null
+        }
+    }
+
+    private fun serializeEntry(entry: BackupEntry): JSONObject {
+        val obj = JSONObject()
+        obj.put(KEY_ENTRY_KEY, entry.key)
+        obj.put(KEY_ENTRY_TYPE, entry.type.tag)
+        val value = when (entry.type) {
+            BackupValueType.STRING_SET -> JSONArray((entry.value as Set<*>).map { it.toString() })
+            BackupValueType.FLOAT -> (entry.value as Float).toDouble()
+            else -> entry.value
+        }
+        obj.put(KEY_ENTRY_VALUE, value)
+        return obj
+    }
+
+    private fun parseEntries(array: JSONArray): List<BackupEntry> =
+        (0 until array.length()).mapNotNull { i -> parseEntry(array.optJSONObject(i)) }
+
+    private fun parseEntry(obj: JSONObject?): BackupEntry? {
+        if (obj == null) return null
+        val key = obj.optString(KEY_ENTRY_KEY, "")
+        val type = BackupValueType.fromTag(obj.optString(KEY_ENTRY_TYPE, ""))
+        if (key.isEmpty() || type == null || !obj.has(KEY_ENTRY_VALUE)) return null
+        val value = parseValue(obj, type) ?: return null
+        return BackupEntry(key, type, value)
+    }
+
+    private fun parseValue(obj: JSONObject, type: BackupValueType): Any? = try {
+        when (type) {
+            BackupValueType.STRING -> obj.getString(KEY_ENTRY_VALUE)
+            BackupValueType.BOOLEAN -> obj.getBoolean(KEY_ENTRY_VALUE)
+            BackupValueType.INT -> obj.getInt(KEY_ENTRY_VALUE)
+            BackupValueType.LONG -> obj.getLong(KEY_ENTRY_VALUE)
+            BackupValueType.FLOAT -> obj.getDouble(KEY_ENTRY_VALUE).toFloat()
+            BackupValueType.DOUBLE -> obj.getDouble(KEY_ENTRY_VALUE)
+            BackupValueType.STRING_SET -> {
+                val array = obj.getJSONArray(KEY_ENTRY_VALUE)
+                buildSet { for (i in 0 until array.length()) add(array.getString(i)) }
+            }
+        }
+    } catch (_: JSONException) {
+        null
+    }
+
+    private fun serializeWidget(widget: WidgetBackup): JSONObject {
+        val obj = JSONObject()
+        obj.put(KEY_WIDGET_PROVIDER, widget.provider)
+        obj.put(KEY_WIDGET_WIDTH, widget.widthDp)
+        obj.put(KEY_WIDGET_HEIGHT, widget.heightDp)
+        obj.put(KEY_WIDGET_OFFSET_X, widget.offsetX.toDouble())
+        obj.put(KEY_WIDGET_OFFSET_Y, widget.offsetY.toDouble())
+        return obj
+    }
+
+    private fun parseWidgets(array: JSONArray): List<WidgetBackup> =
+        (0 until array.length()).mapNotNull { i -> parseWidget(array.optJSONObject(i)) }
+
+    private fun parseWidget(obj: JSONObject?): WidgetBackup? {
+        if (obj == null) return null
+        val provider = obj.optString(KEY_WIDGET_PROVIDER, "")
+        if (provider.isEmpty()) return null
+        return WidgetBackup(
+            provider = provider,
+            widthDp = obj.optInt(KEY_WIDGET_WIDTH, 0),
+            heightDp = obj.optInt(KEY_WIDGET_HEIGHT, 0),
+            offsetX = obj.optDouble(KEY_WIDGET_OFFSET_X, 0.0).toFloat(),
+            offsetY = obj.optDouble(KEY_WIDGET_OFFSET_Y, 0.0).toFloat(),
+        )
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/data/backup/BackupSpec.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/backup/BackupSpec.kt
@@ -1,0 +1,50 @@
+package com.example.androidlauncher.data.backup
+
+/**
+ * Definiert, was ein Settings-Backup (B5) enthält und was bewusst nicht.
+ *
+ * Reine Konstanten-Sammlung ohne Android-Abhängigkeiten, damit die Regeln
+ * unabhängig von DataStore/Krypto testbar sind.
+ */
+object BackupSpec {
+
+    /** Aktuelle Schema-Version der Backup-Datei. Neuere Dateien werden abgelehnt. */
+    const val CURRENT_VERSION = 1
+
+    /** Logische Store-Namen im JSON – entsprechen den DataStore-Dateinamen. */
+    const val STORE_SETTINGS = "settings"
+    const val STORE_FAVORITES = "favorites"
+    const val STORE_FOLDERS = "folders"
+    const val STORE_ICON_MAPPINGS = "icon_mappings"
+
+    val STORE_NAMES = listOf(STORE_SETTINGS, STORE_FAVORITES, STORE_FOLDERS, STORE_ICON_MAPPINGS)
+
+    /**
+     * Keys der "settings"-Datei, die weder exportiert noch beim Restore
+     * überschrieben werden:
+     * - App-Lock-Credentials (`lock_*`, `locked_apps`): Geheimnisse gehören nie in
+     *   eine Export-Datei; eine Locked-Liste ohne zugehöriges Secret wäre inkonsistent.
+     * - `custom_wallpaper_uri`: zeigt auf eine gerätelokale Datei im cacheDir.
+     * - `hosted_widgets`: appWidgetIds sind gerätespezifisch; Widgets werden
+     *   stattdessen id-los in der eigenen `widgets`-Sektion exportiert.
+     */
+    val EXCLUDED_SETTINGS_KEYS = setOf(
+        "lock_secret",
+        "lock_type",
+        "lock_biometric_enabled",
+        "locked_apps",
+        "custom_wallpaper_uri",
+        "hosted_widgets",
+    )
+
+    /**
+     * Keys, deren Werte via CryptoManager gerätegebunden verschlüsselt liegen.
+     * Export legt sie im Klartext ab (Ciphertext wäre auf jedem anderen Gerät
+     * nutzlos), Import verschlüsselt sie mit dem lokalen Schlüssel neu.
+     */
+    val ENCRYPTED_SETTINGS_KEYS = setOf(
+        "hidden_apps",
+        "shake_open_app_package",
+        "double_tap_app_package",
+    )
+}

--- a/app/src/main/java/com/example/androidlauncher/di/BackupModule.kt
+++ b/app/src/main/java/com/example/androidlauncher/di/BackupModule.kt
@@ -1,0 +1,25 @@
+package com.example.androidlauncher.di
+
+import android.content.Context
+import com.example.androidlauncher.data.backup.BackupManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+/**
+ * Stellt den [BackupManager] (B5) bereit. Eigenes Modul statt [DataModule],
+ * damit dessen Provider-Anzahl nicht weiter wächst; gleiche Konvention
+ * (Context-Konstruktor in Produktion, DataStore-Konstruktor in Tests).
+ */
+@Module
+@InstallIn(SingletonComponent::class)
+object BackupModule {
+
+    @Provides
+    @Singleton
+    fun provideBackupManager(@ApplicationContext context: Context): BackupManager =
+        BackupManager(context)
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -43,6 +43,7 @@ import com.composables.icons.lucide.Camera
 import com.composables.icons.lucide.ChevronDown
 import com.composables.icons.lucide.Clock
 import com.composables.icons.lucide.CloudSun
+import com.composables.icons.lucide.Download
 import com.composables.icons.lucide.Flashlight
 import com.composables.icons.lucide.Hand
 import com.composables.icons.lucide.House
@@ -59,6 +60,7 @@ import com.composables.icons.lucide.Shield
 import com.composables.icons.lucide.Smartphone
 import com.composables.icons.lucide.Sparkles
 import com.composables.icons.lucide.Trash2
+import com.composables.icons.lucide.Upload
 import com.example.androidlauncher.ForegroundAppResolver
 import com.example.androidlauncher.LauncherAccessibilityService
 import com.example.androidlauncher.LauncherLogic
@@ -542,6 +544,50 @@ fun EditConfigMenu(
                     designStyle = designStyle,
                     surfaceAccent = surfaceAccent,
                     isDarkTextEnabled = isDarkTextEnabled
+                )
+            }
+
+            item {
+                EditSectionHeader(
+                    title = stringResource(R.string.section_backup),
+                    mainTextColor = mainTextColor
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Download,
+                    label = stringResource(R.string.backup_export),
+                    onClick = { actions.exportBackup() },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "backup_export_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Upload,
+                    label = stringResource(R.string.backup_import),
+                    onClick = { actions.importBackup() },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "backup_import_item"
+                )
+            }
+
+            // Klartext-Hinweis: Exporte enthalten u. a. die Liste der ausgeblendeten
+            // Apps unverschlüsselt (gerätegebundener Ciphertext wäre im Backup nutzlos).
+            item {
+                Text(
+                    text = stringResource(R.string.backup_plaintext_hint),
+                    fontSize = 12.sp,
+                    color = mainTextColor.copy(alpha = 0.6f),
+                    modifier = Modifier.padding(horizontal = 4.dp)
                 )
             }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/home/EditConfigViewModel.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/EditConfigViewModel.kt
@@ -29,6 +29,12 @@ interface EditConfigActions {
 
     /** Öffnet den Foto-Picker für ein eigenes Wallpaper (Ergebnis → Crop-Flow der Activity). */
     fun pickWallpaper()
+
+    /** Öffnet den SAF-Dialog zum Speichern einer Backup-Datei (B5). */
+    fun exportBackup()
+
+    /** Öffnet den SAF-Dialog zum Einlesen einer Backup-Datei (B5). */
+    fun importBackup()
 }
 
 /**

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -155,6 +155,15 @@
     <string name="smart_suggestions">Intelligente Suchvorschläge</string>
     <string name="smart_suggestions_desc">Lernt aus App-Starts und Websuchen. Alles bleibt lokal auf dem Gerät.</string>
     <string name="clear_search_history">Suchverlauf löschen</string>
+    <string name="section_backup">Backup</string>
+    <string name="backup_export">Einstellungen exportieren</string>
+    <string name="backup_import">Einstellungen importieren</string>
+    <string name="backup_plaintext_hint">Die Backup-Datei enthält deine Konfiguration im Klartext, auch die ausgeblendeten Apps. App-Sperre und PIN werden nie exportiert.</string>
+    <string name="backup_export_success">Backup gespeichert</string>
+    <string name="backup_export_error">Backup fehlgeschlagen</string>
+    <string name="backup_import_success">Backup wiederhergestellt</string>
+    <string name="backup_import_error">Datei konnte nicht gelesen werden</string>
+    <string name="backup_import_unsupported">Backup stammt aus einer neueren App-Version</string>
     <string name="default_launcher">Standard-Launcher</string>
     <string name="notifications_label">Benachrichtigung</string>
     <string name="accessibility_label">Bedienungshilfen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -140,6 +140,15 @@
     <string name="smart_suggestions">Sugerencias de búsqueda inteligentes</string>
     <string name="smart_suggestions_desc">Aprende de los inicios de apps y búsquedas web. Todo permanece local en el dispositivo.</string>
     <string name="clear_search_history">Borrar historial de búsqueda</string>
+    <string name="section_backup">Copia de seguridad</string>
+    <string name="backup_export">Exportar ajustes</string>
+    <string name="backup_import">Importar ajustes</string>
+    <string name="backup_plaintext_hint">El archivo de copia contiene tu configuración en texto plano, incluidas las apps ocultas. El bloqueo de apps y el PIN nunca se exportan.</string>
+    <string name="backup_export_success">Copia guardada</string>
+    <string name="backup_export_error">Error al crear la copia</string>
+    <string name="backup_import_success">Copia restaurada</string>
+    <string name="backup_import_error">No se pudo leer el archivo</string>
+    <string name="backup_import_unsupported">La copia proviene de una versión más reciente de la app</string>
     <string name="default_launcher">Lanzador predeterminado</string>
     <string name="notifications_label">Notificaciones</string>
     <string name="accessibility_label">Accesibilidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -140,6 +140,15 @@
     <string name="smart_suggestions">Suggestions de recherche intelligentes</string>
     <string name="smart_suggestions_desc">Apprend des lancements d\'apps et des recherches web. Tout reste local sur l\'appareil.</string>
     <string name="clear_search_history">Effacer l\'historique de recherche</string>
+    <string name="section_backup">Sauvegarde</string>
+    <string name="backup_export">Exporter les réglages</string>
+    <string name="backup_import">Importer les réglages</string>
+    <string name="backup_plaintext_hint">Le fichier de sauvegarde contient votre configuration en clair, y compris les apps masquées. Le verrouillage d\'apps et le code PIN ne sont jamais exportés.</string>
+    <string name="backup_export_success">Sauvegarde enregistrée</string>
+    <string name="backup_export_error">Échec de la sauvegarde</string>
+    <string name="backup_import_success">Sauvegarde restaurée</string>
+    <string name="backup_import_error">Impossible de lire le fichier</string>
+    <string name="backup_import_unsupported">La sauvegarde provient d\'une version plus récente de l\'app</string>
     <string name="default_launcher">Lanceur par défaut</string>
     <string name="notifications_label">Notifications</string>
     <string name="accessibility_label">Accessibilité</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -140,6 +140,15 @@
     <string name="smart_suggestions">Suggerimenti di ricerca intelligenti</string>
     <string name="smart_suggestions_desc">Impara dagli avvii delle app e dalle ricerche web. Tutto rimane locale sul dispositivo.</string>
     <string name="clear_search_history">Cancella cronologia di ricerca</string>
+    <string name="section_backup">Backup</string>
+    <string name="backup_export">Esporta impostazioni</string>
+    <string name="backup_import">Importa impostazioni</string>
+    <string name="backup_plaintext_hint">Il file di backup contiene la tua configurazione in chiaro, incluse le app nascoste. Il blocco app e il PIN non vengono mai esportati.</string>
+    <string name="backup_export_success">Backup salvato</string>
+    <string name="backup_export_error">Backup non riuscito</string>
+    <string name="backup_import_success">Backup ripristinato</string>
+    <string name="backup_import_error">Impossibile leggere il file</string>
+    <string name="backup_import_unsupported">Il backup proviene da una versione più recente dell\'app</string>
     <string name="default_launcher">Launcher predefinito</string>
     <string name="notifications_label">Notifiche</string>
     <string name="accessibility_label">Accessibilità</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -155,6 +155,15 @@
     <string name="smart_suggestions">Smart search suggestions</string>
     <string name="smart_suggestions_desc">Learns from app launches and web searches. Everything stays local on the device.</string>
     <string name="clear_search_history">Clear search history</string>
+    <string name="section_backup">Backup</string>
+    <string name="backup_export">Export settings</string>
+    <string name="backup_import">Import settings</string>
+    <string name="backup_plaintext_hint">The backup file contains your configuration in plain text, including hidden apps. App lock and PIN are never exported.</string>
+    <string name="backup_export_success">Backup saved</string>
+    <string name="backup_export_error">Backup failed</string>
+    <string name="backup_import_success">Backup restored</string>
+    <string name="backup_import_error">File could not be read</string>
+    <string name="backup_import_unsupported">Backup was created by a newer app version</string>
     <string name="default_launcher">Default launcher</string>
     <string name="notifications_label">Notifications</string>
     <string name="accessibility_label">Accessibility</string>

--- a/app/src/test/java/com/example/androidlauncher/data/backup/BackupManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/backup/BackupManagerTest.kt
@@ -1,0 +1,227 @@
+package com.example.androidlauncher.data.backup
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.example.androidlauncher.data.HostedWidget
+import com.example.androidlauncher.data.WidgetSerializer
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupManagerTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private lateinit var files: List<File>
+    private lateinit var settingsStore: DataStore<Preferences>
+    private lateinit var favoritesStore: DataStore<Preferences>
+    private lateinit var foldersStore: DataStore<Preferences>
+    private lateinit var iconStore: DataStore<Preferences>
+    private lateinit var manager: BackupManager
+
+    private val themeKey = stringPreferencesKey("selected_theme")
+    private val dotsKey = booleanPreferencesKey("notification_dots")
+    private val blurKey = floatPreferencesKey("wallpaper_blur")
+    private val countKey = intPreferencesKey("some_count")
+    private val stampKey = longPreferencesKey("some_stamp")
+    private val lockSecretKey = stringPreferencesKey("lock_secret")
+    private val hostedWidgetsKey = stringPreferencesKey("hosted_widgets")
+
+    // In JVM-Tests ist CryptoManager Klartext-Passthrough; der Key-Name reicht für den Pfad.
+    private val hiddenAppsKey = stringPreferencesKey("hidden_apps")
+    private val favoritesKey = stringPreferencesKey("favorites_list")
+    private val iconKey = stringPreferencesKey("com.example.someapp")
+
+    @Before
+    fun setup() {
+        fun store(name: String): Pair<File, DataStore<Preferences>> {
+            val file = File.createTempFile("backup_manager_test_$name", ".preferences_pb")
+            return file to PreferenceDataStoreFactory.create(
+                scope = testScope.backgroundScope,
+                produceFile = { file },
+            )
+        }
+
+        val (f1, s1) = store("settings")
+        val (f2, s2) = store("favorites")
+        val (f3, s3) = store("folders")
+        val (f4, s4) = store("icons")
+        files = listOf(f1, f2, f3, f4)
+        settingsStore = s1
+        favoritesStore = s2
+        foldersStore = s3
+        iconStore = s4
+        manager = BackupManager(settingsStore, favoritesStore, foldersStore, iconStore)
+    }
+
+    @After
+    fun tearDown() {
+        files.forEach { it.delete() }
+    }
+
+    private suspend fun seedTypicalState() {
+        settingsStore.edit {
+            it[themeKey] = "SOFT_SAND"
+            it[dotsKey] = false
+            it[blurKey] = 0.4f
+            it[countKey] = 3
+            it[stampKey] = 9_876_543_210L
+            it[hiddenAppsKey] = "com.hidden.one,com.hidden.two"
+            it[lockSecretKey] = "salt:hash"
+            it[hostedWidgetsKey] = WidgetSerializer.serializeWidgets(
+                listOf(HostedWidget(appWidgetId = 7, provider = "com.x/.Clock", widthDp = 180, heightDp = 110)),
+            )
+        }
+        favoritesStore.edit { it[favoritesKey] = "com.a,com.b" }
+        foldersStore.edit { it[stringPreferencesKey("folders_list")] = """[{"name":"Tools"}]""" }
+        iconStore.edit { it[iconKey] = "rocket" }
+    }
+
+    @Test
+    fun `snapshot excludes credentials but exports widgets id-less`() = testScope.runTest {
+        seedTypicalState()
+
+        val snapshot = manager.createSnapshot(appVersionCode = 5L, nowMs = 123L)
+
+        val settingsKeys = snapshot.stores.getValue(BackupSpec.STORE_SETTINGS).map { it.key }
+        assertFalse("lock_secret" in settingsKeys)
+        assertFalse("hosted_widgets" in settingsKeys)
+        assertTrue("selected_theme" in settingsKeys)
+        assertTrue("hidden_apps" in settingsKeys)
+        assertEquals(BackupSpec.CURRENT_VERSION, snapshot.backupVersion)
+        assertEquals(5L, snapshot.appVersionCode)
+        assertEquals(123L, snapshot.exportedAtMs)
+        assertEquals(
+            listOf(WidgetBackup("com.x/.Clock", 180, 110, 0f, 0f)),
+            snapshot.widgets,
+        )
+    }
+
+    @Test
+    fun `export wipe restore round trip recreates state including types`() = testScope.runTest {
+        seedTypicalState()
+        val snapshot = manager.createSnapshot(appVersionCode = 5L)
+
+        // Wipe: alle vier Stores leeren (simuliert Neuinstallation).
+        listOf(settingsStore, favoritesStore, foldersStore, iconStore).forEach { store ->
+            store.edit { it.clear() }
+        }
+
+        val result = manager.restore(snapshot)
+
+        assertEquals(RestoreResult.APPLIED, result)
+        val prefs = settingsStore.data.first()
+        assertEquals("SOFT_SAND", prefs[themeKey])
+        assertEquals(false, prefs[dotsKey])
+        assertEquals(0.4f, prefs[blurKey])
+        assertEquals(3, prefs[countKey])
+        assertEquals(9_876_543_210L, prefs[stampKey])
+        assertEquals("com.hidden.one,com.hidden.two", prefs[hiddenAppsKey])
+        assertEquals("com.a,com.b", favoritesStore.data.first()[favoritesKey])
+        assertEquals("rocket", iconStore.data.first()[iconKey])
+    }
+
+    @Test
+    fun `restore preserves local credentials and widgets, replaces the rest`() = testScope.runTest {
+        seedTypicalState()
+        val snapshot = manager.createSnapshot(appVersionCode = 5L)
+
+        // Lokaler Zustand nach dem Export: anderes Theme, anderes Secret, anderer Widget-Bestand.
+        val localWidgets = WidgetSerializer.serializeWidgets(
+            listOf(HostedWidget(appWidgetId = 99, provider = "com.local/.W", widthDp = 100, heightDp = 100)),
+        )
+        settingsStore.edit {
+            it[themeKey] = "MIDNIGHT"
+            it[lockSecretKey] = "local-salt:local-hash"
+            it[hostedWidgetsKey] = localWidgets
+            it[stringPreferencesKey("stale_local_key")] = "soll verschwinden"
+        }
+
+        manager.restore(snapshot)
+
+        val prefs = settingsStore.data.first()
+        assertEquals("SOFT_SAND", prefs[themeKey])
+        assertEquals("local-salt:local-hash", prefs[lockSecretKey])
+        assertEquals(localWidgets, prefs[hostedWidgetsKey])
+        assertNull(prefs[stringPreferencesKey("stale_local_key")])
+    }
+
+    @Test
+    fun `restore refuses newer backup versions untouched`() = testScope.runTest {
+        seedTypicalState()
+        val newer = BackupSnapshot(
+            backupVersion = BackupSpec.CURRENT_VERSION + 1,
+            appVersionCode = 99L,
+            exportedAtMs = 0L,
+            stores = mapOf(
+                BackupSpec.STORE_SETTINGS to listOf(
+                    BackupEntry("selected_theme", BackupValueType.STRING, "FUTURE"),
+                ),
+            ),
+            widgets = emptyList(),
+        )
+
+        val result = manager.restore(newer)
+
+        assertEquals(RestoreResult.UNSUPPORTED_VERSION, result)
+        assertEquals("SOFT_SAND", settingsStore.data.first()[themeKey])
+    }
+
+    @Test
+    fun `restore never applies excluded keys from a tampered file`() = testScope.runTest {
+        seedTypicalState()
+        val tampered = BackupSnapshot(
+            backupVersion = BackupSpec.CURRENT_VERSION,
+            appVersionCode = 1L,
+            exportedAtMs = 0L,
+            stores = mapOf(
+                BackupSpec.STORE_SETTINGS to listOf(
+                    BackupEntry("lock_secret", BackupValueType.STRING, "angreifer:hash"),
+                    BackupEntry("selected_theme", BackupValueType.STRING, "OK"),
+                ),
+            ),
+            widgets = emptyList(),
+        )
+
+        manager.restore(tampered)
+
+        val prefs = settingsStore.data.first()
+        assertEquals("salt:hash", prefs[lockSecretKey])
+        assertEquals("OK", prefs[themeKey])
+    }
+
+    @Test
+    fun `full json round trip through serializer and manager`() = testScope.runTest {
+        seedTypicalState()
+        val json = BackupSerializer.serialize(manager.createSnapshot(appVersionCode = 5L))
+
+        listOf(settingsStore, favoritesStore, foldersStore, iconStore).forEach { store ->
+            store.edit { it.clear() }
+        }
+        val parsed = BackupSerializer.parse(json)!!
+        val result = manager.restore(parsed)
+
+        assertEquals(RestoreResult.APPLIED, result)
+        assertEquals("SOFT_SAND", settingsStore.data.first()[themeKey])
+        assertEquals("com.a,com.b", favoritesStore.data.first()[favoritesKey])
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/backup/BackupSerializerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/backup/BackupSerializerTest.kt
@@ -1,0 +1,109 @@
+package com.example.androidlauncher.data.backup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackupSerializerTest {
+
+    private val allTypesSnapshot = BackupSnapshot(
+        backupVersion = BackupSpec.CURRENT_VERSION,
+        appVersionCode = 7L,
+        exportedAtMs = 1_720_000_000_000L,
+        stores = mapOf(
+            BackupSpec.STORE_SETTINGS to listOf(
+                BackupEntry("a_string", BackupValueType.STRING, "SOFT_SAND"),
+                BackupEntry("a_boolean", BackupValueType.BOOLEAN, true),
+                BackupEntry("an_int", BackupValueType.INT, 42),
+                BackupEntry("a_long", BackupValueType.LONG, 9_876_543_210L),
+                BackupEntry("a_float", BackupValueType.FLOAT, 0.75f),
+                BackupEntry("a_double", BackupValueType.DOUBLE, 3.14159),
+                BackupEntry("a_set", BackupValueType.STRING_SET, setOf("x", "y")),
+            ),
+            BackupSpec.STORE_FAVORITES to listOf(
+                BackupEntry("favorites_list", BackupValueType.STRING, "com.a,com.b"),
+            ),
+        ),
+        widgets = listOf(
+            WidgetBackup("com.x/.ClockWidget", 180, 110, 12.5f, -4f),
+        ),
+    )
+
+    @Test
+    fun `round trip preserves every value type exactly`() {
+        val parsed = BackupSerializer.parse(BackupSerializer.serialize(allTypesSnapshot))
+
+        assertNotNull(parsed)
+        assertEquals(allTypesSnapshot, parsed)
+    }
+
+    @Test
+    fun `round trip preserves widget section without ids`() {
+        val parsed = BackupSerializer.parse(BackupSerializer.serialize(allTypesSnapshot))!!
+
+        assertEquals(allTypesSnapshot.widgets, parsed.widgets)
+    }
+
+    @Test
+    fun `corrupt json returns null`() {
+        assertNull(BackupSerializer.parse("not json at all"))
+        assertNull(BackupSerializer.parse("{\"stores\": 12}"))
+        assertNull(BackupSerializer.parse(""))
+    }
+
+    @Test
+    fun `missing version returns null`() {
+        assertNull(BackupSerializer.parse("{\"stores\":{}}"))
+    }
+
+    @Test
+    fun `unknown type tags and malformed entries are skipped`() {
+        val json = """
+            {
+              "backupVersion": 1,
+              "stores": {
+                "settings": [
+                  {"k": "kept", "t": "string", "v": "ok"},
+                  {"k": "future_type", "t": "byteArray", "v": "AAAA"},
+                  {"k": "", "t": "string", "v": "empty key"},
+                  {"k": "no_value", "t": "string"},
+                  {"k": "wrong_value", "t": "int", "v": "keine Zahl"},
+                  "kein Objekt"
+                ],
+                "unknown_future_store": [
+                  {"k": "whatever", "t": "string", "v": "tolerated"}
+                ]
+              }
+            }
+        """.trimIndent()
+
+        val parsed = BackupSerializer.parse(json)!!
+
+        assertEquals(
+            listOf(BackupEntry("kept", BackupValueType.STRING, "ok")),
+            parsed.stores[BackupSpec.STORE_SETTINGS],
+        )
+        // Unbekannte Sektionen werden geparst, aber vom Restore ignoriert.
+        assertTrue(parsed.stores.containsKey("unknown_future_store"))
+    }
+
+    @Test
+    fun `newer version still parses so the manager can refuse it explicitly`() {
+        val parsed = BackupSerializer.parse("""{"backupVersion": 99, "stores": {}}""")
+
+        assertNotNull(parsed)
+        assertEquals(99, parsed!!.backupVersion)
+    }
+
+    @Test
+    fun `type tag derives from runtime class and rejects unsupported values`() {
+        assertEquals(BackupValueType.INT, BackupValueType.fromValue(1))
+        assertEquals(BackupValueType.LONG, BackupValueType.fromValue(1L))
+        assertEquals(BackupValueType.FLOAT, BackupValueType.fromValue(1f))
+        assertEquals(BackupValueType.DOUBLE, BackupValueType.fromValue(1.0))
+        assertEquals(BackupValueType.STRING_SET, BackupValueType.fromValue(setOf("a")))
+        assertNull(BackupValueType.fromValue(byteArrayOf(1)))
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/backup/BackupSpecTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/backup/BackupSpecTest.kt
@@ -1,0 +1,36 @@
+package com.example.androidlauncher.data.backup
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BackupSpecTest {
+
+    @Test
+    fun `credentials and device-local keys are excluded`() {
+        val expected = setOf(
+            "lock_secret",
+            "lock_type",
+            "lock_biometric_enabled",
+            "locked_apps",
+            "custom_wallpaper_uri",
+            "hosted_widgets",
+        )
+        assertEquals(expected, BackupSpec.EXCLUDED_SETTINGS_KEYS)
+    }
+
+    @Test
+    fun `encrypted keys are never simultaneously excluded`() {
+        // Ein Key, der beides wäre, würde beim Export entschlüsselt UND ausgeschlossen –
+        // die Spec muss die Mengen disjunkt halten.
+        assertTrue(BackupSpec.ENCRYPTED_SETTINGS_KEYS.intersect(BackupSpec.EXCLUDED_SETTINGS_KEYS).isEmpty())
+    }
+
+    @Test
+    fun `all four stores are covered`() {
+        assertEquals(
+            listOf("settings", "favorites", "folders", "icon_mappings"),
+            BackupSpec.STORE_NAMES,
+        )
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
- **BackupSpec/BackupSerializer/BackupManager** (`data/backup/`): versionierte JSON-Backups der vier Preference-Stores (settings/favorites/folders/icon_mappings) mit Typ-Tags pro Eintrag (Int≠Long, Float≠Double – falsch typisierte Keys würden Reads still shadowen)
- **Ausgeschlossen:** App-Lock-Credentials (`lock_*`, `locked_apps`), `custom_wallpaper_uri` (gerätelokale Datei), `hosted_widgets` (gerätespezifische appWidgetIds – Widgets werden id-los mitexportiert, v1 ohne Re-Bind), kompletter Suchverlauf (Privacy)
- **Crypto-Werte** (`hidden_apps`, Gesten-Ziel-Pakete): Export entschlüsselt (gerätegebundener Ciphertext wäre nutzlos), Import verschlüsselt lokal neu; Klartext-Hinweis im Menü
- **Restore:** Overwrite-all pro Store in je einem atomaren Edit, geschützte Keys überleben; kein App-Restart nötig (reaktive Flows). Neuere `backupVersion` wird abgelehnt, unbekannte Keys/Sektionen werden toleriert
- **UI:** Backup-Sektion im Edit-Menü, SAF-Dialoge (CreateDocument/OpenDocument) über die EditConfigActions-Bridge, IO auf Dispatchers.IO, Toasts; Strings ×5 Locales

## Tests
- `BackupSerializerTest`: Round-Trip aller Typ-Tags, korruptes JSON, Unknown-Key-Toleranz, Version-Handling
- `BackupManagerTest`: Export→Wipe→Restore-Round-Trip, Preserved-Keys, Tampered-File-Abwehr, Versions-Ablehnung
- `BackupSpecTest`: Spec-Invarianten
- Gates grün: `detekt testDebugUnitTest koverVerifyDebug compileDebugAndroidTestKotlin`

## Offen (bewusst)
- Widget-Re-Bind beim Restore (Bind-Consent-UX) als möglicher Folge-PR
- Emulator-Verifikation laut Plan folgt nach dem Resize-Branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)