### PR TITLE
feat(U2): Widget-Re-Bind beim Backup-Import

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -116,6 +116,7 @@ import com.example.androidlauncher.data.ThemeManager
 import com.example.androidlauncher.data.WidgetBindFlow
 import com.example.androidlauncher.data.WidgetBindStep
 import com.example.androidlauncher.data.WidgetHostManager
+import com.example.androidlauncher.data.WidgetRestoreSummary
 import com.example.androidlauncher.data.WidgetSizeDp
 import com.example.androidlauncher.data.backup.BackupSerializer
 import com.example.androidlauncher.data.backup.RestoreResult
@@ -2188,18 +2189,35 @@ class MainActivity : ComponentActivity() {
     /** B5: liest und validiert eine Backup-Datei und spielt sie ein (Overwrite-all). */
     private fun importBackupFrom(uri: Uri) {
         lifecycleScope.launch(Dispatchers.IO) {
+            // U2: nach erfolgreichem Restore werden Backup-Widgets still re-gebunden
+            // (AppWidget-APIs auf dem Main-Dispatcher, wie der reguläre Bind-Flow).
+            var widgetSummary: WidgetRestoreSummary? = null
             val messageRes = runCatching {
                 val json = contentResolver.openInputStream(uri)?.use { stream ->
                     stream.readBytes().toString(Charsets.UTF_8)
                 } ?: return@runCatching R.string.backup_import_error
                 val snapshot = BackupSerializer.parse(json) ?: return@runCatching R.string.backup_import_error
                 when (backupManager.restore(snapshot)) {
-                    RestoreResult.APPLIED -> R.string.backup_import_success
+                    RestoreResult.APPLIED -> {
+                        if (snapshot.widgets.isNotEmpty()) {
+                            widgetSummary = withContext(Dispatchers.Main) {
+                                widgetHostManager.restoreWidgets(snapshot.widgets)
+                            }
+                        }
+                        R.string.backup_import_success
+                    }
                     RestoreResult.UNSUPPORTED_VERSION -> R.string.backup_import_unsupported
                 }
             }.getOrDefault(R.string.backup_import_error)
             withContext(Dispatchers.Main) {
                 Toast.makeText(this@MainActivity, getString(messageRes), Toast.LENGTH_LONG).show()
+                widgetSummary?.let { summary ->
+                    Toast.makeText(
+                        this@MainActivity,
+                        getString(R.string.backup_import_widgets_result, summary.restored, summary.skipped),
+                        Toast.LENGTH_LONG
+                    ).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
@@ -81,6 +81,23 @@ fun resolveWidgetCleanup(
     )
 }
 
+/** Ergebnis eines Widget-Restores nach Backup-Import (U2). */
+data class WidgetRestoreSummary(val restored: Int, val skipped: Int)
+
+/**
+ * Plant den Widget-Restore nach einem Backup-Import (U2): Eintraege, die bereits
+ * identisch gehostet sind (gleicher Provider an gleicher Position), werden
+ * uebersprungen – sonst wuerde ein Re-Import auf demselben Geraet jedes Widget
+ * verdoppeln (`hosted_widgets` ist vom Restore ausgenommen und ueberlebt ihn).
+ */
+fun planWidgetRestore(
+    backups: List<com.example.androidlauncher.data.backup.WidgetBackup>,
+    existing: List<HostedWidget>,
+): List<com.example.androidlauncher.data.backup.WidgetBackup> {
+    val hosted = existing.map { Triple(it.provider, it.offsetX, it.offsetY) }.toHashSet()
+    return backups.filterNot { Triple(it.provider, it.offsetX, it.offsetY) in hosted }
+}
+
 /** Anzeigegroesse eines gehosteten Widgets in dp. */
 data class WidgetSizeDp(val widthDp: Int, val heightDp: Int)
 

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
@@ -134,6 +134,42 @@ class WidgetHostManager(
     }
 
     /**
+     * Stellt Widgets aus einem Backup wieder her (U2): pro geplantem Eintrag wird eine
+     * frische ID allokiert und still gebunden. Bewusst KEIN `ACTION_APPWIDGET_BIND`-
+     * Consent-Dialog und keine Configure-Activity pro Widget – eine Dialog-Kaskade
+     * direkt nach dem Import waere schlechtere UX; als Default-Launcher hat die App
+     * i. d. R. die Bind-Permission. Verweigerte/kaputte Eintraege fallen still weg.
+     * Alle Erfolge werden in EINEM atomaren Write angehaengt.
+     */
+    suspend fun restoreWidgets(
+        backups: List<com.example.androidlauncher.data.backup.WidgetBackup>,
+        resolveComponent: (String) -> ComponentName? = { ComponentName.unflattenFromString(it) },
+    ): WidgetRestoreSummary {
+        val existing = settings.hostedWidgets.first()
+        val restored = mutableListOf<HostedWidget>()
+        for (backup in planWidgetRestore(backups, existing)) {
+            val component = resolveComponent(backup.provider) ?: continue
+            val appWidgetId = allocateWidgetId()
+            if (bindIfAllowed(appWidgetId, component)) {
+                restored += HostedWidget(
+                    appWidgetId = appWidgetId,
+                    provider = backup.provider,
+                    widthDp = backup.widthDp,
+                    heightDp = backup.heightDp,
+                    offsetX = backup.offsetX,
+                    offsetY = backup.offsetY,
+                )
+            } else {
+                deleteWidgetId(appWidgetId)
+            }
+        }
+        if (restored.isNotEmpty()) {
+            settings.setHostedWidgets(existing + restored)
+        }
+        return WidgetRestoreSummary(restored = restored.size, skipped = backups.size - restored.size)
+    }
+
+    /**
      * Raeumt beim Start Leichen auf (siehe [resolveWidgetCleanup]): geleakte IDs aus
      * abgebrochenen Bind-Flows und Widgets deinstallierter Provider.
      */

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -163,6 +163,7 @@
     <string name="backup_export_success">Backup gespeichert</string>
     <string name="backup_export_error">Backup fehlgeschlagen</string>
     <string name="backup_import_success">Backup wiederhergestellt</string>
+    <string name="backup_import_widgets_result">%1$d Widgets wiederhergestellt, %2$d übersprungen</string>
     <string name="backup_import_error">Datei konnte nicht gelesen werden</string>
     <string name="backup_import_unsupported">Backup stammt aus einer neueren App-Version</string>
     <string name="default_launcher">Standard-Launcher</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -148,6 +148,7 @@
     <string name="backup_export_success">Copia guardada</string>
     <string name="backup_export_error">Error al crear la copia</string>
     <string name="backup_import_success">Copia restaurada</string>
+    <string name="backup_import_widgets_result">%1$d widgets restaurados, %2$d omitidos</string>
     <string name="backup_import_error">No se pudo leer el archivo</string>
     <string name="backup_import_unsupported">La copia proviene de una versión más reciente de la app</string>
     <string name="default_launcher">Lanzador predeterminado</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -148,6 +148,7 @@
     <string name="backup_export_success">Sauvegarde enregistrée</string>
     <string name="backup_export_error">Échec de la sauvegarde</string>
     <string name="backup_import_success">Sauvegarde restaurée</string>
+    <string name="backup_import_widgets_result">%1$d widgets restaurés, %2$d ignorés</string>
     <string name="backup_import_error">Impossible de lire le fichier</string>
     <string name="backup_import_unsupported">La sauvegarde provient d\'une version plus récente de l\'app</string>
     <string name="default_launcher">Lanceur par défaut</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -148,6 +148,7 @@
     <string name="backup_export_success">Backup salvato</string>
     <string name="backup_export_error">Backup non riuscito</string>
     <string name="backup_import_success">Backup ripristinato</string>
+    <string name="backup_import_widgets_result">%1$d widget ripristinati, %2$d saltati</string>
     <string name="backup_import_error">Impossibile leggere il file</string>
     <string name="backup_import_unsupported">Il backup proviene da una versione più recente dell\'app</string>
     <string name="default_launcher">Launcher predefinito</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -163,6 +163,7 @@
     <string name="backup_export_success">Backup saved</string>
     <string name="backup_export_error">Backup failed</string>
     <string name="backup_import_success">Backup restored</string>
+    <string name="backup_import_widgets_result">%1$d widgets restored, %2$d skipped</string>
     <string name="backup_import_error">File could not be read</string>
     <string name="backup_import_unsupported">Backup was created by a newer app version</string>
     <string name="default_launcher">Default launcher</string>

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetBindFlowTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetBindFlowTest.kt
@@ -1,5 +1,6 @@
 package com.example.androidlauncher.data
 
+import com.example.androidlauncher.data.backup.WidgetBackup
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -155,5 +156,48 @@ class WidgetBindFlowTest {
             screenHeightDp = 800,
         )
         assertEquals(WidgetSizeDp(400 - 48, (800 * 0.6f).toInt()), size)
+    }
+
+    // --- planWidgetRestore (U2) ---
+
+    private fun backup(provider: String, x: Float = 0f, y: Float = 0f) = WidgetBackup(
+        provider = provider,
+        widthDp = 200,
+        heightDp = 100,
+        offsetX = x,
+        offsetY = y,
+    )
+
+    private fun hosted(id: Int, provider: String, x: Float = 0f, y: Float = 0f) = HostedWidget(
+        appWidgetId = id,
+        provider = provider,
+        widthDp = 200,
+        heightDp = 100,
+        offsetX = x,
+        offsetY = y,
+    )
+
+    @Test
+    fun `restore plan keeps everything when nothing is hosted`() {
+        val backups = listOf(backup("a/b"), backup("c/d", x = 10f))
+        assertEquals(backups, planWidgetRestore(backups, existing = emptyList()))
+    }
+
+    @Test
+    fun `restore plan skips identically placed duplicates`() {
+        val backups = listOf(backup("a/b"), backup("a/b", x = 50f), backup("c/d"))
+        val existing = listOf(hosted(1, "a/b"), hosted(2, "e/f"))
+
+        // Gleicher Provider an gleicher Position wird uebersprungen; derselbe
+        // Provider an anderer Position und neue Provider bleiben im Plan.
+        assertEquals(listOf(backup("a/b", x = 50f), backup("c/d")), planWidgetRestore(backups, existing))
+    }
+
+    @Test
+    fun `restore plan is empty on same-device re-import`() {
+        val backups = listOf(backup("a/b"), backup("c/d", y = 30f))
+        val existing = listOf(hosted(1, "a/b"), hosted(2, "c/d", y = 30f))
+
+        assertEquals(emptyList<WidgetBackup>(), planWidgetRestore(backups, existing))
     }
 }

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
@@ -174,4 +174,80 @@ class WidgetHostManagerTest {
 
         assertNull(manager.createView(9))
     }
+
+    // --- restoreWidgets (U2) ---
+
+    private fun widgetBackup(provider: String, x: Float = 0f, y: Float = 0f) =
+        com.example.androidlauncher.data.backup.WidgetBackup(
+            provider = provider,
+            widthDp = 200,
+            heightDp = 100,
+            offsetX = x,
+            offsetY = y,
+        )
+
+    @Test
+    fun `restoreWidgets binds and persists with backed-up size and offsets`() = testScope.runTest {
+        val component = mockk<ComponentName>()
+        every { host.allocateAppWidgetId() } returns 41
+        every { appWidgetManager.bindAppWidgetIdIfAllowed(41, component) } returns true
+
+        val summary = manager.restoreWidgets(
+            backups = listOf(widgetBackup("a/b", x = 12f, y = 34f)),
+            resolveComponent = { component },
+        )
+
+        assertEquals(WidgetRestoreSummary(restored = 1, skipped = 0), summary)
+        assertEquals(
+            listOf(
+                HostedWidget(
+                    appWidgetId = 41,
+                    provider = "a/b",
+                    widthDp = 200,
+                    heightDp = 100,
+                    offsetX = 12f,
+                    offsetY = 34f,
+                )
+            ),
+            manager.widgets.first(),
+        )
+    }
+
+    @Test
+    fun `restoreWidgets releases the id and skips when bind is declined or provider is broken`() =
+        testScope.runTest {
+            val component = mockk<ComponentName>()
+            every { host.deleteAppWidgetId(any()) } just Runs
+            every { host.allocateAppWidgetId() } returns 42
+            every { appWidgetManager.bindAppWidgetIdIfAllowed(42, component) } returns false
+
+            val summary = manager.restoreWidgets(
+                backups = listOf(widgetBackup("a/b"), widgetBackup("kaputt")),
+                resolveComponent = { if (it == "a/b") component else null },
+            )
+
+            assertEquals(WidgetRestoreSummary(restored = 0, skipped = 2), summary)
+            assertEquals(emptyList<HostedWidget>(), manager.widgets.first())
+            verify { host.deleteAppWidgetId(42) }
+        }
+
+    @Test
+    fun `restoreWidgets appends in one write and counts deduped entries as skipped`() = testScope.runTest {
+        val component = mockk<ComponentName>()
+        manager.addWidget(widget(1).copy(provider = "a/b"))
+        every { host.allocateAppWidgetId() } returns 43
+        every { appWidgetManager.bindAppWidgetIdIfAllowed(43, component) } returns true
+
+        val summary = manager.restoreWidgets(
+            // Erster Eintrag ist bereits identisch gehostet (Dedupe), zweiter ist neu.
+            backups = listOf(widgetBackup("a/b"), widgetBackup("c/d", x = 5f)),
+            resolveComponent = { component },
+        )
+
+        assertEquals(WidgetRestoreSummary(restored = 1, skipped = 1), summary)
+        val widgets = manager.widgets.first()
+        assertEquals(2, widgets.size)
+        assertEquals(43, widgets.last().appWidgetId)
+        assertEquals("c/d", widgets.last().provider)
+    }
 }


### PR DESCRIPTION
## Zusammenfassung
Schließt die aus B5 offene Lücke: Widgets wurden id-los exportiert, aber beim Restore ignoriert. Jetzt werden sie nach erfolgreichem Import still re-gebunden.

- **`planWidgetRestore`** (pure, `WidgetBindFlow.kt`): Dedupe gegen bereits identisch gehostete Widgets (gleicher Provider + Offsets) — `hosted_widgets` ist vom Restore ausgenommen, ohne Dedupe würde jeder Re-Import auf demselben Gerät duplizieren.
- **`WidgetHostManager.restoreWidgets`**: pro geplantem Eintrag `allocateWidgetId` → `bindAppWidgetIdIfAllowed`; Erfolg übernimmt Größe/Offsets aus dem Backup, Fehlschlag (Bind verweigert, Provider fehlt/kaputt) gibt die ID frei und fällt still weg. Alle Erfolge in **einem** atomaren Write. `resolveComponent` ist injizierbar, weil `ComponentName.unflattenFromString` in JVM-Tests (returnDefaultValues) null liefert.
- **Bewusste Entscheidung:** kein `ACTION_APPWIDGET_BIND`-Consent-Dialog und keine Configure-Activity pro Widget — eine Dialog-Kaskade direkt nach dem Import wäre schlechtere UX; als Default-Launcher hat Rethrone i. d. R. die Bind-Permission. Widgets mit Configure-Zustand erscheinen im Default-Zustand des Providers.
- **`importBackupFrom`**: Re-Bind nach `RestoreResult.APPLIED` auf dem Main-Dispatcher; Ergebnis-Toast ("%d Widgets wiederhergestellt, %d übersprungen") nur, wenn das Backup Widgets enthält. Kein Backup-Versions-Bump (v1-Format unverändert).

## Tests & Verifikation
- `WidgetBindFlowTest`: Dedupe-Plan (leer / teilweise / komplett doppelt)
- `WidgetHostManagerTest`: Bind-OK persistiert mit Größe/Offsets; Bind-Fail gibt ID frei; gemischte Liste → ein Write + korrekte Summary
- `./gradlew detekt testDebugUnitTest koverVerifyDebug` grün
- Emulator: Widget platzieren → Export (id-los im JSON geprüft) → Widget entfernen → Import → Widget erscheint an alter Position/Größe → Re-Import → kein Duplikat

🤖 Generated with [Claude Code](https://claude.com/claude-code)