### PR TITLE
feat(B1): Widget-Resize – interaktives Vergrößern/Verkleinern im Edit-Modus (PR4)

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -118,6 +118,7 @@ import com.example.androidlauncher.data.WidgetBindStep
 import com.example.androidlauncher.data.WidgetHostManager
 import com.example.androidlauncher.data.WidgetSizeDp
 import com.example.androidlauncher.data.defaultWidgetSizeDp
+import com.example.androidlauncher.data.resolveResizeLimits
 import com.example.androidlauncher.gesture.GestureActionEffects
 import com.example.androidlauncher.gesture.GestureActionHandler
 import com.example.androidlauncher.ui.AnimationsConfigMenu
@@ -1331,11 +1332,47 @@ class MainActivity : ComponentActivity() {
                                 },
                                 hostedWidgets = hostedWidgets,
                                 widgetViewProvider = { id -> widgetHostManager.createView(id) },
-                                onSaveWidgetOffsets = { widgetOffsets ->
-                                    scope.launch { widgetHostManager.updateOffsets(widgetOffsets) }
+                                onSaveWidgetLayout = { widgetOffsets, widgetSizes ->
+                                    scope.launch {
+                                        widgetHostManager.updateWidgetPlacement(widgetOffsets, widgetSizes)
+                                    }
                                 },
                                 onRemoveWidget = { id ->
                                     scope.launch { widgetHostManager.removeWidget(id) }
+                                },
+                                // B1-PR4: Resize-Grenzen aus den Provider-Angaben; maxResize*
+                                // gibt es erst ab API 31 (0 = vom Provider nicht begrenzt).
+                                widgetResizeLimits = { id ->
+                                    widgetHostManager.providerInfo(id)?.let { info ->
+                                        val current = hostedWidgets.firstOrNull { it.appWidgetId == id }
+                                        resolveResizeLimits(
+                                            resizeMode = info.resizeMode,
+                                            minResizeWidthDp = if (info.minResizeWidth > 0) {
+                                                info.minResizeWidth
+                                            } else {
+                                                info.minWidth
+                                            },
+                                            minResizeHeightDp = if (info.minResizeHeight > 0) {
+                                                info.minResizeHeight
+                                            } else {
+                                                info.minHeight
+                                            },
+                                            maxResizeWidthDp = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                                info.maxResizeWidth
+                                            } else {
+                                                0
+                                            },
+                                            maxResizeHeightDp = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                                                info.maxResizeHeight
+                                            } else {
+                                                0
+                                            },
+                                            currentWidthDp = current?.widthDp ?: 0,
+                                            currentHeightDp = current?.heightDp ?: 0,
+                                            screenWidthDp = configuration.screenWidthDp,
+                                            screenHeightDp = configuration.screenHeightDp,
+                                        )
+                                    }
                                 }
                             )
                         }

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
@@ -88,14 +88,14 @@ data class WidgetSizeDp(val widthDp: Int, val heightDp: Int)
 private const val WIDGET_CELL_SIZE_DP = 70
 
 /** Untergrenzen, damit auch "0dp"-Provider-Angaben ein greifbares Widget ergeben. */
-private const val MIN_WIDGET_WIDTH_DP = 110
-private const val MIN_WIDGET_HEIGHT_DP = 40
+internal const val MIN_WIDGET_WIDTH_DP = 110
+internal const val MIN_WIDGET_HEIGHT_DP = 40
 
 /** Seitenrand, den ein Widget in der Breite nie ueberdecken darf. */
-private const val SCREEN_EDGE_MARGIN_DP = 48
+internal const val SCREEN_EDGE_MARGIN_DP = 48
 
 /** Hoehen-Kappung, damit ein einzelnes Widget nicht den ganzen Screen einnimmt. */
