### PR TITLE
feat(U2): Leere Zustände & Accessibility-Labels

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/AppDrawer.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -470,6 +471,22 @@ fun AppDrawer(
                                     onOpenFolderConfig = onOpenFolderConfig
                                 )
                             }
+                        }
+                    }
+
+                    // U2: Leerer Zustand, wenn die Drawer-Suche nichts findet.
+                    if (searchQuery.isNotBlank() && visibleApps.isEmpty()) {
+                        item(span = { GridItemSpan(maxLineSpan) }, contentType = "empty") {
+                            Text(
+                                text = stringResource(R.string.drawer_search_no_results),
+                                color = mainTextColor.copy(alpha = 0.6f),
+                                fontSize = 16.sp,
+                                textAlign = TextAlign.Center,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 32.dp)
+                                    .testTag("drawer_search_no_results")
+                            )
                         }
                     }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -94,7 +94,11 @@ fun ColorConfigMenu(
                     color = mainTextColor
                 )
                 IconButton(onClick = onClose) {
-                    Icon(imageVector = Icons.Rounded.Close, contentDescription = null, tint = mainTextColor)
+                    Icon(
+                        imageVector = Icons.Rounded.Close,
+                        contentDescription = stringResource(R.string.cd_close),
+                        tint = mainTextColor
+                    )
                 }
             }
 
@@ -373,7 +377,11 @@ fun ThemeSelectionMenu(
                     color = mainTextColor
                 )
                 IconButton(onClick = onClose) {
-                    Icon(imageVector = Icons.Rounded.Close, contentDescription = null, tint = mainTextColor)
+                    Icon(
+                        imageVector = Icons.Rounded.Close,
+                        contentDescription = stringResource(R.string.cd_close),
+                        tint = mainTextColor
+                    )
                 }
             }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/FavoriteItem.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FavoriteItem.kt
@@ -49,7 +49,8 @@ internal fun EditControlButton(
     tint: Color,
     sizeDp: androidx.compose.ui.unit.Dp = 56.dp,
     containerColor: Color = Color.Transparent,
-    testTag: String? = null
+    testTag: String? = null,
+    contentDescription: String? = null
 ) {
     val intSrc = remember { MutableInteractionSource() }
     val designStyle = LocalDesignStyle.current
@@ -72,7 +73,7 @@ internal fun EditControlButton(
             .clickable(interactionSource = intSrc, indication = null, onClick = onClick),
         contentAlignment = Alignment.Center
     ) {
-        Icon(imageVector = icon, contentDescription = null, tint = tint, modifier = Modifier.size(24.dp))
+        Icon(imageVector = icon, contentDescription = contentDescription, tint = tint, modifier = Modifier.size(24.dp))
     }
 }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/FavoritesConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FavoritesConfigMenu.kt
@@ -143,7 +143,7 @@ fun FavoritesConfigMenu(
                 )
             }
             IconButton(onClick = onClose) {
-                Icon(Icons.Rounded.Close, contentDescription = null, tint = mainTextColor)
+                Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.cd_close), tint = mainTextColor)
             }
         }
 
@@ -442,14 +442,14 @@ private fun FavoriteOrderItem(
             IconButton(onClick = onMoveUp, enabled = index > 0) {
                 Icon(
                     Icons.Rounded.KeyboardArrowUp,
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.cd_move_up),
                     tint = if (index > 0) grayTone else mainTextColor
                 )
             }
             IconButton(onClick = onMoveDown, enabled = index < totalCount - 1) {
                 Icon(
                     Icons.Rounded.KeyboardArrowDown,
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.cd_move_down),
                     tint = if (index < totalCount - 1) grayTone else mainTextColor
                 )
             }

--- a/app/src/main/java/com/example/androidlauncher/ui/FolderConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/FolderConfigMenu.kt
@@ -144,9 +144,13 @@ fun FolderConfigMenu(
                         tint = Color.Red.copy(alpha = 0.8f)
                     )
                 }
