### PR TITLE
feat(U1): Konfigurierbare Swipe-Gesten – HomeScreen-Erkennung + Gesten-Menü

### DIFF
--- a/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
+++ b/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
@@ -53,7 +53,6 @@ class LauncherComposableUiTest {
                     isSettingsOpen = false,
                     isSearchOpen = false,
                     onToggleEditMode = {},
-                    onOpenDrawer = {},
                     onOpenSearch = {},
                     onToggleSettings = {},
                     onOpenFavoritesConfig = {},

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -205,6 +205,10 @@ class MainActivity : ComponentActivity() {
     @javax.inject.Inject
     lateinit var themeManager: ThemeManager
 
+    // U1: direkt injiziert statt über die ThemeManager-Fassade (deren Policy für neue Features).
+    @javax.inject.Inject
+    lateinit var gestureSettings: com.example.androidlauncher.data.settings.GestureSettings
+
     @javax.inject.Inject
     lateinit var folderManager: FolderManager
 
@@ -332,6 +336,9 @@ class MainActivity : ComponentActivity() {
             val shakeOpenAppPackage by themeManager.shakeOpenAppPackage.collectAsState(initial = null)
             val doubleTapAction by themeManager.doubleTapAction.collectAsState(initial = GestureAction.LOCK_SCREEN)
             val doubleTapAppPackage by themeManager.doubleTapAppPackage.collectAsState(initial = null)
+            val swipeGestureConfig by gestureSettings.swipeGestureConfig.collectAsState(
+                initial = com.example.androidlauncher.data.SwipeGestureConfig()
+            )
             val isSmartSuggestionsEnabled by themeManager.isSmartSuggestionsEnabled.collectAsState(initial = true)
             val isHapticFeedbackEnabled by themeManager.isHapticFeedbackEnabled.collectAsState(initial = true)
             val isAnimationsEnabled by themeManager.isAnimationsEnabled.collectAsState(initial = true)
@@ -1316,13 +1323,13 @@ class MainActivity : ComponentActivity() {
                                 isSearchOpen = isSearchOpen && !isSearchClosingState,
                                 isEditMode = isHomeEditMode,
                                 homeLayout = homeLayout,
-                                onOpenDrawer = { homeViewModel.setDrawerOpen(true) },
                                 onOpenSearch = {
                                     isSearchClosingState = false
                                     homeViewModel.setSearchOpen(true)
                                 },
                                 doubleTapAction = doubleTapAction,
                                 doubleTapAppPackage = doubleTapAppPackage,
+                                swipeActions = swipeGestureConfig,
                                 onGestureAction = { action, pkg -> dispatchGestureAction(action, pkg) },
                                 onToggleSettings = { homeViewModel.toggleSettings() },
                                 onToggleEditMode = { homeViewModel.toggleHomeEditMode() },
@@ -1811,6 +1818,13 @@ class MainActivity : ComponentActivity() {
                     ) {
                         GesturesConfigMenu(
                             apps = allApps,
+                            swipeConfig = swipeGestureConfig,
+                            onSwipeActionChange = { direction, action ->
+                                scope.launch { gestureSettings.setSwipeAction(direction, action) }
+                            },
+                            onSwipeAppPackageChange = { direction, pkg ->
+                                scope.launch { gestureSettings.setSwipeAppPackage(direction, pkg) }
+                            },
                             doubleTapAction = doubleTapAction,
                             onDoubleTapActionChange = { scope.launch { themeManager.setDoubleTapAction(it) } },
                             doubleTapAppPackage = doubleTapAppPackage,
@@ -1834,7 +1848,6 @@ class MainActivity : ComponentActivity() {
                             isSearchOpen = false,
                             isEditMode = false,
                             homeLayout = homeLayout,
-                            onOpenDrawer = {},
                             onOpenSearch = {},
                             onToggleSettings = {},
                             onToggleEditMode = {},

--- a/app/src/main/java/com/example/androidlauncher/ui/GesturesConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/GesturesConfigMenu.kt
@@ -1,5 +1,6 @@
 package com.example.androidlauncher.ui
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -27,19 +28,25 @@ import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Smartphone
 import com.example.androidlauncher.R
 import com.example.androidlauncher.data.AppInfo
+import com.example.androidlauncher.data.DesignStyle
 import com.example.androidlauncher.data.GestureAction
+import com.example.androidlauncher.data.SwipeDirection
+import com.example.androidlauncher.data.SwipeGestureConfig
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalDesignStyle
 import com.example.androidlauncher.ui.theme.LocalFontWeight
 
 /**
- * Untermenü „Gesten": pro Geste eine frei wählbare Aktion. Enthält aktuell die
- * Doppeltipp-Geste und die (bestehende) Schüttel-Geste.
+ * Untermenü „Gesten": pro Geste eine frei wählbare Aktion. Enthält die vier
+ * Wisch-Richtungen (U1), die Doppeltipp-Geste und die Schüttel-Geste.
  */
 @Composable
 fun GesturesConfigMenu(
     apps: List<AppInfo>,
+    swipeConfig: SwipeGestureConfig,
+    onSwipeActionChange: (SwipeDirection, GestureAction) -> Unit,
+    onSwipeAppPackageChange: (SwipeDirection, String?) -> Unit,
     doubleTapAction: GestureAction,
     onDoubleTapActionChange: (GestureAction) -> Unit,
     doubleTapAppPackage: String?,
@@ -91,6 +98,27 @@ fun GesturesConfigMenu(
             verticalArrangement = Arrangement.spacedBy(12.dp),
             contentPadding = PaddingValues(top = 24.dp, bottom = 8.dp)
         ) {
+            // --- Wischen (U1) ---
+            item { GestureSectionHeader(stringResource(R.string.gestures_section_swipe), mainTextColor) }
+            SwipeDirection.entries.forEach { direction ->
+                item {
+                    val binding = swipeConfig[direction]
+                    GestureActionRow(
+                        label = stringResource(direction.labelRes),
+                        apps = apps,
+                        action = binding.action,
+                        onActionChange = { onSwipeActionChange(direction, it) },
+                        appPackage = binding.appPackage,
+                        onAppPackageChange = { onSwipeAppPackageChange(direction, it) },
+                        testTagPrefix = "swipe_${direction.name.lowercase()}",
+                        mainTextColor = mainTextColor,
+                        designStyle = designStyle,
+                        surfaceAccent = surfaceAccent,
+                        isDarkTextEnabled = isDarkTextEnabled
+                    )
+                }
+            }
+
             // --- Doppeltippen ---
             item { GestureSectionHeader(stringResource(R.string.gestures_section_double_tap), mainTextColor) }
             item {
@@ -199,6 +227,77 @@ fun GesturesConfigMenu(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/** Label der Menü-Zeile pro Wisch-Richtung. */
+private val SwipeDirection.labelRes: Int
+    @StringRes get() = when (this) {
+        SwipeDirection.UP -> R.string.gestures_on_swipe_up
+        SwipeDirection.DOWN -> R.string.gestures_on_swipe_down
+        SwipeDirection.LEFT -> R.string.gestures_on_swipe_left
+        SwipeDirection.RIGHT -> R.string.gestures_on_swipe_right
+    }
+
+/**
+ * Aktion-Auswahl für eine Geste samt konditionalem App-Picker für
+ * [GestureAction.OPEN_APP] – gleiches Muster wie die Doppeltipp-Zeile.
+ */
+@Composable
+private fun GestureActionRow(
+    label: String,
+    apps: List<AppInfo>,
+    action: GestureAction,
+    onActionChange: (GestureAction) -> Unit,
+    appPackage: String?,
+    onAppPackageChange: (String?) -> Unit,
+    testTagPrefix: String,
+    mainTextColor: Color,
+    designStyle: DesignStyle,
+    surfaceAccent: Color,
+    isDarkTextEnabled: Boolean,
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        EditActionSelectorItem(
+            label = label,
+            selectedAction = action,
+            onActionSelected = onActionChange,
+            mainTextColor = mainTextColor,
+            designStyle = designStyle,
+            surfaceAccent = surfaceAccent,
+            isDarkTextEnabled = isDarkTextEnabled,
+            testTag = "${testTagPrefix}_action_selector"
+        )
+        if (action == GestureAction.OPEN_APP) {
+            var showPicker by remember { mutableStateOf(false) }
+            val selectedLabel = apps.firstOrNull { it.packageName == appPackage }?.label
+            EditMenuItem(
+                icon = Lucide.Smartphone,
+                label = stringResource(R.string.choose_app),
+                onClick = { showPicker = true },
+                statusLabel = selectedLabel ?: stringResource(R.string.none),
+                mainTextColor = mainTextColor,
+                designStyle = designStyle,
+                surfaceAccent = surfaceAccent,
+                isDarkTextEnabled = isDarkTextEnabled,
+                testTag = "${testTagPrefix}_open_app_picker"
+            )
+            if (showPicker) {
+                GestureAppPickerDialog(
+                    apps = apps,
+                    selectedPackage = appPackage,
+                    onAppSelected = {
+                        onAppPackageChange(it)
+                        showPicker = false
+                    },
+                    onDismiss = { showPicker = false },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled
+                )
             }
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
@@ -63,9 +62,11 @@ import com.example.androidlauncher.data.FavoritesBorderStyle
 import com.example.androidlauncher.data.GestureAction
 import com.example.androidlauncher.data.HomeLayout
 import com.example.androidlauncher.data.HostedWidget
+import com.example.androidlauncher.data.SwipeGestureConfig
 import com.example.androidlauncher.data.WidgetResizeLimits
 import com.example.androidlauncher.data.WidgetSizeDp
 import com.example.androidlauncher.data.applyResizeDrag
+import com.example.androidlauncher.gesture.SwipeDirectionResolver
 import com.example.androidlauncher.launchShortcut
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
 import com.example.androidlauncher.ui.theme.*
@@ -101,10 +102,12 @@ fun HomeScreen(
     isSearchOpen: Boolean,
     isEditMode: Boolean = false,
     homeLayout: HomeLayout = HomeLayout(),
-    onOpenDrawer: () -> Unit,
     onOpenSearch: () -> Unit,
     doubleTapAction: GestureAction = GestureAction.LOCK_SCREEN,
     doubleTapAppPackage: String? = null,
+    // U1: Belegung der 4 Wisch-Richtungen; Default = bisheriges Verhalten
+    // (hoch = Drawer, runter = Benachrichtigungen). Dispatch via onGestureAction.
+    swipeActions: SwipeGestureConfig = SwipeGestureConfig(),
     onGestureAction: (GestureAction, String?) -> Unit = { _, _ -> },
     onToggleSettings: () -> Unit,
     onToggleEditMode: () -> Unit,
@@ -514,6 +517,7 @@ fun HomeScreen(
     // rememberUpdatedState sorgt dafür, dass die Geste immer den aktuellen Wert liest.
     val currentDoubleTapAction by rememberUpdatedState(doubleTapAction)
     val currentDoubleTapAppPackage by rememberUpdatedState(doubleTapAppPackage)
+    val currentSwipeActions by rememberUpdatedState(swipeActions)
     val currentOnGestureAction by rememberUpdatedState(onGestureAction)
 
     val rotation by animateFloatAsState(
@@ -532,34 +536,31 @@ fun HomeScreen(
                     Modifier
                         .pointerInput(isEditMode, appAccessMode) {
                             if (!isEditMode) {
-                                // Untere System-Gestenzone (Home-Wisch) aussparen, sonst öffnet ein Wisch
-                                // von ganz unten versehentlich den Drawer. Zudem die Gesamtstrecke
-                                // akkumulieren (robuster als der fragile Pro-Frame-Delta).
+                                // U1: Wisch-Erkennung für alle 4 Richtungen. Akkumulation,
+                                // Dominante-Achse-Regel und die Aussparung der unteren
+                                // System-Gestenzone liegen testbar im SwipeDirectionResolver;
+                                // pro Drag wird er mit der aktuellen Höhe neu aufgesetzt.
                                 val deadZonePx = 48.dp.toPx()
-                                val thresholdPx = 60f
-                                var startY = 0f
-                                var totalDy = 0f
-                                var handled = false
-                                detectVerticalDragGestures(
+                                var resolver: SwipeDirectionResolver? = null
+                                detectDragGestures(
                                     onDragStart = { offset ->
-                                        startY = offset.y
-                                        totalDy = 0f
-                                        handled = false
+                                        resolver = SwipeDirectionResolver(
+                                            thresholdPx = 60f,
+                                            bottomDeadZonePx = deadZonePx,
+                                            containerHeightPx = size.height.toFloat(),
+                                        ).also { it.onDragStart(offset.y) }
                                     },
-                                    onDragCancel = { handled = false }
+                                    onDragCancel = { resolver = null }
                                 ) { _, dragAmount ->
-                                    val startedInBottomGestureZone = startY > size.height - deadZonePx
-                                    if (!handled && !startedInBottomGestureZone) {
-                                        totalDy += dragAmount
-                                        // Im HOME_LIST-Modus gibt es keinen hochziehbaren Drawer – der App-Zugriff
-                                        // läuft über die seitliche Randleiste (HomeAppScrubber).
-                                        if (totalDy < -thresholdPx && appAccessMode != AppAccessMode.HOME_LIST) {
-                                            handled = true
-                                            onOpenDrawer()
-                                        } else if (totalDy > thresholdPx) {
-                                            handled = true
-                                            expandNotifications(context)
-                                        }
+                                    val direction = resolver?.onDrag(dragAmount.x, dragAmount.y)
+                                        ?: return@detectDragGestures
+                                    val binding = currentSwipeActions[direction]
+                                    // Im HOME_LIST-Modus gibt es keinen hochziehbaren Drawer – der App-Zugriff
+                                    // läuft über die seitliche Randleiste (HomeAppScrubber).
+                                    val drawerUnavailable = binding.action == GestureAction.APP_DRAWER &&
+                                        appAccessMode == AppAccessMode.HOME_LIST
+                                    if (!drawerUnavailable) {
+                                        currentOnGestureAction(binding.action, binding.appPackage)
                                     }
                                 }
                             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -188,6 +188,11 @@
     <string name="gesture_action_open_settings">Einstellungen</string>
 
     <!-- Gesten-Menü -->
+    <string name="gestures_section_swipe">Wischen</string>
+    <string name="gestures_on_swipe_up">Beim Wischen nach oben</string>
+    <string name="gestures_on_swipe_down">Beim Wischen nach unten</string>
+    <string name="gestures_on_swipe_left">Beim Wischen nach links</string>
+    <string name="gestures_on_swipe_right">Beim Wischen nach rechts</string>
     <string name="gestures_section_double_tap">Doppeltippen</string>
     <string name="gestures_on_double_tap">Beim Doppeltippen</string>
     <string name="gestures_section_shake">Schütteln</string>
@@ -422,7 +427,7 @@
     <string name="onboarding_gestures_title">Schnelle Gesten</string>
     <string name="onboarding_gestures_desc">Ein paar Griffe, die Rethrone flott machen.</string>
     <string name="onboarding_gesture_swipe_title">Nach oben wischen</string>
-    <string name="onboarding_gesture_swipe_desc">Öffnet den App-Drawer mit allen Apps.</string>
+    <string name="onboarding_gesture_swipe_desc">Öffnet den App-Drawer – jede Wisch-Richtung ist unter Einstellungen → Gesten anpassbar.</string>
     <string name="onboarding_gesture_doubletap_title">Doppeltippen</string>
     <string name="onboarding_gesture_doubletap_desc">Tippe zweimal auf den Startbildschirm für deine gewählte Aktion.</string>
     <string name="onboarding_gesture_shake_title">Schütteln</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -173,6 +173,11 @@
     <string name="gesture_action_open_settings">Ajustes</string>
 
     <!-- Menú Gestos -->
+    <string name="gestures_section_swipe">Deslizar</string>
+    <string name="gestures_on_swipe_up">Al deslizar hacia arriba</string>
+    <string name="gestures_on_swipe_down">Al deslizar hacia abajo</string>
+    <string name="gestures_on_swipe_left">Al deslizar a la izquierda</string>
+    <string name="gestures_on_swipe_right">Al deslizar a la derecha</string>
     <string name="gestures_section_double_tap">Doble toque</string>
     <string name="gestures_on_double_tap">Al doble toque</string>
     <string name="gestures_section_shake">Agitar</string>
@@ -407,7 +412,7 @@
     <string name="onboarding_gestures_title">Gestos rápidos</string>
     <string name="onboarding_gestures_desc">Unos gestos para usar Rethrone en un instante.</string>
     <string name="onboarding_gesture_swipe_title">Desliza hacia arriba</string>
-    <string name="onboarding_gesture_swipe_desc">Abre el cajón con todas tus apps.</string>
+    <string name="onboarding_gesture_swipe_desc">Abre el cajón de apps: cada dirección de deslizamiento se puede personalizar en Ajustes → Gestos.</string>
     <string name="onboarding_gesture_doubletap_title">Doble toque</string>
     <string name="onboarding_gesture_doubletap_desc">Toca dos veces la pantalla de inicio para tu acción elegida.</string>
     <string name="onboarding_gesture_shake_title">Agitar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -173,6 +173,11 @@
     <string name="gesture_action_open_settings">Réglages</string>
 
     <!-- Menu Gestes -->
+    <string name="gestures_section_swipe">Balayage</string>
+    <string name="gestures_on_swipe_up">Au balayage vers le haut</string>
+    <string name="gestures_on_swipe_down">Au balayage vers le bas</string>
+    <string name="gestures_on_swipe_left">Au balayage vers la gauche</string>
+    <string name="gestures_on_swipe_right">Au balayage vers la droite</string>
     <string name="gestures_section_double_tap">Double appui</string>
     <string name="gestures_on_double_tap">Au double appui</string>
     <string name="gestures_section_shake">Secousse</string>
@@ -407,7 +412,7 @@
     <string name="onboarding_gestures_title">Gestes rapides</string>
     <string name="onboarding_gestures_desc">Quelques gestes pour utiliser Rethrone en un éclair.</string>
     <string name="onboarding_gesture_swipe_title">Balayer vers le haut</string>
-    <string name="onboarding_gesture_swipe_desc">Ouvre le tiroir avec toutes vos apps.</string>
+    <string name="onboarding_gesture_swipe_desc">Ouvre le tiroir d\'applications – chaque direction de balayage est personnalisable dans Réglages → Gestes.</string>
     <string name="onboarding_gesture_doubletap_title">Double appui</string>
     <string name="onboarding_gesture_doubletap_desc">Appuyez deux fois sur l\'écran d\'accueil pour votre action choisie.</string>
     <string name="onboarding_gesture_shake_title">Secouer</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -173,6 +173,11 @@
     <string name="gesture_action_open_settings">Impostazioni</string>
 
     <!-- Menu Gesti -->
+    <string name="gestures_section_swipe">Scorrimento</string>
+    <string name="gestures_on_swipe_up">Allo scorrimento verso l\'alto</string>
+    <string name="gestures_on_swipe_down">Allo scorrimento verso il basso</string>
+    <string name="gestures_on_swipe_left">Allo scorrimento verso sinistra</string>
+    <string name="gestures_on_swipe_right">Allo scorrimento verso destra</string>
     <string name="gestures_section_double_tap">Doppio tocco</string>
     <string name="gestures_on_double_tap">Al doppio tocco</string>
     <string name="gestures_section_shake">Scuotimento</string>
@@ -407,7 +412,7 @@
     <string name="onboarding_gestures_title">Gesti rapidi</string>
     <string name="onboarding_gestures_desc">Alcuni gesti per usare Rethrone in un lampo.</string>
     <string name="onboarding_gesture_swipe_title">Scorri verso l\'alto</string>
-    <string name="onboarding_gesture_swipe_desc">Apre il drawer con tutte le tue app.</string>
+    <string name="onboarding_gesture_swipe_desc">Apre il drawer delle app: ogni direzione di scorrimento è personalizzabile in Impostazioni → Gesti.</string>
     <string name="onboarding_gesture_doubletap_title">Doppio tocco</string>
     <string name="onboarding_gesture_doubletap_desc">Tocca due volte la Home per la tua azione scelta.</string>
     <string name="onboarding_gesture_shake_title">Scuoti</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,11 @@
     <string name="gesture_action_open_settings">Settings</string>
 
     <!-- Gestures menu -->
+    <string name="gestures_section_swipe">Swipe</string>
+    <string name="gestures_on_swipe_up">On swipe up</string>
+    <string name="gestures_on_swipe_down">On swipe down</string>
+    <string name="gestures_on_swipe_left">On swipe left</string>
+    <string name="gestures_on_swipe_right">On swipe right</string>
     <string name="gestures_section_double_tap">Double tap</string>
     <string name="gestures_on_double_tap">On double tap</string>
     <string name="gestures_section_shake">Shake</string>
@@ -422,7 +427,7 @@
     <string name="onboarding_gestures_title">Quick gestures</string>
     <string name="onboarding_gestures_desc">A few moves that make Rethrone fast to use.</string>
     <string name="onboarding_gesture_swipe_title">Swipe up</string>
-    <string name="onboarding_gesture_swipe_desc">Open the app drawer with all your apps.</string>
+    <string name="onboarding_gesture_swipe_desc">Opens the app drawer – every swipe direction can be customized under Settings → Gestures.</string>
     <string name="onboarding_gesture_doubletap_title">Double tap</string>
     <string name="onboarding_gesture_doubletap_desc">Tap the home screen twice to trigger your chosen action.</string>
     <string name="onboarding_gesture_shake_title">Shake</string>


### PR DESCRIPTION
## Zusammenfassung
Zweiter U1-PR (gestackt auf #124). Macht alle vier Swipe-Richtungen auf dem Homescreen konfigurierbar.

- **HomeScreen**: `detectVerticalDragGestures` → `detectDragGestures` mit dem `SwipeDirectionResolver` aus #124 (pro Drag frisch mit aktueller Container-Höhe aufgesetzt). Alle Richtungen laufen über den bestehenden `onGestureAction`-Dispatch; der `expandNotifications`-Direktaufruf und der `onOpenDrawer`-Parameter entfallen.
- **HOME_LIST-Modus**: nur `APP_DRAWER` wird unterdrückt (es gibt keinen Drawer; App-Zugriff via HomeAppScrubber) — jede andere Aktion feuert auch auf Swipe hoch.
- **GesturesConfigMenu**: neue Sektion „Wischen" mit den 4 Richtungen; gemeinsame private `GestureActionRow` (Aktion-Selector + konditionaler OPEN_APP-App-Picker, exakt das Doppeltipp-Muster). Signatur bleibt kompakt: `SwipeGestureConfig` + 2 `(SwipeDirection, …)`-Lambdas statt 16 Einzelparameter.
- **MainActivity**: `GestureSettings` direkt injiziert (ThemeManager-Fassaden-Policy), ein `collectAsState` für die Config.
- **Strings** in values + de/es/fr/it; Onboarding-Swipe-Beschreibung erwähnt die Konfigurierbarkeit.

## Verifikation
- `./gradlew detekt testDebugUnitTest koverVerifyDebug` grün
- Emulator (frische Installation):
  - Defaults unverändert: hoch=Drawer, runter=Benachrichtigungen, links/rechts nichts
  - Gesten-Menü zeigt alle 4 Richtungen; rechts=Suche greift sofort (reaktiver Flow)
  - Swipe links mit „Off" tut nichts
  - HOME_LIST: Swipe hoch mit APP_DRAWER unterdrückt; auf Notifications umgelegt → feuert

🤖 Generated with [Claude Code](https://claude.com/claude-code)