-private const val MAX_HEIGHT_SCREEN_FRACTION = 0.6f
+internal const val MAX_HEIGHT_SCREEN_FRACTION = 0.6f
 
 /**
  * Default-Groesse beim Binden (MVP ohne Resize): bevorzugt die Zell-Angaben des Providers

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
@@ -115,11 +115,20 @@ class WidgetHostManager(
 
     /** Persistiert neue Edit-Mode-Offsets (ein atomarer Write fuer alle Widgets). */
     suspend fun updateOffsets(offsets: Map<Int, Offset>) {
-        if (offsets.isEmpty()) return
+        updateWidgetPlacement(offsets, emptyMap())
+    }
+
+    /**
+     * Persistiert Offsets und Groessen aus dem Edit-Modus in einem einzigen
+     * atomaren Write (B1-PR4: der Speichern-Knopf committet beides gemeinsam).
+     */
+    suspend fun updateWidgetPlacement(offsets: Map<Int, Offset>, sizes: Map<Int, WidgetSizeDp>) {
+        if (offsets.isEmpty() && sizes.isEmpty()) return
         val updated = settings.hostedWidgets.first().map { widget ->
-            offsets[widget.appWidgetId]
-                ?.let { widget.copy(offsetX = it.x, offsetY = it.y) }
-                ?: widget
+            var result = widget
+            offsets[widget.appWidgetId]?.let { result = result.copy(offsetX = it.x, offsetY = it.y) }
+            sizes[widget.appWidgetId]?.let { result = result.copy(widthDp = it.widthDp, heightDp = it.heightDp) }
+            result
         }
         settings.setHostedWidgets(updated)
     }

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
@@ -1,0 +1,105 @@
+package com.example.androidlauncher.data
+
+import kotlin.math.roundToInt
+
+/**
+ * Framework-freie Groessen-Logik fuer das interaktive Widget-Resize im Edit-Modus
+ * (B1-PR4). Wie [WidgetBindFlow]: nur Primitive rein, Entscheidungen raus –
+ * `AppWidgetProviderInfo` selbst ist nicht JVM-testbar, daher spiegeln die
+ * Aufrufstellen dessen Felder in die Parameter.
+ */
+
+/** `AppWidgetProviderInfo.RESIZE_HORIZONTAL/VERTICAL`, framework-frei gespiegelt. */
+const val WIDGET_RESIZE_HORIZONTAL = 1
+const val WIDGET_RESIZE_VERTICAL = 2
+
+/**
+ * Erlaubter Groessenbereich eines Widgets in dp. Eine nicht skalierbare Achse
+ * wird ueber `min == max` ausgedrueckt – der Drag auf ihr ist dann ein No-Op,
+ * wodurch ein einzelnes Eck-Handle alle vier resizeMode-Faelle abdeckt.
+ */
+data class WidgetResizeLimits(
+    val minWidthDp: Int,
+    val maxWidthDp: Int,
+    val minHeightDp: Int,
+    val maxHeightDp: Int,
+) {
+    /** `false` bei RESIZE_NONE (oder degeneriertem Bereich) → kein Handle anzeigen. */
+    val isResizable: Boolean get() = maxWidthDp > minWidthDp || maxHeightDp > minHeightDp
+}
+
+/**
+ * Leitet die Resize-Grenzen aus den Provider-Angaben und der Screen-Groesse ab.
+ *
+ * - Provider-Minima von 0 fallen auf die App-Untergrenzen zurueck (greifbares Widget).
+ * - `maxResize*Dp == 0` heisst "vom Provider nicht begrenzt" (API-31-Semantik) –
+ *   dann begrenzt nur der Screen (gleiche Kappung wie [defaultWidgetSizeDp]).
+ * - Degeneriert (Provider-Minimum ueber der Screen-Kappung): Achse wird auf dem
+ *   Minimum festgesetzt statt zu invertieren.
+ */
+@Suppress("LongParameterList") // spiegelt bewusst die AppWidgetProviderInfo-Felder als Primitive
+fun resolveResizeLimits(
+    resizeMode: Int,
+    minResizeWidthDp: Int,
+    minResizeHeightDp: Int,
+    maxResizeWidthDp: Int,
+    maxResizeHeightDp: Int,
+    currentWidthDp: Int,
+    currentHeightDp: Int,
+    screenWidthDp: Int,
+    screenHeightDp: Int,
+): WidgetResizeLimits {
+    val screenMaxWidth = (screenWidthDp - SCREEN_EDGE_MARGIN_DP).coerceAtLeast(MIN_WIDGET_WIDTH_DP)
+    val screenMaxHeight = (screenHeightDp * MAX_HEIGHT_SCREEN_FRACTION).toInt()
+        .coerceAtLeast(MIN_WIDGET_HEIGHT_DP)
+
+    val (minWidth, maxWidth) = axisRange(
+        allowed = resizeMode and WIDGET_RESIZE_HORIZONTAL != 0,
+        providerMinDp = minResizeWidthDp,
+        providerMaxDp = maxResizeWidthDp,
+        floorDp = MIN_WIDGET_WIDTH_DP,
+        screenCapDp = screenMaxWidth,
+        currentDp = currentWidthDp,
+    )
+    val (minHeight, maxHeight) = axisRange(
+        allowed = resizeMode and WIDGET_RESIZE_VERTICAL != 0,
+        providerMinDp = minResizeHeightDp,
+        providerMaxDp = maxResizeHeightDp,
+        floorDp = MIN_WIDGET_HEIGHT_DP,
+        screenCapDp = screenMaxHeight,
+        currentDp = currentHeightDp,
+    )
+    return WidgetResizeLimits(minWidth, maxWidth, minHeight, maxHeight)
+}
+
+private fun axisRange(
+    allowed: Boolean,
+    providerMinDp: Int,
+    providerMaxDp: Int,
+    floorDp: Int,
+    screenCapDp: Int,
+    currentDp: Int,
+): Pair<Int, Int> {
+    if (!allowed) return currentDp to currentDp
+    val min = if (providerMinDp > 0) providerMinDp else floorDp
+    val providerMax = if (providerMaxDp > 0) providerMaxDp else Int.MAX_VALUE
+    val max = minOf(providerMax, screenCapDp).coerceAtLeast(min)
+    return min to max
+}
+
+/**
+ * Groesse waehrend eines Resize-Drags: [startSize] ist die Groesse beim Gesten-Start,
+ * [totalDragXDp]/[totalDragYDp] der **kumulierte** Drag seitdem (nicht das letzte
+ * Delta – so gehen Sub-dp-Bewegungen nicht durch Rundung verloren).
+ */
+fun applyResizeDrag(
+    startSize: WidgetSizeDp,
+    totalDragXDp: Float,
+    totalDragYDp: Float,
+    limits: WidgetResizeLimits,
+): WidgetSizeDp = WidgetSizeDp(
+    widthDp = (startSize.widthDp + totalDragXDp).roundToInt()
+        .coerceIn(limits.minWidthDp, limits.maxWidthDp),
+    heightDp = (startSize.heightDp + totalDragYDp).roundToInt()
+        .coerceIn(limits.minHeightDp, limits.maxHeightDp),
+)

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import com.example.androidlauncher.data.HomeLayout
 import com.example.androidlauncher.data.HostedWidget