-                IconButton(
-                    onClick = onClose
-                ) { Icon(Icons.Rounded.Close, contentDescription = null, tint = mainTextColor) }
+                IconButton(onClick = onClose) {
+                    Icon(
+                        Icons.Rounded.Close,
+                        contentDescription = stringResource(R.string.cd_close),
+                        tint = mainTextColor
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -928,8 +928,19 @@ fun HomeScreen(
                                     ),
                                 contentAlignment = Alignment.Center
                             ) {
-                                Icon(Icons.Rounded.Add, contentDescription = null, tint = mainTextColor)
+                                Icon(
+                                    Icons.Rounded.Add,
+                                    contentDescription = stringResource(R.string.cd_add_favorites),
+                                    tint = mainTextColor
+                                )
                             }
+                            // U2: kleiner Hinweis unter dem "+", was der Kreis tut.
+                            Text(
+                                text = stringResource(R.string.favorites_empty_hint),
+                                color = mainTextColor.copy(alpha = 0.6f),
+                                fontSize = 13.sp,
+                                modifier = Modifier.testTag("favorites_empty_hint")
+                            )
                         } else {
                             favorites.forEachIndexed { index, app ->
                                 FavoriteItem(
@@ -999,7 +1010,8 @@ fun HomeScreen(
                         },
                         sizeDp = 56.dp,
                         tint = mainTextColor.copy(alpha = 0.6f),
-                        testTag = "home_edit_cancel"
+                        testTag = "home_edit_cancel",
+                        contentDescription = stringResource(R.string.cd_cancel)
                     )
 
                     EditControlButton(
@@ -1018,7 +1030,8 @@ fun HomeScreen(
                         sizeDp = 56.dp,
                         containerColor = mainTextColor,
                         tint = if (isDarkTextEnabled) Color.White else Color(0xFF0F172A),
-                        testTag = "home_edit_save"
+                        testTag = "home_edit_save",
+                        contentDescription = stringResource(R.string.cd_save)
                     )
                 }
             }
@@ -1173,7 +1186,9 @@ fun HomeScreen(
                         Box(contentAlignment = Alignment.Center, modifier = Modifier.rotate(rotation)) {
                             Icon(
                                 imageVector = if (isSettingsOpen) Icons.Rounded.Close else Icons.Rounded.Settings,
-                                contentDescription = null,
+                                contentDescription = stringResource(
+                                    if (isSettingsOpen) R.string.cd_close else R.string.cd_open_settings
+                                ),
                                 tint = mainTextColor,
                                 modifier = Modifier.size(if (isSettingsOpen) 32.dp else 28.dp)
                             )

--- a/app/src/main/java/com/example/androidlauncher/ui/NiagaraAppDrawer.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/NiagaraAppDrawer.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -245,6 +246,21 @@ fun NiagaraAppDrawer(
                         state = listState,
                         contentPadding = PaddingValues(end = if (isSearching) 0.dp else 24.dp, bottom = 32.dp)
                     ) {
+                        // U2: Leerer Zustand, wenn die Suche nichts findet.
+                        if (isSearching && visibleApps.isEmpty()) {
+                            item(contentType = "empty") {
+                                Text(
+                                    text = stringResource(R.string.drawer_search_no_results),
+                                    color = mainTextColor.copy(alpha = 0.6f),
+                                    fontSize = 16.sp,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 32.dp)
+                                        .testTag("niagara_search_no_results")
+                                )
+                            }
+                        }
                         if (isSearching) {
                             items(items = visibleApps, key = { it.packageName }, contentType = { "app" }) { app ->
                                 NiagaraAppRow(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -79,6 +79,11 @@
 
     <!-- Inhaltsbeschreibungen (Barrierefreiheit) -->
     <string name="cd_close">Schließen</string>
+    <string name="cd_cancel">Abbrechen</string>
+    <string name="cd_move_up">Nach oben verschieben</string>
+    <string name="cd_move_down">Nach unten verschieben</string>
+    <string name="cd_open_settings">Menü öffnen</string>
+    <string name="cd_add_favorites">Favoriten hinzufügen</string>
     <string name="cd_back">Zurück</string>
     <string name="cd_search">Suche</string>
     <string name="cd_clear">Leeren</string>
@@ -429,4 +434,6 @@
     <string name="onboarding_gesture_shake_desc">Schüttle dein Handy für eine schnelle Aktion wie die Taschenlampe.</string>
     <string name="onboarding_finish_title">Alles bereit</string>
     <string name="onboarding_finish_desc">Viel Freude mit deinem neuen Startbildschirm. Alles ist jederzeit in den Einstellungen änderbar.</string>
+    <string name="drawer_search_no_results">Keine Apps gefunden</string>
+    <string name="favorites_empty_hint">Favoriten hinzufügen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -79,6 +79,11 @@
 
     <!-- Descripciones de contenido (accesibilidad) -->
     <string name="cd_close">Cerrar</string>
+    <string name="cd_cancel">Cancelar</string>
+    <string name="cd_move_up">Mover hacia arriba</string>
+    <string name="cd_move_down">Mover hacia abajo</string>
+    <string name="cd_open_settings">Abrir menú</string>
+    <string name="cd_add_favorites">Añadir favoritos</string>
     <string name="cd_back">Atrás</string>
     <string name="cd_search">Buscar</string>
     <string name="cd_clear">Borrar</string>
@@ -414,4 +419,6 @@
     <string name="onboarding_gesture_shake_desc">Agita el teléfono para una acción rápida como la linterna.</string>
     <string name="onboarding_finish_title">Todo listo</string>
     <string name="onboarding_finish_desc">Disfruta de tu nueva pantalla de inicio. Todo se puede cambiar cuando quieras en los ajustes.</string>
+    <string name="drawer_search_no_results">No se encontraron apps</string>
+    <string name="favorites_empty_hint">Añadir favoritos</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -79,6 +79,11 @@
 
     <!-- Descriptions de contenu (accessibilité) -->
     <string name="cd_close">Fermer</string>
+    <string name="cd_cancel">Annuler</string>
+    <string name="cd_move_up">Déplacer vers le haut</string>
+    <string name="cd_move_down">Déplacer vers le bas</string>
+    <string name="cd_open_settings">Ouvrir le menu</string>
+    <string name="cd_add_favorites">Ajouter des favoris</string>
     <string name="cd_back">Retour</string>
     <string name="cd_search">Rechercher</string>
     <string name="cd_clear">Effacer</string>
@@ -414,4 +419,6 @@
     <string name="onboarding_gesture_shake_desc">Secouez le téléphone pour une action rapide comme la lampe.</string>
     <string name="onboarding_finish_title">Tout est prêt</string>
     <string name="onboarding_finish_desc">Profitez de votre nouvel écran d\'accueil. Tout est modifiable à tout moment dans les paramètres.</string>
+    <string name="drawer_search_no_results">Aucune app trouvée</string>
+    <string name="favorites_empty_hint">Ajouter des favoris</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -79,6 +79,11 @@
 
     <!-- Descrizioni del contenuto (accessibilità) -->
     <string name="cd_close">Chiudi</string>
+    <string name="cd_cancel">Annulla</string>
+    <string name="cd_move_up">Sposta in alto</string>
+    <string name="cd_move_down">Sposta in basso</string>
+    <string name="cd_open_settings">Apri il menu</string>
+    <string name="cd_add_favorites">Aggiungi preferiti</string>
     <string name="cd_back">Indietro</string>
     <string name="cd_search">Cerca</string>
     <string name="cd_clear">Cancella</string>
@@ -414,4 +419,6 @@
     <string name="onboarding_gesture_shake_desc">Scuoti il telefono per un\'azione rapida come la torcia.</string>
     <string name="onboarding_finish_title">Tutto pronto</string>
     <string name="onboarding_finish_desc">Goditi la tua nuova schermata Home. Puoi cambiare tutto quando vuoi nelle impostazioni.</string>
+    <string name="drawer_search_no_results">Nessuna app trovata</string>
+    <string name="favorites_empty_hint">Aggiungi preferiti</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,11 @@
 
     <!-- Content descriptions (accessibility) -->
     <string name="cd_close">Close</string>
+    <string name="cd_cancel">Cancel</string>
+    <string name="cd_move_up">Move up</string>
+    <string name="cd_move_down">Move down</string>
+    <string name="cd_open_settings">Open menu</string>
+    <string name="cd_add_favorites">Add favorites</string>
     <string name="cd_back">Back</string>
     <string name="cd_search">Search</string>
     <string name="cd_clear">Clear</string>
@@ -429,4 +434,6 @@
     <string name="onboarding_gesture_shake_desc">Shake your phone for a quick action like the flashlight.</string>
     <string name="onboarding_finish_title">You\'re all set</string>
     <string name="onboarding_finish_desc">Enjoy your new home screen. Everything can be changed anytime in the settings.</string>
+    <string name="drawer_search_no_results">No apps found</string>
+    <string name="favorites_empty_hint">Add favorites</string>
 </resources>


### PR DESCRIPTION
## Zusammenfassung
Letzter PR der Usability-Runde U1/U2 — kleine Discoverability- und Accessibility-Verbesserungen.

### Empty States
- Drawer-Suche ohne Treffer zeigt **„Keine Apps gefunden"** — im Grid (`AppDrawer`, Item über volle Breite via `GridItemSpan(maxLineSpan)`) und in der Niagara-Liste (`NiagaraAppDrawer`)
- Leere Favoriten: dezente Hint-Zeile **„Favoriten hinzufügen"** unter dem bestehenden „+"-Kreis (Tap-Ziel bleibt der Kreis)

### Accessibility
Audit der 69 `contentDescription = null`-Stellen: Die große Mehrheit sind dekorative Icons in Zeilen mit sichtbarem Text-Label — dort bleibt `null` korrekt (TalkBack liest das Label). Gelabelt wurden die tatsächlich interaktiven Icon-only-Controls:
- Close-Buttons in ColorConfigMenu (2×), FavoritesConfigMenu, FolderConfigMenu → `cd_close`
- Hoch/Runter-Sortier-Buttons in der Favoriten-Liste → `cd_move_up`/`cd_move_down`
- Settings-Zahnrad auf dem Homescreen → zustandsabhängig `cd_open_settings`/`cd_close`
- Edit-Modus Abbrechen/Speichern: `EditControlButton` bekommt einen optionalen `contentDescription`-Parameter → `cd_cancel`/`cd_save`
- „+"-Favoriten-Button → `cd_add_favorites`

Alle neuen Strings in values + de/es/fr/it.

## Verifikation
- `./gradlew detekt testDebugUnitTest koverVerifyDebug` grün (reine UI, Dateien bereits Kover-excluded)
- Emulator: Suche „zzzz" → Hinweis im Grid- **und** Niagara-Modus; leere Favoriten → Hint sichtbar

🤖 Generated with [Claude Code](https://claude.com/claude-code)