### PR TITLE
feat(U1): Swipe-Gesten-Datenschicht – SwipeDirection, Settings-Keys, Backup

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/data/SwipeGesture.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/SwipeGesture.kt
@@ -1,0 +1,30 @@
+package com.example.androidlauncher.data
+
+/** Wisch-Richtung auf dem Startbildschirm, der eine [GestureAction] zugeordnet werden kann. */
+enum class SwipeDirection { UP, DOWN, LEFT, RIGHT }
+
+/** Einer Wisch-Richtung zugeordnete Aktion samt Ziel-App für [GestureAction.OPEN_APP]. */
+data class SwipeBinding(
+    val action: GestureAction,
+    val appPackage: String? = null,
+)
+
+/**
+ * Vollständige Swipe-Gesten-Belegung des Startbildschirms. Fehlende Richtungen
+ * fallen auf die Defaults zurück, die dem früher fest verdrahteten Verhalten
+ * entsprechen (hoch = App-Drawer, runter = Benachrichtigungen).
+ */
+data class SwipeGestureConfig(
+    private val bindings: Map<SwipeDirection, SwipeBinding> = emptyMap(),
+) {
+    operator fun get(direction: SwipeDirection): SwipeBinding =
+        bindings[direction] ?: SwipeBinding(defaultActionFor(direction))
+
+    companion object {
+        fun defaultActionFor(direction: SwipeDirection): GestureAction = when (direction) {
+            SwipeDirection.UP -> GestureAction.APP_DRAWER
+            SwipeDirection.DOWN -> GestureAction.NOTIFICATIONS
+            SwipeDirection.LEFT, SwipeDirection.RIGHT -> GestureAction.NONE
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/data/backup/BackupSpec.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/backup/BackupSpec.kt
@@ -46,5 +46,9 @@ object BackupSpec {
         "hidden_apps",
         "shake_open_app_package",
         "double_tap_app_package",
+        "swipe_up_app_package",
+        "swipe_down_app_package",
+        "swipe_left_app_package",
+        "swipe_right_app_package",
     )
 }

--- a/app/src/main/java/com/example/androidlauncher/data/settings/GestureSettings.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/settings/GestureSettings.kt
@@ -12,6 +12,9 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.example.androidlauncher.data.CryptoManager
 import com.example.androidlauncher.data.GestureAction
+import com.example.androidlauncher.data.SwipeBinding
+import com.example.androidlauncher.data.SwipeDirection
+import com.example.androidlauncher.data.SwipeGestureConfig
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -39,6 +42,14 @@ class GestureSettings(
         private val DOUBLE_TAP_ACTION_KEY = stringPreferencesKey("double_tap_action")
         private val DOUBLE_TAP_APP_PACKAGE_KEY = stringPreferencesKey("double_tap_app_package")
         private val HAPTIC_FEEDBACK_KEY = booleanPreferencesKey("haptic_feedback_enabled")
+
+        // U1: Keys pro Wisch-Richtung, z. B. "swipe_up_action" / "swipe_up_app_package".
+        // Die *_app_package-Keys müssen in BackupSpec.ENCRYPTED_SETTINGS_KEYS gelistet sein.
+        private fun swipeActionKey(direction: SwipeDirection) =
+            stringPreferencesKey("swipe_${direction.name.lowercase()}_action")
+
+        private fun swipeAppPackageKey(direction: SwipeDirection) =
+            stringPreferencesKey("swipe_${direction.name.lowercase()}_app_package")
     }
 
     /** Observable flow for shake gesture toggle. */
@@ -76,6 +87,26 @@ class GestureSettings(
             CryptoManager.decryptOrLegacy(
                 preferences[DOUBLE_TAP_APP_PACKAGE_KEY]
             ).takeIf { it.isNotBlank() }
+        }
+
+    /**
+     * Komplette Swipe-Gesten-Belegung des Startbildschirms (U1). Ein einzelner
+     * `map` über den DataStore statt kombinierter Einzel-Flows – ein Emit pro Änderung.
+     */
+    val swipeGestureConfig: Flow<SwipeGestureConfig> = dataStore.data
+        .map { preferences ->
+            SwipeGestureConfig(
+                SwipeDirection.entries.associateWith { direction ->
+                    val name = preferences[swipeActionKey(direction)]
+                    SwipeBinding(
+                        action = runCatching { GestureAction.valueOf(name ?: "") }
+                            .getOrDefault(SwipeGestureConfig.defaultActionFor(direction)),
+                        appPackage = CryptoManager.decryptOrLegacy(
+                            preferences[swipeAppPackageKey(direction)]
+                        ).takeIf { it.isNotBlank() },
+                    )
+                }
+            )
         }
 
     /**
@@ -144,6 +175,22 @@ class GestureSettings(
                 preferences.remove(DOUBLE_TAP_APP_PACKAGE_KEY)
             } else {
                 preferences[DOUBLE_TAP_APP_PACKAGE_KEY] = CryptoManager.encrypt(packageName)
+            }
+        }
+    }
+
+    /** Setzt die Aktion für eine Wisch-Richtung auf dem Startbildschirm. */
+    suspend fun setSwipeAction(direction: SwipeDirection, action: GestureAction) {
+        dataStore.edit { it[swipeActionKey(direction)] = action.name }
+    }
+
+    /** Setzt das Paket der App für [GestureAction.OPEN_APP] der Wisch-Richtung (null löscht die Wahl). */
+    suspend fun setSwipeAppPackage(direction: SwipeDirection, packageName: String?) {
+        dataStore.edit { preferences ->
+            if (packageName.isNullOrBlank()) {
+                preferences.remove(swipeAppPackageKey(direction))
+            } else {
+                preferences[swipeAppPackageKey(direction)] = CryptoManager.encrypt(packageName)
             }
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/gesture/SwipeDirectionResolver.kt
+++ b/app/src/main/java/com/example/androidlauncher/gesture/SwipeDirectionResolver.kt
@@ -1,0 +1,56 @@
+package com.example.androidlauncher.gesture
+
+import com.example.androidlauncher.data.SwipeDirection
+import kotlin.math.abs
+
+/**
+ * Erkennt aus akkumulierten Drag-Deltas die Wisch-Richtung auf dem Startbildschirm.
+ * Ersetzt die frühere Inline-Akkumulation in HomeScreen (nur vertikal) und ist
+ * pure Kotlin, damit die Schwellwert-/Dead-Zone-Logik unit-testbar bleibt.
+ *
+ * Regeln:
+ * - Es feuert höchstens EINE Richtung pro Drag ([onDragStart] setzt zurück).
+ * - Die dominante Achse (größerer Absolutbetrag) entscheidet, damit ein leicht
+ *   schräger vertikaler Wisch nicht links/rechts auslöst.
+ * - Drags, die in der unteren System-Gestenzone starten, feuern nie (sonst
+ *   öffnet ein Home-Wisch von ganz unten versehentlich den Drawer).
+ */
+class SwipeDirectionResolver(
+    private val thresholdPx: Float,
+    private val bottomDeadZonePx: Float,
+    private val containerHeightPx: Float,
+) {
+    private var totalDx = 0f
+    private var totalDy = 0f
+    private var handled = false
+    private var startedInDeadZone = false
+
+    fun onDragStart(startY: Float) {
+        totalDx = 0f
+        totalDy = 0f
+        handled = false
+        startedInDeadZone = startY > containerHeightPx - bottomDeadZonePx
+    }
+
+    /** Liefert genau einmal pro Drag die erkannte Richtung, sonst null. */
+    fun onDrag(dx: Float, dy: Float): SwipeDirection? {
+        if (handled || startedInDeadZone) return null
+        totalDx += dx
+        totalDy += dy
+        val direction = if (abs(totalDy) >= abs(totalDx)) {
+            when {
+                totalDy < -thresholdPx -> SwipeDirection.UP
+                totalDy > thresholdPx -> SwipeDirection.DOWN
+                else -> null
+            }
+        } else {
+            when {
+                totalDx < -thresholdPx -> SwipeDirection.LEFT
+                totalDx > thresholdPx -> SwipeDirection.RIGHT
+                else -> null
+            }
+        }
+        if (direction != null) handled = true
+        return direction
+    }
+}

--- a/app/src/test/java/com/example/androidlauncher/data/backup/BackupSpecTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/backup/BackupSpecTest.kt
@@ -27,6 +27,19 @@ class BackupSpecTest {
     }
 
     @Test
+    fun `swipe gesture target packages are re-encrypted on import`() {
+        // U1: Die pro Richtung gewählte OPEN_APP-Ziel-App liegt CryptoManager-verschlüsselt
+        // im Store und muss beim Export/Import wie die anderen Paket-Keys behandelt werden.
+        val swipeKeys = setOf(
+            "swipe_up_app_package",
+            "swipe_down_app_package",
+            "swipe_left_app_package",
+            "swipe_right_app_package",
+        )
+        assertTrue(BackupSpec.ENCRYPTED_SETTINGS_KEYS.containsAll(swipeKeys))
+    }
+
+    @Test
     fun `all four stores are covered`() {
         assertEquals(
             listOf("settings", "favorites", "folders", "icon_mappings"),

--- a/app/src/test/java/com/example/androidlauncher/data/settings/GestureSettingsTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/settings/GestureSettingsTest.kt
@@ -1,8 +1,14 @@
 package com.example.androidlauncher.data.settings
 
 import android.content.Context
+import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.example.androidlauncher.data.GestureAction
+import com.example.androidlauncher.data.SwipeDirection
+import com.example.androidlauncher.data.SwipeGestureConfig
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -28,6 +34,7 @@ import java.io.File
 class GestureSettingsTest {
 
     private lateinit var testFile: File
+    private lateinit var testDataStore: DataStore<Preferences>
     private lateinit var settings: GestureSettings
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -36,7 +43,7 @@ class GestureSettingsTest {
     @Before
     fun setup() {
         testFile = File.createTempFile("gesture_settings_test", ".preferences_pb")
-        val testDataStore = PreferenceDataStoreFactory.create(
+        testDataStore = PreferenceDataStoreFactory.create(
             scope = testScope.backgroundScope,
             produceFile = { testFile }
         )
@@ -79,5 +86,46 @@ class GestureSettingsTest {
         settings.setDoubleTapAppPackage("")
         assertNull(settings.shakeOpenAppPackage.first())
         assertNull(settings.doubleTapAppPackage.first())
+    }
+
+    @Test
+    fun `swipe defaults match the previously hardcoded behaviour`() = testScope.runTest {
+        val config = settings.swipeGestureConfig.first()
+        assertEquals(GestureAction.APP_DRAWER, config[SwipeDirection.UP].action)
+        assertEquals(GestureAction.NOTIFICATIONS, config[SwipeDirection.DOWN].action)
+        assertEquals(GestureAction.NONE, config[SwipeDirection.LEFT].action)
+        assertEquals(GestureAction.NONE, config[SwipeDirection.RIGHT].action)
+        SwipeDirection.entries.forEach { assertNull(config[it].appPackage) }
+        // Leere Config (HomeScreen-Default-Parameter) verhält sich identisch.
+        SwipeDirection.entries.forEach { assertEquals(SwipeGestureConfig()[it], config[it]) }
+    }
+
+    @Test
+    fun `swipe actions roundtrip per direction`() = testScope.runTest {
+        settings.setSwipeAction(SwipeDirection.UP, GestureAction.SEARCH)
+        settings.setSwipeAction(SwipeDirection.DOWN, GestureAction.LOCK_SCREEN)
+        settings.setSwipeAction(SwipeDirection.LEFT, GestureAction.CAMERA)
+        settings.setSwipeAction(SwipeDirection.RIGHT, GestureAction.FLASHLIGHT)
+
+        val config = settings.swipeGestureConfig.first()
+        assertEquals(GestureAction.SEARCH, config[SwipeDirection.UP].action)
+        assertEquals(GestureAction.LOCK_SCREEN, config[SwipeDirection.DOWN].action)
+        assertEquals(GestureAction.CAMERA, config[SwipeDirection.LEFT].action)
+        assertEquals(GestureAction.FLASHLIGHT, config[SwipeDirection.RIGHT].action)
+    }
+
+    @Test
+    fun `swipe app packages roundtrip and null clears the choice`() = testScope.runTest {
+        settings.setSwipeAppPackage(SwipeDirection.RIGHT, "com.example.mailapp")
+        assertEquals("com.example.mailapp", settings.swipeGestureConfig.first()[SwipeDirection.RIGHT].appPackage)
+
+        settings.setSwipeAppPackage(SwipeDirection.RIGHT, null)
+        assertNull(settings.swipeGestureConfig.first()[SwipeDirection.RIGHT].appPackage)
+    }
+
+    @Test
+    fun `invalid stored swipe action name falls back to the direction default`() = testScope.runTest {
+        testDataStore.edit { it[stringPreferencesKey("swipe_up_action")] = "NOT_A_REAL_ACTION" }
+        assertEquals(GestureAction.APP_DRAWER, settings.swipeGestureConfig.first()[SwipeDirection.UP].action)
     }
 }

--- a/app/src/test/java/com/example/androidlauncher/gesture/SwipeDirectionResolverTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/gesture/SwipeDirectionResolverTest.kt
@@ -1,0 +1,83 @@
+package com.example.androidlauncher.gesture
+
+import com.example.androidlauncher.data.SwipeDirection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class SwipeDirectionResolverTest {
+
+    private fun resolver() = SwipeDirectionResolver(
+        thresholdPx = 60f,
+        bottomDeadZonePx = 100f,
+        containerHeightPx = 2000f,
+    )
+
+    @Test
+    fun `detects all four directions once the threshold is crossed`() {
+        val cases = listOf(
+            Triple(0f, -70f, SwipeDirection.UP),
+            Triple(0f, 70f, SwipeDirection.DOWN),
+            Triple(-70f, 0f, SwipeDirection.LEFT),
+            Triple(70f, 0f, SwipeDirection.RIGHT),
+        )
+        for ((dx, dy, expected) in cases) {
+            val r = resolver()
+            r.onDragStart(startY = 500f)
+            assertEquals(expected, r.onDrag(dx, dy))
+        }
+    }
+
+    @Test
+    fun `below threshold nothing fires`() {
+        val r = resolver()
+        r.onDragStart(startY = 500f)
+        assertNull(r.onDrag(0f, -59f))
+        assertNull(r.onDrag(30f, 0f))
+    }
+
+    @Test
+    fun `deltas accumulate across drag events`() {
+        val r = resolver()
+        r.onDragStart(startY = 500f)
+        assertNull(r.onDrag(0f, -40f))
+        assertEquals(SwipeDirection.UP, r.onDrag(0f, -30f))
+    }
+
+    @Test
+    fun `dominant axis wins on diagonal swipes`() {
+        val r = resolver()
+        r.onDragStart(startY = 500f)
+        // Mehr horizontal als vertikal: Links gewinnt, obwohl auch dy über dem Threshold liegt.
+        assertEquals(SwipeDirection.LEFT, r.onDrag(-100f, -70f))
+
+        val r2 = resolver()
+        r2.onDragStart(startY = 500f)
+        // Gleichstand zählt als vertikal (bisheriges Verhalten bevorzugt die vertikale Geste).
+        assertEquals(SwipeDirection.UP, r2.onDrag(-80f, -80f))
+    }
+
+    @Test
+    fun `fires at most once per drag and resets on new drag`() {
+        val r = resolver()
+        r.onDragStart(startY = 500f)
+        assertEquals(SwipeDirection.UP, r.onDrag(0f, -70f))
+        assertNull(r.onDrag(0f, -500f))
+        assertNull(r.onDrag(500f, 0f))
+
+        r.onDragStart(startY = 500f)
+        assertEquals(SwipeDirection.DOWN, r.onDrag(0f, 70f))
+    }
+
+    @Test
+    fun `drags starting in the bottom dead zone never fire`() {
+        val r = resolver()
+        r.onDragStart(startY = 1950f)
+        assertNull(r.onDrag(0f, -500f))
+        assertNull(r.onDrag(500f, 0f))
+
+        // Start knapp oberhalb der Zone feuert normal.
+        r.onDragStart(startY = 1899f)
+        assertEquals(SwipeDirection.UP, r.onDrag(0f, -70f))
+    }
+}


### PR DESCRIPTION
## Zusammenfassung
Erster von zwei gestackten PRs für konfigurierbare Swipe-Gesten (Usability-Runde U1). Reine Datenschicht, keine UI-Änderung — das Verhalten der App ist unverändert.

- **`data/SwipeGesture.kt`**: `SwipeDirection` (UP/DOWN/LEFT/RIGHT), `SwipeBinding` (Aktion + OPEN_APP-Zielpaket), `SwipeGestureConfig` mit Fallback auf das bisher fest verdrahtete Verhalten (hoch=Drawer, runter=Benachrichtigungen, links/rechts=NONE)
- **`GestureSettings`**: `swipeGestureConfig`-Flow als **ein** `map` über `dataStore.data` (kein 8-fach-combine) + `setSwipeAction`/`setSwipeAppPackage`; Zielpakete CryptoManager-verschlüsselt wie `double_tap_app_package`; ungültige gespeicherte Action-Namen fallen auf den Richtungs-Default zurück
- **`gesture/SwipeDirectionResolver`**: pure, getestete Drag-Logik (dominante Achse gewinnt, genau ein Event pro Drag, untere System-Gestenzone feuert nie) — ersetzt in PR 2 die Inline-Akkumulation in HomeScreen
- **`BackupSpec`**: die 4 `swipe_*_app_package`-Keys in `ENCRYPTED_SETTINGS_KEYS` (Export Klartext, Import re-verschlüsselt); Action-Keys fließen automatisch mit
- **ThemeManager bewusst nicht erweitert** — Fassaden-Policy im Klassen-Kommentar: neue Features injizieren den Store direkt (PR 2 injiziert `GestureSettings` in MainActivity)

## Tests
- `SwipeDirectionResolverTest`: 4 Richtungen, Threshold, Akkumulation, Diagonale, Einmal-pro-Drag, Dead-Zone
- `GestureSettingsTest`: Swipe-Defaults, Roundtrip pro Richtung, Krypto-Roundtrip, ungültiger Name → Default
- `BackupSpecTest`: Swipe-Paket-Keys im Encrypted-Set
- `./gradlew detekt testDebugUnitTest koverVerifyDebug` grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)