+import com.example.androidlauncher.data.WidgetSizeDp
 
 /**
  * Bündelt die transienten Zustände des Edit-Modus auf dem Startbildschirm
@@ -39,6 +40,11 @@ internal class HomeDragStateHolder(
         initialWidgets.forEach {
             put(HomeEditTarget.Widget(it.appWidgetId), Offset(it.offsetX, it.offsetY))
         }
+    }
+
+    /** Live-Größen der gehosteten Widgets während des Resize-Drags (B1-PR4). */
+    val widgetSizes = mutableStateMapOf<Int, WidgetSizeDp>().apply {
+        initialWidgets.forEach { put(it.appWidgetId, WidgetSizeDp(it.widthDp, it.heightDp)) }
     }
 
     /** Neutralposition (Bounds ohne Offset) je Element – Basis der Kollisionsprüfung. */
@@ -79,6 +85,7 @@ internal class HomeDragStateHolder(
                 offsets.remove(stale)
                 neutralBounds.remove(stale)
                 lastBlockedHapticMs.remove(stale)
+                widgetSizes.remove(stale.appWidgetId)
                 if (selectedEditTarget == stale) {
                     selectedEditTarget = null
                     isEditTargetUserPinned = false
@@ -86,6 +93,7 @@ internal class HomeDragStateHolder(
             }
         widgets.forEach {
             offsets[HomeEditTarget.Widget(it.appWidgetId)] = Offset(it.offsetX, it.offsetY)
+            widgetSizes[it.appWidgetId] = WidgetSizeDp(it.widthDp, it.heightDp)
         }
     }
 
@@ -103,6 +111,9 @@ internal class HomeDragStateHolder(
             (target as? HomeEditTarget.Widget)?.let { it.appWidgetId to offset }
         }
         .toMap()
+
+    /** Aktuelle Live-Größen der gehosteten Widgets (Speichern-Knopf, B1-PR4). */
+    fun toWidgetSizes(): Map<Int, WidgetSizeDp> = widgetSizes.toMap()
 }
 
 /** Merkt sich den Holder über Recompositions hinweg (nicht über Config-Wechsel). */

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.OpenInFull
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material3.*
@@ -62,6 +63,9 @@ import com.example.androidlauncher.data.FavoritesBorderStyle
 import com.example.androidlauncher.data.GestureAction
 import com.example.androidlauncher.data.HomeLayout
 import com.example.androidlauncher.data.HostedWidget
+import com.example.androidlauncher.data.WidgetResizeLimits
+import com.example.androidlauncher.data.WidgetSizeDp
+import com.example.androidlauncher.data.applyResizeDrag
 import com.example.androidlauncher.launchShortcut
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
 import com.example.androidlauncher.ui.theme.*
@@ -118,8 +122,10 @@ fun HomeScreen(
     // B1: gehostete System-Widgets als frei verschiebbare Home-Objekte.
     hostedWidgets: List<HostedWidget> = emptyList(),
     widgetViewProvider: (Int) -> AppWidgetHostView? = { null },
-    onSaveWidgetOffsets: (Map<Int, Offset>) -> Unit = {},
-    onRemoveWidget: (Int) -> Unit = {}
+    onSaveWidgetLayout: (Map<Int, Offset>, Map<Int, WidgetSizeDp>) -> Unit = { _, _ -> },
+    onRemoveWidget: (Int) -> Unit = {},
+    // B1-PR4: Resize-Grenzen je Widget (null = unbekannt/kein Resize, z. B. Preview).
+    widgetResizeLimits: (Int) -> WidgetResizeLimits? = { null }
 ) {
     val context = LocalContext.current
     val colorTheme = LocalColorTheme.current
@@ -683,11 +689,78 @@ fun HomeScreen(
                             .targetLayout(widgetTarget)
                             .targetEditModifier(widgetTarget)
                     ) {
+                        // Live-Größe aus dem Drag-State (Resize-Vorschau); Fallback: persistiert.
+                        val liveSize = dragState.widgetSizes[widget.appWidgetId]
                         HostedWidgetView(
-                            widget = widget,
+                            widget = liveSize
+                                ?.let { widget.copy(widthDp = it.widthDp, heightDp = it.heightDp) }
+                                ?: widget,
                             hostView = if (isPreview) null else widgetViewProvider(widget.appWidgetId),
                             isEditMode = isEditMode,
                         )
+                        // Resize-Handle (Ecke unten rechts) am ausgewählten Widget – nur wenn
+                        // der Provider Resize erlaubt (B1-PR4). Gesperrte Achsen sind in den
+                        // Limits über min == max abgebildet, der Drag dort ist ein No-Op.
+                        if (isEditMode && selectedEditTarget == widgetTarget) {
+                            val resizable = remember(widgetTarget) {
+                                widgetResizeLimits(widget.appWidgetId)?.isResizable == true
+                            }
+                            if (resizable) {
+                                var resizeStartSize by remember { mutableStateOf<WidgetSizeDp?>(null) }
+                                var resizeLimits by remember { mutableStateOf<WidgetResizeLimits?>(null) }
+                                var resizeTotalDrag by remember { mutableStateOf(Offset.Zero) }
+                                // Vorab gefangen: im PointerInputScope würde `density` die
+                                // Scope-Property (Float) statt des äußeren LocalDensity treffen.
+                                val densityFactor = density.density
+                                Box(
+                                    modifier = Modifier
+                                        .align(Alignment.BottomEnd)
+                                        .zIndex(10f)
+                                        .size(28.dp)
+                                        .clip(CircleShape)
+                                        .designSurface(
+                                            designStyle,
+                                            CircleShape,
+                                            isDarkTextEnabled,
+                                            surfaceAccent,
+                                            fillAlpha = 0.5f
+                                        )
+                                        .pointerInput(widgetTarget) {
+                                            detectDragGestures(
+                                                onDragStart = {
+                                                    resizeStartSize =
+                                                        dragState.widgetSizes[widget.appWidgetId]
+                                                            ?: WidgetSizeDp(widget.widthDp, widget.heightDp)
+                                                    resizeLimits = widgetResizeLimits(widget.appWidgetId)
+                                                    resizeTotalDrag = Offset.Zero
+                                                },
+                                                onDrag = { change, dragAmount ->
+                                                    change.consume()
+                                                    resizeTotalDrag += dragAmount
+                                                    val start = resizeStartSize ?: return@detectDragGestures
+                                                    val limits = resizeLimits ?: return@detectDragGestures
+                                                    dragState.widgetSizes[widget.appWidgetId] =
+                                                        applyResizeDrag(
+                                                            startSize = start,
+                                                            totalDragXDp = resizeTotalDrag.x / densityFactor,
+                                                            totalDragYDp = resizeTotalDrag.y / densityFactor,
+                                                            limits = limits,
+                                                        )
+                                                }
+                                            )
+                                        }
+                                        .testTag("home_widget_resize_${widget.appWidgetId}"),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.OpenInFull,
+                                        contentDescription = stringResource(R.string.cd_resize_widget),
+                                        tint = mainTextColor,
+                                        modifier = Modifier.size(14.dp)
+                                    )
+                                }
+                            }
+                        }
                         // Entfernen-Badge am ausgewählten Widget (nur im Edit-Modus).
                         if (isEditMode && selectedEditTarget == widgetTarget) {
                             Box(
@@ -934,7 +1007,7 @@ fun HomeScreen(
                         onClick = {
                             updateCollisionFeedback(false)
                             onSaveHomeLayout(dragState.toHomeLayout())
-                            onSaveWidgetOffsets(dragState.toWidgetOffsets())
+                            onSaveWidgetLayout(dragState.toWidgetOffsets(), dragState.toWidgetSizes())
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.position_saved),

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -141,6 +141,7 @@
     <string name="widget_picker_empty">Keine Widgets gefunden</string>
     <string name="widget_bind_failed">Widget konnte nicht hinzugefügt werden</string>
     <string name="cd_remove_widget">Widget entfernen</string>
+    <string name="cd_resize_widget">Widget-Größe ändern</string>
     <string name="icon_pack_section_title">Icon-Pack</string>
     <string name="icon_pack_system_default">System-Icons</string>
     <string name="icon_pack_system_default_sub">Standard-App-Icons ohne Pack</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -126,6 +126,7 @@
     <string name="widget_picker_empty">No se encontraron widgets</string>
     <string name="widget_bind_failed">No se pudo añadir el widget</string>
     <string name="cd_remove_widget">Quitar el widget</string>
+    <string name="cd_resize_widget">Cambiar tamaño del widget</string>
     <string name="icon_pack_section_title">Paquete de iconos</string>
     <string name="icon_pack_system_default">Iconos del sistema</string>
     <string name="icon_pack_system_default_sub">Iconos de apps por defecto, sin paquete</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -126,6 +126,7 @@
     <string name="widget_picker_empty">Aucun widget trouvé</string>
     <string name="widget_bind_failed">Impossible d\'ajouter le widget</string>
     <string name="cd_remove_widget">Retirer le widget</string>
+    <string name="cd_resize_widget">Redimensionner le widget</string>
     <string name="icon_pack_section_title">Pack d\'icônes</string>
     <string name="icon_pack_system_default">Icônes système</string>
     <string name="icon_pack_system_default_sub">Icônes d\'apps par défaut, sans pack</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -126,6 +126,7 @@
     <string name="widget_picker_empty">Nessun widget trovato</string>
     <string name="widget_bind_failed">Impossibile aggiungere il widget</string>
     <string name="cd_remove_widget">Rimuovi widget</string>
+    <string name="cd_resize_widget">Ridimensiona widget</string>
     <string name="icon_pack_section_title">Icon pack</string>
     <string name="icon_pack_system_default">Icone di sistema</string>
     <string name="icon_pack_system_default_sub">Icone predefinite delle app, senza pack</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -141,6 +141,7 @@
     <string name="widget_picker_empty">No widgets found</string>
     <string name="widget_bind_failed">Widget could not be added</string>
     <string name="cd_remove_widget">Remove widget</string>
+    <string name="cd_resize_widget">Resize widget</string>
     <string name="icon_pack_section_title">Icon pack</string>
     <string name="icon_pack_system_default">System icons</string>
     <string name="icon_pack_system_default_sub">Default app icons without a pack</string>

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
@@ -113,6 +113,26 @@ class WidgetHostManagerTest {
     }
 
     @Test
+    fun `updateWidgetPlacement writes offsets and sizes atomically per widget`() = testScope.runTest {
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+        manager.addWidget(widget(3))
+
+        manager.updateWidgetPlacement(
+            offsets = mapOf(1 to Offset(15f, -25f)),
+            sizes = mapOf(1 to WidgetSizeDp(widthDp = 250, heightDp = 140), 2 to WidgetSizeDp(180, 90)),
+        )
+
+        val result = manager.widgets.first()
+        assertEquals(
+            widget(1).copy(offsetX = 15f, offsetY = -25f, widthDp = 250, heightDp = 140),
+            result.first { it.appWidgetId == 1 },
+        )
+        assertEquals(widget(2).copy(widthDp = 180, heightDp = 90), result.first { it.appWidgetId == 2 })
+        assertEquals(widget(3), result.first { it.appWidgetId == 3 })
+    }
+
+    @Test
     fun `cleanupOrphans deletes leaked ids and prunes uninstalled providers`() = testScope.runTest {
         every { host.deleteAppWidgetId(any()) } just Runs
         // Persistiert: 1 (Provider vorhanden) und 2 (Provider deinstalliert); im Host geleakt: 3.

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
@@ -1,0 +1,132 @@
+package com.example.androidlauncher.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WidgetResizeTest {
+
+    @Suppress("LongParameterList") // spiegelt bewusst die Parameterliste von resolveResizeLimits
+    private fun limits(
+        resizeMode: Int,
+        minResizeWidthDp: Int = 100,
+        minResizeHeightDp: Int = 60,
+        maxResizeWidthDp: Int = 0,
+        maxResizeHeightDp: Int = 0,
+        currentWidthDp: Int = 180,
+        currentHeightDp: Int = 110,
+        screenWidthDp: Int = 400,
+        screenHeightDp: Int = 800,
+    ) = resolveResizeLimits(
+        resizeMode = resizeMode,
+        minResizeWidthDp = minResizeWidthDp,
+        minResizeHeightDp = minResizeHeightDp,
+        maxResizeWidthDp = maxResizeWidthDp,
+        maxResizeHeightDp = maxResizeHeightDp,
+        currentWidthDp = currentWidthDp,
+        currentHeightDp = currentHeightDp,
+        screenWidthDp = screenWidthDp,
+        screenHeightDp = screenHeightDp,
+    )
+
+    @Test
+    fun `resize none locks both axes to the current size`() {
+        val result = limits(resizeMode = 0)
+
+        assertEquals(WidgetResizeLimits(180, 180, 110, 110), result)
+        assertFalse(result.isResizable)
+    }
+
+    @Test
+    fun `horizontal only locks the vertical axis`() {
+        val result = limits(resizeMode = WIDGET_RESIZE_HORIZONTAL)
+
+        assertEquals(100, result.minWidthDp)
+        assertEquals(400 - SCREEN_EDGE_MARGIN_DP, result.maxWidthDp)
+        assertEquals(110, result.minHeightDp)
+        assertEquals(110, result.maxHeightDp)
+        assertTrue(result.isResizable)
+    }
+
+    @Test
+    fun `vertical only locks the horizontal axis`() {
+        val result = limits(resizeMode = WIDGET_RESIZE_VERTICAL)
+
+        assertEquals(180, result.minWidthDp)
+        assertEquals(180, result.maxWidthDp)
+        assertEquals(60, result.minHeightDp)
+        assertEquals((800 * MAX_HEIGHT_SCREEN_FRACTION).toInt(), result.maxHeightDp)
+    }
+
+    @Test
+    fun `both axes use provider max when set and smaller than screen cap`() {
+        val result = limits(
+            resizeMode = WIDGET_RESIZE_HORIZONTAL or WIDGET_RESIZE_VERTICAL,
+            maxResizeWidthDp = 300,
+            maxResizeHeightDp = 200,
+        )
+
+        assertEquals(WidgetResizeLimits(100, 300, 60, 200), result)
+    }
+
+    @Test
+    fun `unset provider max of zero falls back to the screen cap`() {
+        val result = limits(resizeMode = WIDGET_RESIZE_HORIZONTAL or WIDGET_RESIZE_VERTICAL)
+
+        assertEquals(400 - SCREEN_EDGE_MARGIN_DP, result.maxWidthDp)
+        assertEquals((800 * MAX_HEIGHT_SCREEN_FRACTION).toInt(), result.maxHeightDp)
+    }
+
+    @Test
+    fun `provider min of zero falls back to the app floors`() {
+        val result = limits(
+            resizeMode = WIDGET_RESIZE_HORIZONTAL or WIDGET_RESIZE_VERTICAL,
+            minResizeWidthDp = 0,
+            minResizeHeightDp = 0,
+        )
+
+        assertEquals(MIN_WIDGET_WIDTH_DP, result.minWidthDp)
+        assertEquals(MIN_WIDGET_HEIGHT_DP, result.minHeightDp)
+    }
+
+    @Test
+    fun `degenerate provider min above screen cap pins the axis to the min`() {
+        val result = limits(
+            resizeMode = WIDGET_RESIZE_HORIZONTAL,
+            minResizeWidthDp = 900,
+            screenWidthDp = 400,
+        )
+
+        assertEquals(900, result.minWidthDp)
+        assertEquals(900, result.maxWidthDp)
+    }
+
+    @Test
+    fun `applyResizeDrag clamps to the limits`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        assertEquals(WidgetSizeDp(320, 60), applyResizeDrag(start, 500f, -500f, limits))
+        assertEquals(WidgetSizeDp(100, 200), applyResizeDrag(start, -500f, 500f, limits))
+    }
+
+    @Test
+    fun `applyResizeDrag accumulates from the start size without rounding drift`() {
+        val limits = WidgetResizeLimits(100, 400, 60, 300)
+        val start = WidgetSizeDp(180, 110)
+
+        // Kumulierter Drag statt Delta-Summe: 0.4dp bewegt (noch) nichts …
+        assertEquals(start, applyResizeDrag(start, 0.4f, 0.4f, limits))
+        // … 30.6dp landet gerundet bei +31/+31.
+        assertEquals(WidgetSizeDp(211, 141), applyResizeDrag(start, 30.6f, 30.6f, limits))
+    }
+
+    @Test
+    fun `locked axis is a no-op even with drag input`() {
+        val limits = WidgetResizeLimits(180, 180, 60, 300)
+        val start = WidgetSizeDp(180, 110)
+
+        assertEquals(WidgetSizeDp(180, 210), applyResizeDrag(start, 999f, 100f, limits))
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
@@ -3,6 +3,7 @@ package com.example.androidlauncher.ui
 import androidx.compose.ui.geometry.Offset
 import com.example.androidlauncher.data.HomeLayout
 import com.example.androidlauncher.data.HostedWidget
+import com.example.androidlauncher.data.WidgetSizeDp
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -100,5 +101,31 @@ class HomeDragStateHolderTest {
 
         assertTrue(holder.offsets.containsKey(HomeEditTarget.Widget(5)))
         assertEquals(mapOf(5 to Offset(3f, 4f)), holder.toWidgetOffsets())
+    }
+
+    // --- B1-PR4: Live-Größen beim Resize ---
+
+    @Test
+    fun `widget sizes seed from persisted entries and roundtrip`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(7)))
+
+        assertEquals(mapOf(7 to WidgetSizeDp(200, 100)), holder.toWidgetSizes())
+
+        holder.widgetSizes[7] = WidgetSizeDp(260, 140)
+        assertEquals(mapOf(7 to WidgetSizeDp(260, 140)), holder.toWidgetSizes())
+
+        // Abbrechen: seedFrom revertiert auch die Live-Größen.
+        holder.seedFrom(HomeLayout(), listOf(widget(7)))
+        assertEquals(mapOf(7 to WidgetSizeDp(200, 100)), holder.toWidgetSizes())
+    }
+
+    @Test
+    fun `removed widgets drop their size entries too`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1), widget(2)))
+
+        holder.seedFrom(HomeLayout(), listOf(widget(1)))
+
+        assertEquals(mapOf(1 to WidgetSizeDp(200, 100)), holder.toWidgetSizes())
+        assertFalse(holder.widgetSizes.containsKey(2))
     }
 }


### PR DESCRIPTION
## Zusammenfassung
- **`data/WidgetResize.kt`** (framework-frei, unit-getestet): `resolveResizeLimits` leitet den erlaubten Größenbereich aus `resizeMode`, Provider-Min/Max (0 = unbegrenzt, API-31-Semantik) und der Screen-Kappung des Bind-Flows ab; gesperrte Achsen werden über `min == max` abgebildet – ein einzelnes Eck-Handle deckt damit alle vier resizeMode-Fälle ab. `applyResizeDrag` clampt den **kumulierten** Drag (kein Rundungsdrift).
- **`WidgetHostManager.updateWidgetPlacement(offsets, sizes)`**: ein atomarer Write für beide; `updateOffsets` delegiert.
- **`HomeDragStateHolder.widgetSizes`**: Live-Größen mit seed/revert/stale-Cleanup wie die Offsets – Cancel revertiert gratis.
- **HomeScreen**: Resize-Handle (BottomEnd, `home_widget_resize_{id}`) am ausgewählten Widget im Edit-Modus, nur bei `isResizable`; die Live-Größe fließt über das bestehende `updateAppWidgetSizeCompat` in `HostedWidgetView` an den Provider (dort null Änderungen). Save committet Offsets + Größen gemeinsam.
- **MainActivity**: Limits-Lambda aus `providerInfo` (+ Build-Gate für `maxResize*`), Save-Verdrahtung auf `updateWidgetPlacement`.

## Tests
- `WidgetResizeTest`: RESIZE_NONE/H/V/BOTH, unset Provider-Max, Floors, degenerierter Min>Screen-Fall, Clamping, kumulierte Drags, gesperrte Achsen
- `WidgetHostManagerTest`: atomare Placement-Writes
- `HomeDragStateHolderTest`: Größen-Seed/-Revert/-Cleanup
- Gates grün: `detekt testDebugUnitTest koverVerifyDebug compileDebugAndroidTestKotlin`

## Offen
- Emulator-Verifikation (Handle-Drag, Achsen-Locks, Cancel/Save, force-stop-Persistenz) folgt laut Plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)