### PR TITLE
U3: Widget-Edit-Usability – Pinch-to-Resize, Entfernen mit Rückgängig, px/dp-Fix

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -566,11 +566,15 @@ class MainActivity : ComponentActivity() {
                     needsConfigure = info.configure != null,
                 )
                 pendingWidgetBind = pending
+                // AppWidgetProviderInfo.minWidth/minHeight liefert Android in PIXELN
+                // (aus den dp-XML-Werten mal Geraetedichte) – vor der dp-Weiterverarbeitung
+                // zurueckrechnen, sonst werden Widgets auf dichten Geraeten riesig.
+                val widgetDensity = context.resources.displayMetrics.density
                 pendingWidgetSize = defaultWidgetSizeDp(
                     targetCellWidth = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.targetCellWidth else 0,
                     targetCellHeight = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.targetCellHeight else 0,
-                    minWidthDp = info.minWidth,
-                    minHeightDp = info.minHeight,
+                    minWidthDp = (info.minWidth / widgetDensity).roundToInt(),
+                    minHeightDp = (info.minHeight / widgetDensity).roundToInt(),
                     screenWidthDp = configuration.screenWidthDp,
                     screenHeightDp = configuration.screenHeightDp,
                 )
@@ -1371,28 +1375,20 @@ class MainActivity : ComponentActivity() {
                                 widgetResizeLimits = { id ->
                                     widgetHostManager.providerInfo(id)?.let { info ->
                                         val current = hostedWidgets.firstOrNull { it.appWidgetId == id }
+                                        // Alle minResize*/maxResize*/min* Felder sind in PIXELN –
+                                        // vor resolveResizeLimits (dp-Semantik) in dp umrechnen,
+                                        // sonst ist die Untergrenze riesig ("kann nicht kleiner").
+                                        val dens = context.resources.displayMetrics.density
+                                        val minW = if (info.minResizeWidth > 0) info.minResizeWidth else info.minWidth
+                                        val minH = if (info.minResizeHeight > 0) info.minResizeHeight else info.minHeight
+                                        val maxW = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.maxResizeWidth else 0
+                                        val maxH = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) info.maxResizeHeight else 0
                                         resolveResizeLimits(
                                             resizeMode = info.resizeMode,
-                                            minResizeWidthDp = if (info.minResizeWidth > 0) {
-                                                info.minResizeWidth
-                                            } else {
-                                                info.minWidth
-                                            },
-                                            minResizeHeightDp = if (info.minResizeHeight > 0) {
-                                                info.minResizeHeight
-                                            } else {
-                                                info.minHeight
-                                            },
-                                            maxResizeWidthDp = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                                info.maxResizeWidth
-                                            } else {
-                                                0
-                                            },
-                                            maxResizeHeightDp = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                                                info.maxResizeHeight
-                                            } else {
-                                                0
-                                            },
+                                            minResizeWidthDp = (minW / dens).roundToInt(),
+                                            minResizeHeightDp = (minH / dens).roundToInt(),
+                                            maxResizeWidthDp = if (maxW > 0) (maxW / dens).roundToInt() else 0,
+                                            maxResizeHeightDp = if (maxH > 0) (maxH / dens).roundToInt() else 0,
                                             currentWidthDp = current?.widthDp ?: 0,
                                             currentHeightDp = current?.heightDp ?: 0,
                                             screenWidthDp = configuration.screenWidthDp,

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -1359,13 +1359,12 @@ class MainActivity : ComponentActivity() {
                                 },
                                 hostedWidgets = hostedWidgets,
                                 widgetViewProvider = { id -> widgetHostManager.createView(id) },
-                                onSaveWidgetLayout = { widgetOffsets, widgetSizes ->
+                                // U3: Entfernen laeuft ueber denselben Save-Commit (removedIds)
+                                // statt sofort zu loeschen – Abbrechen/Rueckgaengig bleibt moeglich.
+                                onSaveWidgetLayout = { widgetOffsets, widgetSizes, removedIds ->
                                     scope.launch {
-                                        widgetHostManager.updateWidgetPlacement(widgetOffsets, widgetSizes)
+                                        widgetHostManager.updateWidgetPlacement(widgetOffsets, widgetSizes, removedIds)
                                     }
-                                },
-                                onRemoveWidget = { id ->
-                                    scope.launch { widgetHostManager.removeWidget(id) }
                                 },
                                 // B1-PR4: Resize-Grenzen aus den Provider-Angaben; maxResize*
                                 // gibt es erst ab API 31 (0 = vom Provider nicht begrenzt).

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetBindFlow.kt
@@ -115,7 +115,7 @@ internal const val SCREEN_EDGE_MARGIN_DP = 48
 internal const val MAX_HEIGHT_SCREEN_FRACTION = 0.6f
 
 /**
- * Default-Groesse beim Binden (MVP ohne Resize): bevorzugt die Zell-Angaben des Providers
+ * Default-Groesse beim Binden (aenderbar per Resize im Edit-Modus): bevorzugt die Zell-Angaben des Providers
  * (API 31+, `targetCellWidth/Height`, 0 = nicht gesetzt), sonst `minWidth/minHeight` –
  * geclampt auf sinnvolle Unter-/Obergrenzen relativ zur Screen-Groesse.
  */

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetHostManager.kt
@@ -119,17 +119,26 @@ class WidgetHostManager(
     }
 
     /**
-     * Persistiert Offsets und Groessen aus dem Edit-Modus in einem einzigen
-     * atomaren Write (B1-PR4: der Speichern-Knopf committet beides gemeinsam).
+     * Persistiert Offsets, Groessen und vorgemerkte Loeschungen aus dem Edit-Modus
+     * in einem einzigen atomaren Write (B1-PR4/U3: der Speichern-Knopf committet
+     * alles gemeinsam – erst hier werden Host-IDs entfernter Widgets freigegeben,
+     * damit Abbrechen/Rueckgaengig die Host-View nie verliert).
      */
-    suspend fun updateWidgetPlacement(offsets: Map<Int, Offset>, sizes: Map<Int, WidgetSizeDp>) {
-        if (offsets.isEmpty() && sizes.isEmpty()) return
-        val updated = settings.hostedWidgets.first().map { widget ->
-            var result = widget
-            offsets[widget.appWidgetId]?.let { result = result.copy(offsetX = it.x, offsetY = it.y) }
-            sizes[widget.appWidgetId]?.let { result = result.copy(widthDp = it.widthDp, heightDp = it.heightDp) }
-            result
-        }
+    suspend fun updateWidgetPlacement(
+        offsets: Map<Int, Offset>,
+        sizes: Map<Int, WidgetSizeDp>,
+        removedIds: Set<Int> = emptySet(),
+    ) {
+        if (offsets.isEmpty() && sizes.isEmpty() && removedIds.isEmpty()) return
+        removedIds.forEach(::deleteWidgetId)
+        val updated = settings.hostedWidgets.first()
+            .filterNot { it.appWidgetId in removedIds }
+            .map { widget ->
+                var result = widget
+                offsets[widget.appWidgetId]?.let { result = result.copy(offsetX = it.x, offsetY = it.y) }
+                sizes[widget.appWidgetId]?.let { result = result.copy(widthDp = it.widthDp, heightDp = it.heightDp) }
+                result
+            }
         settings.setHostedWidgets(updated)
     }
 

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
@@ -99,31 +99,66 @@ data class ResizeZoomResult(
     val size: WidgetSizeDp,
     val clampedWidth: Boolean,
     val clampedHeight: Boolean,
+    /**
+     * Auf den nuetzlichen Bereich zurueckgeklemmter Akkumulator – der Aufrufer
+     * MUSS seinen kumulierten Faktor hiermit ueberschreiben. Ohne die Kappung
+     * laeuft der Akkumulator am Anschlag weiter, waehrend die Groesse geklemmt
+     * bleibt, und die Gegenrichtung hat eine riesige tote Zone ("einmal gross
+     * gezogen, nicht mehr kleinziehbar").
+     */
+    val appliedZoom: Float,
 )
 
 /** Untergrenze des Zoom-Faktors – schuetzt vor degenerierten Gesten-Werten (0/negativ). */
 private const val MIN_RESIZE_ZOOM = 0.05f
 
 /**
+ * Kappt [zoom] auf den Bereich, in dem sich mindestens eine freie Achse noch
+ * bewegt: Untergrenze = kleinstes min/start-Verhaeltnis, Obergrenze = groesstes
+ * max/start-Verhaeltnis der freien Achsen. Dadurch reagiert das Reinziehen nach
+ * einem Anschlag sofort wieder.
+ */
+private fun clampZoomToUsefulRange(
+    startSize: WidgetSizeDp,
+    zoom: Float,
+    limits: WidgetResizeLimits,
+): Float {
+    var minZoom = Float.MAX_VALUE
+    var maxZoom = Float.MIN_VALUE
+    if (limits.maxWidthDp > limits.minWidthDp && startSize.widthDp > 0) {
+        minZoom = minOf(minZoom, limits.minWidthDp.toFloat() / startSize.widthDp)
+        maxZoom = maxOf(maxZoom, limits.maxWidthDp.toFloat() / startSize.widthDp)
+    }
+    if (limits.maxHeightDp > limits.minHeightDp && startSize.heightDp > 0) {
+        minZoom = minOf(minZoom, limits.minHeightDp.toFloat() / startSize.heightDp)
+        maxZoom = maxOf(maxZoom, limits.maxHeightDp.toFloat() / startSize.heightDp)
+    }
+    if (minZoom > maxZoom) return zoom.coerceAtLeast(MIN_RESIZE_ZOOM)
+    return zoom.coerceIn(minZoom, maxZoom)
+}
+
+/**
  * Groesse waehrend einer Pinch-Geste (U3): [startSize] ist die Groesse beim
  * Gesten-Start, [zoom] der **kumulierte** Zoom-Faktor seitdem (nicht das letzte
  * Delta – so gehen Sub-dp-Aenderungen nicht durch Rundung verloren). Beide Achsen
  * skalieren mit demselben Faktor; gesperrte Achsen (min == max) bleiben durch das
- * Clamping automatisch fest.
+ * Clamping automatisch fest. Der Aufrufer fuehrt seinen Akkumulator mit
+ * [ResizeZoomResult.appliedZoom] weiter, damit er am Anschlag nicht davonlaeuft.
  */
 fun resolveResizeZoom(
     startSize: WidgetSizeDp,
     zoom: Float,
     limits: WidgetResizeLimits,
 ): ResizeZoomResult {
-    val safeZoom = zoom.coerceAtLeast(MIN_RESIZE_ZOOM)
-    val rawWidth = (startSize.widthDp * safeZoom).roundToInt()
-    val rawHeight = (startSize.heightDp * safeZoom).roundToInt()
+    val appliedZoom = clampZoomToUsefulRange(startSize, zoom, limits)
+    val rawWidth = (startSize.widthDp * appliedZoom).roundToInt()
+    val rawHeight = (startSize.heightDp * appliedZoom).roundToInt()
     val width = rawWidth.coerceIn(limits.minWidthDp, limits.maxWidthDp)
     val height = rawHeight.coerceIn(limits.minHeightDp, limits.maxHeightDp)
     return ResizeZoomResult(
         size = WidgetSizeDp(width, height),
         clampedWidth = limits.maxWidthDp > limits.minWidthDp && rawWidth != width,
         clampedHeight = limits.maxHeightDp > limits.minHeightDp && rawHeight != height,
+        appliedZoom = appliedZoom,
     )
 }

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
@@ -88,45 +88,42 @@ private fun axisRange(
 }
 
 /**
- * Ergebnis eines Resize-Drags inkl. Anschlag-Information (U3: Haptik + Chip-Puls).
+ * Ergebnis eines Resize-Zooms inkl. Anschlag-Information (U3: Haptik + Chip-Puls).
  *
  * [clampedWidth]/[clampedHeight] sind nur dann `true`, wenn die Achse **frei** ist
  * (`max > min`) und der ungeklemmte Wert ausserhalb des Bereichs lag. Eine gesperrte
- * Achse (`min == max`) meldet bewusst nie "geklemmt" – sonst wuerde jeder
- * Diagonal-Drag an einem nur-einachsig skalierbaren Widget dauerhaft vibrieren.
+ * Achse (`min == max`) meldet bewusst nie "geklemmt" – sonst wuerde jede Pinch-Geste
+ * an einem nur-einachsig skalierbaren Widget dauerhaft vibrieren.
  */
-data class ResizeDragResult(
+data class ResizeZoomResult(
     val size: WidgetSizeDp,
     val clampedWidth: Boolean,
     val clampedHeight: Boolean,
 )
 
+/** Untergrenze des Zoom-Faktors – schuetzt vor degenerierten Gesten-Werten (0/negativ). */
+private const val MIN_RESIZE_ZOOM = 0.05f
+
 /**
- * Groesse waehrend eines Resize-Drags: [startSize] ist die Groesse beim Gesten-Start,
- * [totalDragXDp]/[totalDragYDp] der **kumulierte** Drag seitdem (nicht das letzte
- * Delta – so gehen Sub-dp-Bewegungen nicht durch Rundung verloren).
+ * Groesse waehrend einer Pinch-Geste (U3): [startSize] ist die Groesse beim
+ * Gesten-Start, [zoom] der **kumulierte** Zoom-Faktor seitdem (nicht das letzte
+ * Delta – so gehen Sub-dp-Aenderungen nicht durch Rundung verloren). Beide Achsen
+ * skalieren mit demselben Faktor; gesperrte Achsen (min == max) bleiben durch das
+ * Clamping automatisch fest.
  */
-fun resolveResizeDrag(
+fun resolveResizeZoom(
     startSize: WidgetSizeDp,
-    totalDragXDp: Float,
-    totalDragYDp: Float,
+    zoom: Float,
     limits: WidgetResizeLimits,
-): ResizeDragResult {
-    val rawWidth = (startSize.widthDp + totalDragXDp).roundToInt()
-    val rawHeight = (startSize.heightDp + totalDragYDp).roundToInt()
+): ResizeZoomResult {
+    val safeZoom = zoom.coerceAtLeast(MIN_RESIZE_ZOOM)
+    val rawWidth = (startSize.widthDp * safeZoom).roundToInt()
+    val rawHeight = (startSize.heightDp * safeZoom).roundToInt()
     val width = rawWidth.coerceIn(limits.minWidthDp, limits.maxWidthDp)
     val height = rawHeight.coerceIn(limits.minHeightDp, limits.maxHeightDp)
-    return ResizeDragResult(
+    return ResizeZoomResult(
         size = WidgetSizeDp(width, height),
         clampedWidth = limits.maxWidthDp > limits.minWidthDp && rawWidth != width,
         clampedHeight = limits.maxHeightDp > limits.minHeightDp && rawHeight != height,
     )
 }
-
-/** Nur die geklemmte Groesse eines Resize-Drags (Details siehe [resolveResizeDrag]). */
-fun applyResizeDrag(
-    startSize: WidgetSizeDp,
-    totalDragXDp: Float,
-    totalDragYDp: Float,
-    limits: WidgetResizeLimits,
-): WidgetSizeDp = resolveResizeDrag(startSize, totalDragXDp, totalDragYDp, limits).size

--- a/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
+++ b/app/src/main/java/com/example/androidlauncher/data/WidgetResize.kt
@@ -88,18 +88,45 @@ private fun axisRange(
 }
 
 /**
+ * Ergebnis eines Resize-Drags inkl. Anschlag-Information (U3: Haptik + Chip-Puls).
+ *
+ * [clampedWidth]/[clampedHeight] sind nur dann `true`, wenn die Achse **frei** ist
+ * (`max > min`) und der ungeklemmte Wert ausserhalb des Bereichs lag. Eine gesperrte
+ * Achse (`min == max`) meldet bewusst nie "geklemmt" – sonst wuerde jeder
+ * Diagonal-Drag an einem nur-einachsig skalierbaren Widget dauerhaft vibrieren.
+ */
+data class ResizeDragResult(
+    val size: WidgetSizeDp,
+    val clampedWidth: Boolean,
+    val clampedHeight: Boolean,
+)
+
+/**
  * Groesse waehrend eines Resize-Drags: [startSize] ist die Groesse beim Gesten-Start,
  * [totalDragXDp]/[totalDragYDp] der **kumulierte** Drag seitdem (nicht das letzte
  * Delta – so gehen Sub-dp-Bewegungen nicht durch Rundung verloren).
  */
+fun resolveResizeDrag(
+    startSize: WidgetSizeDp,
+    totalDragXDp: Float,
+    totalDragYDp: Float,
+    limits: WidgetResizeLimits,
+): ResizeDragResult {
+    val rawWidth = (startSize.widthDp + totalDragXDp).roundToInt()
+    val rawHeight = (startSize.heightDp + totalDragYDp).roundToInt()
+    val width = rawWidth.coerceIn(limits.minWidthDp, limits.maxWidthDp)
+    val height = rawHeight.coerceIn(limits.minHeightDp, limits.maxHeightDp)
+    return ResizeDragResult(
+        size = WidgetSizeDp(width, height),
+        clampedWidth = limits.maxWidthDp > limits.minWidthDp && rawWidth != width,
+        clampedHeight = limits.maxHeightDp > limits.minHeightDp && rawHeight != height,
+    )
+}
+
+/** Nur die geklemmte Groesse eines Resize-Drags (Details siehe [resolveResizeDrag]). */
 fun applyResizeDrag(
     startSize: WidgetSizeDp,
     totalDragXDp: Float,
     totalDragYDp: Float,
     limits: WidgetResizeLimits,
-): WidgetSizeDp = WidgetSizeDp(
-    widthDp = (startSize.widthDp + totalDragXDp).roundToInt()
-        .coerceIn(limits.minWidthDp, limits.maxWidthDp),
-    heightDp = (startSize.heightDp + totalDragYDp).roundToInt()
-        .coerceIn(limits.minHeightDp, limits.maxHeightDp),
-)
+): WidgetSizeDp = resolveResizeDrag(startSize, totalDragXDp, totalDragYDp, limits).size

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeDragStateHolder.kt
@@ -3,6 +3,7 @@ package com.example.androidlauncher.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,12 +68,40 @@ internal class HomeDragStateHolder(
     var isEditTargetUserPinned by mutableStateOf(false)
 
     /**
+     * Zum Entfernen vorgemerkte Widgets (U3): das X-Badge markiert nur, erst der
+     * Speichern-Knopf loescht wirklich – Abbrechen (via [seedFrom]) und die
+     * Rueckgaengig-Pille stellen markierte Widgets verlustfrei wieder her.
+     */
+    val pendingWidgetRemovals = mutableStateListOf<Int>()
+
+    /** Merkt ein Widget zum Entfernen vor und hebt ggf. dessen Auswahl auf. */
+    fun markWidgetForRemoval(appWidgetId: Int) {
+        if (appWidgetId !in pendingWidgetRemovals) pendingWidgetRemovals.add(appWidgetId)
+        if (selectedEditTarget == HomeEditTarget.Widget(appWidgetId)) {
+            selectedEditTarget = null
+            isEditTargetUserPinned = false
+        }
+    }
+
+    /** Nimmt die Entfernen-Vormerkung zurueck (Rueckgaengig-Pille). */
+    fun undoWidgetRemoval(appWidgetId: Int) {
+        pendingWidgetRemovals.remove(appWidgetId)
+    }
+
+    fun isWidgetPendingRemoval(appWidgetId: Int): Boolean =
+        appWidgetId in pendingWidgetRemovals
+
+    /** Snapshot der Vormerkungen fuer den Speichern-Commit. */
+    fun pendingRemovalsSnapshot(): Set<Int> = pendingWidgetRemovals.toSet()
+
+    /**
      * Seedet die Live-Offsets aus dem persistierten Stand – beim Betreten des
      * Edit-Modus 1:1 übernehmen, Abbrechen revertiert damit automatisch.
      * Widget-Einträge werden synchronisiert: entfernte Widgets verschwinden
      * mitsamt Buchführung (und ggf. Auswahl) aus dem Holder.
      */
     fun seedFrom(layout: HomeLayout, widgets: List<HostedWidget> = emptyList()) {
+        pendingWidgetRemovals.clear()
         offsets[HomeEditTarget.Clock] = layout.clock
         offsets[HomeEditTarget.Date] = layout.date
         offsets[HomeEditTarget.Weather] = layout.weather
@@ -105,15 +134,22 @@ internal class HomeDragStateHolder(
         favorites = offsets[HomeEditTarget.Favorites] ?: Offset.Zero,
     )
 
-    /** Aktuelle Live-Offsets der gehosteten Widgets, keyed per appWidgetId (Speichern-Knopf). */
+    /**
+     * Aktuelle Live-Offsets der gehosteten Widgets, keyed per appWidgetId
+     * (Speichern-Knopf). Zum Entfernen vorgemerkte Widgets sind ausgenommen –
+     * fuer sie wird im selben Write keine Platzierung mehr persistiert.
+     */
     fun toWidgetOffsets(): Map<Int, Offset> = offsets.entries
         .mapNotNull { (target, offset) ->
-            (target as? HomeEditTarget.Widget)?.let { it.appWidgetId to offset }
+            (target as? HomeEditTarget.Widget)
+                ?.takeUnless { it.appWidgetId in pendingWidgetRemovals }
+                ?.let { it.appWidgetId to offset }
         }
         .toMap()
 
-    /** Aktuelle Live-Größen der gehosteten Widgets (Speichern-Knopf, B1-PR4). */
-    fun toWidgetSizes(): Map<Int, WidgetSizeDp> = widgetSizes.toMap()
+    /** Aktuelle Live-Größen der gehosteten Widgets (Speichern-Knopf, B1-PR4); ohne Vormerkungen. */
+    fun toWidgetSizes(): Map<Int, WidgetSizeDp> = widgetSizes
+        .filterKeys { it !in pendingWidgetRemovals }
 }
 
 /** Merkt sich den Holder über Recompositions hinweg (nicht über Config-Wechsel). */

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -10,7 +10,9 @@ import androidx.compose.animation.core.*
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.calculateZoom
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -21,11 +23,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material.icons.rounded.OpenInFull
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
-import androidx.compose.material.icons.rounded.SwapHoriz
-import androidx.compose.material.icons.rounded.SwapVert
 import androidx.compose.material3.*
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.*
@@ -67,7 +66,7 @@ import com.example.androidlauncher.data.HostedWidget
 import com.example.androidlauncher.data.SwipeGestureConfig
 import com.example.androidlauncher.data.WidgetResizeLimits
 import com.example.androidlauncher.data.WidgetSizeDp
-import com.example.androidlauncher.data.resolveResizeDrag
+import com.example.androidlauncher.data.resolveResizeZoom
 import com.example.androidlauncher.gesture.SwipeDirectionResolver
 import com.example.androidlauncher.launchShortcut
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
@@ -690,12 +689,19 @@ fun HomeScreen(
                     val widgetTarget = HomeEditTarget.Widget(widget.appWidgetId)
                     val isPendingRemoval = dragState.isWidgetPendingRemoval(widget.appWidgetId)
                     // Limits einmal pro Edit-Session cachen (U3): `widgetResizeLimits` fragt
-                    // providerInfo ab (System-Call) – nicht bei jedem Drag-Start wiederholen.
+                    // providerInfo ab (System-Call) – nicht bei jeder Geste wiederholen.
                     val resizeLimits = if (isEditMode) {
                         remember(widget.appWidgetId) { widgetResizeLimits(widget.appWidgetId) }
                     } else {
                         null
                     }
+                    // Resize-Feedback (U3): steuert Chip-Sichtbarkeit und Anschlag-Puls
+                    // der Pinch-Geste.
+                    var isResizing by remember { mutableStateOf(false) }
+                    var resizeClamped by remember { mutableStateOf(false) }
+                    // Vorab gefangen: im PointerInputScope würde `density` die
+                    // Scope-Property (Float) statt des äußeren LocalDensity treffen.
+                    val densityFactor = density.density
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopStart)
@@ -704,6 +710,99 @@ fun HomeScreen(
                             // Vorgemerkte Widgets sind eingefroren: kein Wiggle, kein Drag,
                             // keine Auswahl – nur die Rueckgaengig-Pille reagiert.
                             .then(if (isPendingRemoval) Modifier else Modifier.targetEditModifier(widgetTarget))
+                            // Pinch-to-Resize (U3): zwei Finger auf dem Widget skalieren es.
+                            // Steht in der Kette NACH dem Move-Drag und konsumiert damit im
+                            // Main-Pass zuerst – setzt der zweite Finger auf, bricht der
+                            // Ein-Finger-Drag sauber ab und die Geste wird zum Resize.
+                            .then(
+                                if (isEditMode && !isPendingRemoval && resizeLimits?.isResizable == true) {
+                                    Modifier.pointerInput(widgetTarget, resizeLimits) {
+                                        awaitEachGesture {
+                                            awaitFirstDown(requireUnconsumed = false)
+                                            var pinching = false
+                                            var startSize = WidgetSizeDp(widget.widthDp, widget.heightDp)
+                                            var zoomAcc = 1f
+                                            var lastTickMs = 0L
+                                            var lastTickedSize: WidgetSizeDp? = null
+                                            while (true) {
+                                                val event = awaitPointerEvent()
+                                                val pressed = event.changes.count { it.pressed }
+                                                if (pressed == 0) break
+                                                if (pressed >= 2) {
+                                                    if (!pinching) {
+                                                        pinching = true
+                                                        zoomAcc = 1f
+                                                        startSize = dragState.widgetSizes[widget.appWidgetId]
+                                                            ?: WidgetSizeDp(widget.widthDp, widget.heightDp)
+                                                        selectedEditTarget = widgetTarget
+                                                        isEditTargetUserPinned = true
+                                                        isResizing = true
+                                                        appHaptics.select()
+                                                    }
+                                                    zoomAcc *= event.calculateZoom()
+                                                    val result = resolveResizeZoom(
+                                                        startSize = startSize,
+                                                        zoom = zoomAcc,
+                                                        limits = resizeLimits,
+                                                    )
+                                                    dragState.widgetSizes[widget.appWidgetId] = result.size
+                                                    // Rand-Korrektur (U3): waechst das Widget ueber den
+                                                    // Bildschirmrand hinaus, zieht der Offset mit, damit
+                                                    // es komplett sichtbar (und greifbar) bleibt.
+                                                    dragState.neutralBounds[widgetTarget]?.let { neutral ->
+                                                        val cur = dragState.offsets[widgetTarget] ?: Offset.Zero
+                                                        val grownBounds = Rect(
+                                                            left = neutral.left,
+                                                            top = neutral.top,
+                                                            right = neutral.left + result.size.widthDp * densityFactor,
+                                                            bottom = neutral.top + result.size.heightDp * densityFactor,
+                                                        )
+                                                        val corrected = clampOffsetToBounds(
+                                                            bounds = grownBounds,
+                                                            rootWidth = rootSize.width,
+                                                            rootHeight = rootSize.height,
+                                                            topLimit = 0f,
+                                                            navigationBarHeightPx = navigationBarHeightPx,
+                                                            x = cur.x,
+                                                            y = cur.y,
+                                                        )
+                                                        if (corrected != cur) {
+                                                            dragState.offsets[widgetTarget] = corrected
+                                                        }
+                                                    }
+                                                    // Haptik (U3): deutlicher Impuls beim Erreichen eines
+                                                    // Limits, sonst gedrosseltes Ticken je Groessenaenderung.
+                                                    val clampedNow = result.clampedWidth || result.clampedHeight
+                                                    if (clampedNow && !resizeClamped) {
+                                                        appHaptics.confirm()
+                                                    }
+                                                    resizeClamped = clampedNow
+                                                    val now = SystemClock.uptimeMillis()
+                                                    if (result.size != lastTickedSize &&
+                                                        now - lastTickMs >= blockedDragHapticMinIntervalMs
+                                                    ) {
+                                                        appHaptics.select()
+                                                        lastTickMs = now
+                                                        lastTickedSize = result.size
+                                                    }
+                                                    event.changes.forEach { it.consume() }
+                                                } else if (pinching) {
+                                                    // Nach dem Pinch weiter konsumieren, bis alle Finger
+                                                    // oben sind – sonst springt das Widget dem letzten
+                                                    // Finger als Move-Drag hinterher.
+                                                    event.changes.forEach { it.consume() }
+                                                }
+                                            }
+                                            if (pinching) {
+                                                isResizing = false
+                                                resizeClamped = false
+                                            }
+                                        }
+                                    }
+                                } else {
+                                    Modifier
+                                }
+                            )
                     ) {
                         // Live-Größe aus dem Drag-State (Resize-Vorschau); Fallback: persistiert.
                         val liveSize = dragState.widgetSizes[widget.appWidgetId]
@@ -736,111 +835,24 @@ fun HomeScreen(
                             )
                         }
                         if (isEditMode && selectedEditTarget == widgetTarget && !isPendingRemoval) {
-                            // Resize-Handle (Ecke unten rechts) – nur wenn der Provider Resize
-                            // erlaubt (B1-PR4). Gesperrte Achsen sind in den Limits über
-                            // min == max abgebildet, der Drag dort ist ein No-Op; das Icon
-                            // zeigt den Achsen-Modus an (U3).
-                            if (resizeLimits != null && resizeLimits.isResizable) {
-                                val widthResizable = resizeLimits.maxWidthDp > resizeLimits.minWidthDp
-                                val heightResizable = resizeLimits.maxHeightDp > resizeLimits.minHeightDp
-                                var resizeStartSize by remember { mutableStateOf<WidgetSizeDp?>(null) }
-                                var resizeTotalDrag by remember { mutableStateOf(Offset.Zero) }
-                                var isResizing by remember { mutableStateOf(false) }
-                                var resizeClamped by remember { mutableStateOf(false) }
-                                var lastResizeTickMs by remember { mutableLongStateOf(0L) }
-                                var lastTickedSize by remember { mutableStateOf<WidgetSizeDp?>(null) }
-                                // Vorab gefangen: im PointerInputScope würde `density` die
-                                // Scope-Property (Float) statt des äußeren LocalDensity treffen.
-                                val densityFactor = density.density
-                                WidgetEditHandle(
-                                    icon = when {
-                                        widthResizable && heightResizable -> Icons.Rounded.OpenInFull
-                                        widthResizable -> Icons.Rounded.SwapHoriz
-                                        else -> Icons.Rounded.SwapVert
-                                    },
-                                    contentDescription = stringResource(
-                                        when {
-                                            widthResizable && heightResizable -> R.string.cd_resize_widget
-                                            widthResizable -> R.string.cd_resize_widget_horizontal
-                                            else -> R.string.cd_resize_widget_vertical
-                                        }
-                                    ),
-                                    modifier = Modifier
-                                        // Ragt über die Ecke hinaus: verdeckt weniger Widget-Inhalt,
-                                        // das 48.dp-Ziel bleibt trotzdem gut treffbar.
-                                        .align(Alignment.BottomEnd)
-                                        .offset(x = 10.dp, y = 10.dp)
-                                        .zIndex(10f)
-                                        .pointerInput(widgetTarget) {
-                                            detectDragGestures(
-                                                onDragStart = {
-                                                    resizeStartSize =
-                                                        dragState.widgetSizes[widget.appWidgetId]
-                                                            ?: WidgetSizeDp(widget.widthDp, widget.heightDp)
-                                                    resizeTotalDrag = Offset.Zero
-                                                    lastTickedSize = null
-                                                    isResizing = true
-                                                    appHaptics.select()
-                                                },
-                                                onDragEnd = {
-                                                    isResizing = false
-                                                    resizeClamped = false
-                                                },
-                                                onDragCancel = {
-                                                    isResizing = false
-                                                    resizeClamped = false
-                                                },
-                                                onDrag = { change, dragAmount ->
-                                                    change.consume()
-                                                    resizeTotalDrag += dragAmount
-                                                    val start = resizeStartSize ?: return@detectDragGestures
-                                                    val result = resolveResizeDrag(
-                                                        startSize = start,
-                                                        totalDragXDp = resizeTotalDrag.x / densityFactor,
-                                                        totalDragYDp = resizeTotalDrag.y / densityFactor,
-                                                        limits = resizeLimits,
-                                                    )
-                                                    dragState.widgetSizes[widget.appWidgetId] = result.size
-                                                    // Haptik (U3): deutlicher Impuls beim Erreichen
-                                                    // eines Limits, sonst gedrosseltes Ticken je
-                                                    // Groessenaenderung.
-                                                    val clampedNow = result.clampedWidth || result.clampedHeight
-                                                    if (clampedNow && !resizeClamped) {
-                                                        appHaptics.confirm()
-                                                    }
-                                                    resizeClamped = clampedNow
-                                                    val now = SystemClock.uptimeMillis()
-                                                    if (result.size != lastTickedSize &&
-                                                        now - lastResizeTickMs >= blockedDragHapticMinIntervalMs
-                                                    ) {
-                                                        appHaptics.select()
-                                                        lastResizeTickMs = now
-                                                        lastTickedSize = result.size
-                                                    }
-                                                }
-                                            )
-                                        }
-                                        .testTag("home_widget_resize_${widget.appWidgetId}"),
+                            // Live-Groessen-Chip (U3): zeigt „B × H dp" waehrend der
+                            // Pinch-Geste, pulsiert am Min/Max-Anschlag.
+                            AnimatedVisibility(
+                                visible = isResizing,
+                                enter = rememberMenuEnter(animationsEnabled, fromBottom = false),
+                                exit = rememberMenuExit(animationsEnabled, toBottom = false),
+                                modifier = Modifier
+                                    .align(Alignment.TopCenter)
+                                    .offset(y = (-40).dp)
+                                    .zIndex(12f)
+                            ) {
+                                val chipSize = dragState.widgetSizes[widget.appWidgetId]
+                                WidgetSizeChip(
+                                    widthDp = chipSize?.widthDp ?: widget.widthDp,
+                                    heightDp = chipSize?.heightDp ?: widget.heightDp,
+                                    clamped = resizeClamped,
+                                    modifier = Modifier.testTag("home_widget_size_label_${widget.appWidgetId}")
                                 )
-                                // Live-Groessen-Chip (U3): zeigt „B × H dp" waehrend des Drags,
-                                // pulsiert am Min/Max-Anschlag.
-                                AnimatedVisibility(
-                                    visible = isResizing,
-                                    enter = rememberMenuEnter(animationsEnabled, fromBottom = false),
-                                    exit = rememberMenuExit(animationsEnabled, toBottom = false),
-                                    modifier = Modifier
-                                        .align(Alignment.TopCenter)
-                                        .offset(y = (-40).dp)
-                                        .zIndex(12f)
-                                ) {
-                                    val chipSize = dragState.widgetSizes[widget.appWidgetId]
-                                    WidgetSizeChip(
-                                        widthDp = chipSize?.widthDp ?: widget.widthDp,
-                                        heightDp = chipSize?.heightDp ?: widget.heightDp,
-                                        clamped = resizeClamped,
-                                        modifier = Modifier.testTag("home_widget_size_label_${widget.appWidgetId}")
-                                    )
-                                }
                             }
                             // Entfernen-Badge (U3): merkt nur vor – gelöscht wird erst beim
                             // Speichern, Abbrechen/Rueckgaengig stellt das Widget wieder her.

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.OpenInFull
 import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.SwapHoriz
+import androidx.compose.material.icons.rounded.SwapVert
 import androidx.compose.material3.*
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.*
@@ -65,7 +67,7 @@ import com.example.androidlauncher.data.HostedWidget
 import com.example.androidlauncher.data.SwipeGestureConfig
 import com.example.androidlauncher.data.WidgetResizeLimits
 import com.example.androidlauncher.data.WidgetSizeDp
-import com.example.androidlauncher.data.applyResizeDrag
+import com.example.androidlauncher.data.resolveResizeDrag
 import com.example.androidlauncher.gesture.SwipeDirectionResolver
 import com.example.androidlauncher.launchShortcut
 import com.example.androidlauncher.ui.LiquidGlass.designSurface
@@ -125,8 +127,9 @@ fun HomeScreen(
     // B1: gehostete System-Widgets als frei verschiebbare Home-Objekte.
     hostedWidgets: List<HostedWidget> = emptyList(),
     widgetViewProvider: (Int) -> AppWidgetHostView? = { null },
-    onSaveWidgetLayout: (Map<Int, Offset>, Map<Int, WidgetSizeDp>) -> Unit = { _, _ -> },
-    onRemoveWidget: (Int) -> Unit = {},
+    // U3: dritter Parameter = zum Entfernen vorgemerkte Widget-IDs; das Entfernen
+    // laeuft damit ueber denselben Speichern-Commit wie Offsets und Groessen.
+    onSaveWidgetLayout: (Map<Int, Offset>, Map<Int, WidgetSizeDp>, Set<Int>) -> Unit = { _, _, _ -> },
     // B1-PR4: Resize-Grenzen je Widget (null = unbekannt/kein Resize, z. B. Preview).
     widgetResizeLimits: (Int) -> WidgetResizeLimits? = { null }
 ) {
@@ -140,7 +143,9 @@ fun HomeScreen(
     val surfaceAccent = colorTheme.menuSurfaceColor(isDarkTextEnabled)
     val haptic = androidx.compose.ui.platform.LocalHapticFeedback.current
     val hapticEnabled = LocalHapticFeedbackEnabled.current
+    val appHaptics = rememberAppHaptics()
     val animationsEnabled = LocalAnimationsEnabled.current
+    val animationSpeed = LocalAnimationSpeed.current
     val menuAnimationsEnabled = LocalMenuAnimationEnabled.current
     val density = androidx.compose.ui.platform.LocalDensity.current
 
@@ -683,111 +688,176 @@ fun HomeScreen(
             hostedWidgets.forEachIndexed { index, widget ->
                 key(widget.appWidgetId) {
                     val widgetTarget = HomeEditTarget.Widget(widget.appWidgetId)
+                    val isPendingRemoval = dragState.isWidgetPendingRemoval(widget.appWidgetId)
+                    // Limits einmal pro Edit-Session cachen (U3): `widgetResizeLimits` fragt
+                    // providerInfo ab (System-Call) – nicht bei jedem Drag-Start wiederholen.
+                    val resizeLimits = if (isEditMode) {
+                        remember(widget.appWidgetId) { widgetResizeLimits(widget.appWidgetId) }
+                    } else {
+                        null
+                    }
                     Box(
                         modifier = Modifier
                             .align(Alignment.TopStart)
                             .padding(top = 160.dp + (index * 24).dp)
                             .targetLayout(widgetTarget)
-                            .targetEditModifier(widgetTarget)
+                            // Vorgemerkte Widgets sind eingefroren: kein Wiggle, kein Drag,
+                            // keine Auswahl – nur die Rueckgaengig-Pille reagiert.
+                            .then(if (isPendingRemoval) Modifier else Modifier.targetEditModifier(widgetTarget))
                     ) {
                         // Live-Größe aus dem Drag-State (Resize-Vorschau); Fallback: persistiert.
                         val liveSize = dragState.widgetSizes[widget.appWidgetId]
-                        HostedWidgetView(
-                            widget = liveSize
-                                ?.let { widget.copy(widthDp = it.widthDp, heightDp = it.heightDp) }
-                                ?: widget,
-                            hostView = if (isPreview) null else widgetViewProvider(widget.appWidgetId),
-                            isEditMode = isEditMode,
+                        // Geister-Zustand (U3): vorgemerkte Widgets bleiben komponiert (die
+                        // Host-View behaelt ihren internen Zustand fuers Rueckgaengig), nur abgeblendet.
+                        val ghostAlpha by animateFloatAsState(
+                            targetValue = if (isPendingRemoval) 0.35f else 1f,
+                            animationSpec = if (animationsEnabled) RethroneSprings.effects(animationSpeed) else snap(),
+                            label = "widgetGhostAlpha"
                         )
-                        // Resize-Handle (Ecke unten rechts) am ausgewählten Widget – nur wenn
-                        // der Provider Resize erlaubt (B1-PR4). Gesperrte Achsen sind in den
-                        // Limits über min == max abgebildet, der Drag dort ist ein No-Op.
-                        if (isEditMode && selectedEditTarget == widgetTarget) {
-                            val resizable = remember(widgetTarget) {
-                                widgetResizeLimits(widget.appWidgetId)?.isResizable == true
-                            }
-                            if (resizable) {
+                        Box(modifier = Modifier.graphicsLayer { alpha = ghostAlpha }) {
+                            HostedWidgetView(
+                                widget = liveSize
+                                    ?.let { widget.copy(widthDp = it.widthDp, heightDp = it.heightDp) }
+                                    ?: widget,
+                                hostView = if (isPreview) null else widgetViewProvider(widget.appWidgetId),
+                                isEditMode = isEditMode,
+                            )
+                        }
+                        if (isPendingRemoval) {
+                            WidgetPendingRemovalOverlay(
+                                onUndo = {
+                                    appHaptics.tap()
+                                    dragState.undoWidgetRemoval(widget.appWidgetId)
+                                },
+                                modifier = Modifier
+                                    .matchParentSize()
+                                    .zIndex(11f),
+                                undoTestTag = "home_widget_undo_${widget.appWidgetId}"
+                            )
+                        }
+                        if (isEditMode && selectedEditTarget == widgetTarget && !isPendingRemoval) {
+                            // Resize-Handle (Ecke unten rechts) – nur wenn der Provider Resize
+                            // erlaubt (B1-PR4). Gesperrte Achsen sind in den Limits über
+                            // min == max abgebildet, der Drag dort ist ein No-Op; das Icon
+                            // zeigt den Achsen-Modus an (U3).
+                            if (resizeLimits != null && resizeLimits.isResizable) {
+                                val widthResizable = resizeLimits.maxWidthDp > resizeLimits.minWidthDp
+                                val heightResizable = resizeLimits.maxHeightDp > resizeLimits.minHeightDp
                                 var resizeStartSize by remember { mutableStateOf<WidgetSizeDp?>(null) }
-                                var resizeLimits by remember { mutableStateOf<WidgetResizeLimits?>(null) }
                                 var resizeTotalDrag by remember { mutableStateOf(Offset.Zero) }
+                                var isResizing by remember { mutableStateOf(false) }
+                                var resizeClamped by remember { mutableStateOf(false) }
+                                var lastResizeTickMs by remember { mutableLongStateOf(0L) }
+                                var lastTickedSize by remember { mutableStateOf<WidgetSizeDp?>(null) }
                                 // Vorab gefangen: im PointerInputScope würde `density` die
                                 // Scope-Property (Float) statt des äußeren LocalDensity treffen.
                                 val densityFactor = density.density
-                                Box(
+                                WidgetEditHandle(
+                                    icon = when {
+                                        widthResizable && heightResizable -> Icons.Rounded.OpenInFull
+                                        widthResizable -> Icons.Rounded.SwapHoriz
+                                        else -> Icons.Rounded.SwapVert
+                                    },
+                                    contentDescription = stringResource(
+                                        when {
+                                            widthResizable && heightResizable -> R.string.cd_resize_widget
+                                            widthResizable -> R.string.cd_resize_widget_horizontal
+                                            else -> R.string.cd_resize_widget_vertical
+                                        }
+                                    ),
                                     modifier = Modifier
+                                        // Ragt über die Ecke hinaus: verdeckt weniger Widget-Inhalt,
+                                        // das 48.dp-Ziel bleibt trotzdem gut treffbar.
                                         .align(Alignment.BottomEnd)
+                                        .offset(x = 10.dp, y = 10.dp)
                                         .zIndex(10f)
-                                        .size(28.dp)
-                                        .clip(CircleShape)
-                                        .designSurface(
-                                            designStyle,
-                                            CircleShape,
-                                            isDarkTextEnabled,
-                                            surfaceAccent,
-                                            fillAlpha = 0.5f
-                                        )
                                         .pointerInput(widgetTarget) {
                                             detectDragGestures(
                                                 onDragStart = {
                                                     resizeStartSize =
                                                         dragState.widgetSizes[widget.appWidgetId]
                                                             ?: WidgetSizeDp(widget.widthDp, widget.heightDp)
-                                                    resizeLimits = widgetResizeLimits(widget.appWidgetId)
                                                     resizeTotalDrag = Offset.Zero
+                                                    lastTickedSize = null
+                                                    isResizing = true
+                                                    appHaptics.select()
+                                                },
+                                                onDragEnd = {
+                                                    isResizing = false
+                                                    resizeClamped = false
+                                                },
+                                                onDragCancel = {
+                                                    isResizing = false
+                                                    resizeClamped = false
                                                 },
                                                 onDrag = { change, dragAmount ->
                                                     change.consume()
                                                     resizeTotalDrag += dragAmount
                                                     val start = resizeStartSize ?: return@detectDragGestures
-                                                    val limits = resizeLimits ?: return@detectDragGestures
-                                                    dragState.widgetSizes[widget.appWidgetId] =
-                                                        applyResizeDrag(
-                                                            startSize = start,
-                                                            totalDragXDp = resizeTotalDrag.x / densityFactor,
-                                                            totalDragYDp = resizeTotalDrag.y / densityFactor,
-                                                            limits = limits,
-                                                        )
+                                                    val result = resolveResizeDrag(
+                                                        startSize = start,
+                                                        totalDragXDp = resizeTotalDrag.x / densityFactor,
+                                                        totalDragYDp = resizeTotalDrag.y / densityFactor,
+                                                        limits = resizeLimits,
+                                                    )
+                                                    dragState.widgetSizes[widget.appWidgetId] = result.size
+                                                    // Haptik (U3): deutlicher Impuls beim Erreichen
+                                                    // eines Limits, sonst gedrosseltes Ticken je
+                                                    // Groessenaenderung.
+                                                    val clampedNow = result.clampedWidth || result.clampedHeight
+                                                    if (clampedNow && !resizeClamped) {
+                                                        appHaptics.confirm()
+                                                    }
+                                                    resizeClamped = clampedNow
+                                                    val now = SystemClock.uptimeMillis()
+                                                    if (result.size != lastTickedSize &&
+                                                        now - lastResizeTickMs >= blockedDragHapticMinIntervalMs
+                                                    ) {
+                                                        appHaptics.select()
+                                                        lastResizeTickMs = now
+                                                        lastTickedSize = result.size
+                                                    }
                                                 }
                                             )
                                         }
                                         .testTag("home_widget_resize_${widget.appWidgetId}"),
-                                    contentAlignment = Alignment.Center
+                                )
+                                // Live-Groessen-Chip (U3): zeigt „B × H dp" waehrend des Drags,
+                                // pulsiert am Min/Max-Anschlag.
+                                AnimatedVisibility(
+                                    visible = isResizing,
+                                    enter = rememberMenuEnter(animationsEnabled, fromBottom = false),
+                                    exit = rememberMenuExit(animationsEnabled, toBottom = false),
+                                    modifier = Modifier
+                                        .align(Alignment.TopCenter)
+                                        .offset(y = (-40).dp)
+                                        .zIndex(12f)
                                 ) {
-                                    Icon(
-                                        imageVector = Icons.Rounded.OpenInFull,
-                                        contentDescription = stringResource(R.string.cd_resize_widget),
-                                        tint = mainTextColor,
-                                        modifier = Modifier.size(14.dp)
+                                    val chipSize = dragState.widgetSizes[widget.appWidgetId]
+                                    WidgetSizeChip(
+                                        widthDp = chipSize?.widthDp ?: widget.widthDp,
+                                        heightDp = chipSize?.heightDp ?: widget.heightDp,
+                                        clamped = resizeClamped,
+                                        modifier = Modifier.testTag("home_widget_size_label_${widget.appWidgetId}")
                                     )
                                 }
                             }
-                        }
-                        // Entfernen-Badge am ausgewählten Widget (nur im Edit-Modus).
-                        if (isEditMode && selectedEditTarget == widgetTarget) {
-                            Box(
+                            // Entfernen-Badge (U3): merkt nur vor – gelöscht wird erst beim
+                            // Speichern, Abbrechen/Rueckgaengig stellt das Widget wieder her.
+                            WidgetEditHandle(
+                                icon = Icons.Rounded.Close,
+                                contentDescription = stringResource(R.string.cd_remove_widget),
                                 modifier = Modifier
                                     .align(Alignment.TopEnd)
+                                    .offset(x = 10.dp, y = (-10).dp)
                                     .zIndex(10f)
-                                    .size(28.dp)
                                     .clip(CircleShape)
-                                    .designSurface(
-                                        designStyle,
-                                        CircleShape,
-                                        isDarkTextEnabled,
-                                        surfaceAccent,
-                                        fillAlpha = 0.5f
-                                    )
-                                    .clickable { onRemoveWidget(widget.appWidgetId) }
+                                    .clickable {
+                                        appHaptics.tap()
+                                        dragState.markWidgetForRemoval(widget.appWidgetId)
+                                    }
                                     .testTag("home_widget_remove_${widget.appWidgetId}"),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Close,
-                                    contentDescription = stringResource(R.string.cd_remove_widget),
-                                    tint = mainTextColor,
-                                    modifier = Modifier.size(18.dp)
-                                )
-                            }
+                            )
                         }
                     }
                 }
@@ -1020,7 +1090,11 @@ fun HomeScreen(
                         onClick = {
                             updateCollisionFeedback(false)
                             onSaveHomeLayout(dragState.toHomeLayout())
-                            onSaveWidgetLayout(dragState.toWidgetOffsets(), dragState.toWidgetSizes())
+                            onSaveWidgetLayout(
+                                dragState.toWidgetOffsets(),
+                                dragState.toWidgetSizes(),
+                                dragState.pendingRemovalsSnapshot(),
+                            )
                             Toast.makeText(
                                 context,
                                 context.getString(R.string.position_saved),

--- a/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HomeScreen.kt
@@ -719,7 +719,11 @@ fun HomeScreen(
                                     Modifier.pointerInput(widgetTarget, resizeLimits) {
                                         awaitEachGesture {
                                             awaitFirstDown(requireUnconsumed = false)
-                                            var pinching = false
+                                            // pinchActive = gerade >=2 Finger unten; wird beim Abheben
+                                            // eines Fingers zurueckgesetzt, damit ein erneutes Aufsetzen
+                                            // mit frischer Basis (aktuelle Groesse, Faktor 1) startet.
+                                            var pinchActive = false
+                                            var pinchedThisGesture = false
                                             var startSize = WidgetSizeDp(widget.widthDp, widget.heightDp)
                                             var zoomAcc = 1f
                                             var lastTickMs = 0L
@@ -729,15 +733,18 @@ fun HomeScreen(
                                                 val pressed = event.changes.count { it.pressed }
                                                 if (pressed == 0) break
                                                 if (pressed >= 2) {
-                                                    if (!pinching) {
-                                                        pinching = true
+                                                    if (!pinchActive) {
+                                                        pinchActive = true
                                                         zoomAcc = 1f
                                                         startSize = dragState.widgetSizes[widget.appWidgetId]
                                                             ?: WidgetSizeDp(widget.widthDp, widget.heightDp)
-                                                        selectedEditTarget = widgetTarget
-                                                        isEditTargetUserPinned = true
-                                                        isResizing = true
-                                                        appHaptics.select()
+                                                        if (!pinchedThisGesture) {
+                                                            pinchedThisGesture = true
+                                                            selectedEditTarget = widgetTarget
+                                                            isEditTargetUserPinned = true
+                                                            isResizing = true
+                                                            appHaptics.select()
+                                                        }
                                                     }
                                                     zoomAcc *= event.calculateZoom()
                                                     val result = resolveResizeZoom(
@@ -745,6 +752,10 @@ fun HomeScreen(
                                                         zoom = zoomAcc,
                                                         limits = resizeLimits,
                                                     )
+                                                    // Akkumulator zurueckklemmen: sonst laeuft er am
+                                                    // Anschlag davon und das Reinziehen haette eine
+                                                    // tote Zone (nicht mehr kleinziehbar).
+                                                    zoomAcc = result.appliedZoom
                                                     dragState.widgetSizes[widget.appWidgetId] = result.size
                                                     // Rand-Korrektur (U3): waechst das Widget ueber den
                                                     // Bildschirmrand hinaus, zieht der Offset mit, damit
@@ -786,14 +797,17 @@ fun HomeScreen(
                                                         lastTickedSize = result.size
                                                     }
                                                     event.changes.forEach { it.consume() }
-                                                } else if (pinching) {
-                                                    // Nach dem Pinch weiter konsumieren, bis alle Finger
-                                                    // oben sind – sonst springt das Widget dem letzten
-                                                    // Finger als Move-Drag hinterher.
-                                                    event.changes.forEach { it.consume() }
+                                                } else {
+                                                    pinchActive = false
+                                                    if (pinchedThisGesture) {
+                                                        // Nach dem Pinch weiter konsumieren, bis alle
+                                                        // Finger oben sind – sonst springt das Widget dem
+                                                        // letzten Finger als Move-Drag hinterher.
+                                                        event.changes.forEach { it.consume() }
+                                                    }
                                                 }
                                             }
-                                            if (pinching) {
+                                            if (pinchedThisGesture) {
                                                 isResizing = false
                                                 resizeClamped = false
                                             }

--- a/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.example.androidlauncher.data.HostedWidget
-import kotlin.math.roundToInt
 
 /**
  * Compose-Wrapper um eine [AppWidgetHostView] (B1). Die Host-View kommt gecacht aus
@@ -52,12 +51,6 @@ fun HostedWidgetView(
         },
         update = { frame ->
             frame.blockTouches = isEditMode
-            // Gewuenschte Groesse spec-unabhaengig in px an den Frame geben (siehe
-            // BlockableFrameLayout.onMeasure) – nur so schrumpft das Widget wieder.
-            val d = frame.resources.displayMetrics.density
-            frame.desiredWidthPx = (widget.widthDp * d).roundToInt()
-            frame.desiredHeightPx = (widget.heightDp * d).roundToInt()
-            frame.requestLayout()
             updateAppWidgetSizeCompat(hostView, widget.widthDp, widget.heightDp)
         },
         modifier = modifier
@@ -87,27 +80,6 @@ private fun updateAppWidgetSizeCompat(hostView: AppWidgetHostView, widthDp: Int,
 private class BlockableFrameLayout(context: Context) : FrameLayout(context) {
 
     var blockTouches = false
-
-    /** Vom Compose-`update`-Block gesetzte Zielgroesse in px (0 = noch nicht gesetzt). */
-    var desiredWidthPx = 0
-    var desiredHeightPx = 0
-
-    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        // Groesse spec-unabhaengig erzwingen: AppWidgetHostView meldet beim
-        // Verkleinern eine groessere Content-Min, und der AndroidView-Holder reicht
-        // dem Kind nicht zwingend EXACTLY-Specs durch -> die View wuerde sonst nicht
-        // schrumpfen ("wird groesser, uebernimmt die kleine Version nicht").
-        if (desiredWidthPx > 0 && desiredHeightPx > 0) {
-            val childWidthSpec = MeasureSpec.makeMeasureSpec(desiredWidthPx, MeasureSpec.EXACTLY)
-            val childHeightSpec = MeasureSpec.makeMeasureSpec(desiredHeightPx, MeasureSpec.EXACTLY)
-            for (i in 0 until childCount) {
-                getChildAt(i).measure(childWidthSpec, childHeightSpec)
-            }
-            setMeasuredDimension(desiredWidthPx, desiredHeightPx)
-        } else {
-            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
-        }
-    }
 
     override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean =
         blockTouches || super.onInterceptTouchEvent(ev)

--- a/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
@@ -12,6 +12,7 @@ import android.widget.FrameLayout
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.example.androidlauncher.data.HostedWidget
@@ -52,7 +53,9 @@ fun HostedWidgetView(
             frame.blockTouches = isEditMode
             updateAppWidgetSizeCompat(hostView, widget.widthDp, widget.heightDp)
         },
-        modifier = modifier.size(widget.widthDp.dp, widget.heightDp.dp)
+        modifier = modifier
+            .size(widget.widthDp.dp, widget.heightDp.dp)
+            .clipToBounds()
     )
 }
 
@@ -77,6 +80,28 @@ private fun updateAppWidgetSizeCompat(hostView: AppWidgetHostView, widthDp: Int,
 private class BlockableFrameLayout(context: Context) : FrameLayout(context) {
 
     var blockTouches = false
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        // Compose liefert via Modifier.size() EXACTLY-Specs. AppWidgetHostView meldet
+        // beim Verkleinern gerne eine groessere measuredWidth/Height (Content-Min),
+        // wodurch das Widget im Compose-Layout zwar schrumpft, die View selbst aber
+        // nicht -> "wird groesser, uebernimmt die kleine Version nicht". Daher die
+        // angeforderte Groesse hart durchsetzen und die Kinder darauf messen.
+        if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
+            MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
+        ) {
+            val w = MeasureSpec.getSize(widthMeasureSpec)
+            val h = MeasureSpec.getSize(heightMeasureSpec)
+            val childWidthSpec = MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY)
+            val childHeightSpec = MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
+            for (i in 0 until childCount) {
+                getChildAt(i).measure(childWidthSpec, childHeightSpec)
+            }
+            setMeasuredDimension(w, h)
+        } else {
+            super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+        }
+    }
 
     override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean =
         blockTouches || super.onInterceptTouchEvent(ev)

--- a/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/HostedWidgetView.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.example.androidlauncher.data.HostedWidget
+import kotlin.math.roundToInt
 
 /**
  * Compose-Wrapper um eine [AppWidgetHostView] (B1). Die Host-View kommt gecacht aus
@@ -51,6 +52,12 @@ fun HostedWidgetView(
         },
         update = { frame ->
             frame.blockTouches = isEditMode
+            // Gewuenschte Groesse spec-unabhaengig in px an den Frame geben (siehe
+            // BlockableFrameLayout.onMeasure) – nur so schrumpft das Widget wieder.
+            val d = frame.resources.displayMetrics.density
+            frame.desiredWidthPx = (widget.widthDp * d).roundToInt()
+            frame.desiredHeightPx = (widget.heightDp * d).roundToInt()
+            frame.requestLayout()
             updateAppWidgetSizeCompat(hostView, widget.widthDp, widget.heightDp)
         },
         modifier = modifier
@@ -81,23 +88,22 @@ private class BlockableFrameLayout(context: Context) : FrameLayout(context) {
 
     var blockTouches = false
 
+    /** Vom Compose-`update`-Block gesetzte Zielgroesse in px (0 = noch nicht gesetzt). */
+    var desiredWidthPx = 0
+    var desiredHeightPx = 0
+
     override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
-        // Compose liefert via Modifier.size() EXACTLY-Specs. AppWidgetHostView meldet
-        // beim Verkleinern gerne eine groessere measuredWidth/Height (Content-Min),
-        // wodurch das Widget im Compose-Layout zwar schrumpft, die View selbst aber
-        // nicht -> "wird groesser, uebernimmt die kleine Version nicht". Daher die
-        // angeforderte Groesse hart durchsetzen und die Kinder darauf messen.
-        if (MeasureSpec.getMode(widthMeasureSpec) == MeasureSpec.EXACTLY &&
-            MeasureSpec.getMode(heightMeasureSpec) == MeasureSpec.EXACTLY
-        ) {
-            val w = MeasureSpec.getSize(widthMeasureSpec)
-            val h = MeasureSpec.getSize(heightMeasureSpec)
-            val childWidthSpec = MeasureSpec.makeMeasureSpec(w, MeasureSpec.EXACTLY)
-            val childHeightSpec = MeasureSpec.makeMeasureSpec(h, MeasureSpec.EXACTLY)
+        // Groesse spec-unabhaengig erzwingen: AppWidgetHostView meldet beim
+        // Verkleinern eine groessere Content-Min, und der AndroidView-Holder reicht
+        // dem Kind nicht zwingend EXACTLY-Specs durch -> die View wuerde sonst nicht
+        // schrumpfen ("wird groesser, uebernimmt die kleine Version nicht").
+        if (desiredWidthPx > 0 && desiredHeightPx > 0) {
+            val childWidthSpec = MeasureSpec.makeMeasureSpec(desiredWidthPx, MeasureSpec.EXACTLY)
+            val childHeightSpec = MeasureSpec.makeMeasureSpec(desiredHeightPx, MeasureSpec.EXACTLY)
             for (i in 0 until childCount) {
                 getChildAt(i).measure(childWidthSpec, childHeightSpec)
             }
-            setMeasuredDimension(w, h)
+            setMeasuredDimension(desiredWidthPx, desiredHeightPx)
         } else {
             super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         }

--- a/app/src/main/java/com/example/androidlauncher/ui/WidgetEditChrome.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/WidgetEditChrome.kt
@@ -1,0 +1,199 @@
+package com.example.androidlauncher.ui
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.snap
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Undo
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.androidlauncher.R
+import com.example.androidlauncher.ui.LiquidGlass.designSurface
+import com.example.androidlauncher.ui.theme.LocalAnimationSpeed
+import com.example.androidlauncher.ui.theme.LocalAnimationsEnabled
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalDesignStyle
+import com.example.androidlauncher.ui.theme.LocalHomeTextColor
+import com.example.androidlauncher.ui.theme.RethroneSprings
+
+/**
+ * Gemeinsame Edit-Chrome der gehosteten Widgets (U3): Eck-Handles mit
+ * A11y-tauglicher Treffflaeche, Live-Groessen-Chip und Vormerkungs-Overlay
+ * fuers Entfernen. Ersetzt die zwei handgebauten 28.dp-Kreise aus B1-PR4.
+ */
+
+/**
+ * Eck-Handle der Widget-Edit-Chrome: [touchTarget] grosse Treffbox (48.dp =
+ * A11y-Minimum) um einen kleineren sichtbaren Kreis. Gesten/Klicks/testTag
+ * haengt der Aufrufer per [modifier] an – die landen auf der Treffbox, sodass
+ * die volle Flaeche reagiert, waehrend die Optik kompakt bleibt.
+ */
+@Composable
+internal fun WidgetEditHandle(
+    icon: ImageVector,
+    contentDescription: String,
+    modifier: Modifier = Modifier,
+    touchTarget: Dp = 48.dp,
+    visualSize: Dp = 32.dp,
+    iconSize: Dp = 16.dp,
+) {
+    val designStyle = LocalDesignStyle.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+
+    Box(
+        modifier = modifier.size(touchTarget),
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = Modifier
+                .size(visualSize)
+                .clip(CircleShape)
+                .designSurface(designStyle, CircleShape, isDarkTextEnabled, surfaceAccent, fillAlpha = 0.5f),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = contentDescription,
+                tint = LocalHomeTextColor.current,
+                modifier = Modifier.size(iconSize)
+            )
+        }
+    }
+}
+
+/**
+ * Live-Groessen-Chip waehrend des Resize-Drags: „B × H dp". Am Min/Max-Anschlag
+ * ([clamped]) pulsiert die Pille kurz und der Text springt auf die Akzentfarbe –
+ * ohne Animationen nur der (instant geschaltete) Farbwechsel.
+ */
+@Composable
+internal fun WidgetSizeChip(
+    widthDp: Int,
+    heightDp: Int,
+    clamped: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val designStyle = LocalDesignStyle.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val colorTheme = LocalColorTheme.current
+    val surfaceAccent = colorTheme.menuSurfaceColor(isDarkTextEnabled)
+    val animationsEnabled = LocalAnimationsEnabled.current
+    val speed = LocalAnimationSpeed.current
+
+    val scale by animateFloatAsState(
+        targetValue = if (clamped && animationsEnabled) 1.08f else 1f,
+        animationSpec = if (animationsEnabled) RethroneSprings.spatial(speed) else snap(),
+        label = "widgetSizeChipScale"
+    )
+    val textColor by animateColorAsState(
+        targetValue = if (clamped) colorTheme.accentColor(isDarkTextEnabled) else LocalHomeTextColor.current,
+        animationSpec = if (animationsEnabled) RethroneSprings.effects(speed) else snap(),
+        label = "widgetSizeChipColor"
+    )
+
+    Box(
+        modifier = modifier
+            .graphicsLayer {
+                scaleX = scale
+                scaleY = scale
+            }
+            .clip(RoundedCornerShape(50))
+            .designSurface(designStyle, RoundedCornerShape(50), isDarkTextEnabled, surfaceAccent, fillAlpha = 0.6f)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.widget_size_label, widthDp, heightDp),
+            color = textColor,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+/**
+ * Geister-Overlay eines zum Entfernen vorgemerkten Widgets: Scrim ueber der
+ * (ausgeblendeten) Widget-Flaeche, Hinweis-Label und eine Rueckgaengig-Pille.
+ * Der Aufrufer liefert per [modifier] `matchParentSize` + zIndex.
+ */
+@Composable
+internal fun WidgetPendingRemovalOverlay(
+    onUndo: () -> Unit,
+    modifier: Modifier = Modifier,
+    undoTestTag: String? = null,
+) {
+    val designStyle = LocalDesignStyle.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+    val textColor = LocalHomeTextColor.current
+    val overlayShape = RoundedCornerShape(20.dp)
+
+    Box(
+        modifier = modifier
+            .clip(overlayShape)
+            .designSurface(designStyle, overlayShape, isDarkTextEnabled, surfaceAccent, fillAlpha = 0.35f),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = stringResource(R.string.widget_pending_removal),
+                color = textColor.copy(alpha = 0.8f),
+                fontSize = 12.sp
+            )
+            Row(
+                modifier = Modifier
+                    .padding(top = 6.dp)
+                    .clip(RoundedCornerShape(50))
+                    .designSurface(
+                        designStyle,
+                        RoundedCornerShape(50),
+                        isDarkTextEnabled,
+                        surfaceAccent,
+                        fillAlpha = 0.6f
+                    )
+                    .then(if (undoTestTag != null) Modifier.testTag(undoTestTag) else Modifier)
+                    .clickable(onClick = onUndo)
+                    .defaultMinSize(minHeight = 48.dp)
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Undo,
+                    contentDescription = null,
+                    tint = textColor,
+                    modifier = Modifier.size(16.dp)
+                )
+                Text(
+                    text = stringResource(R.string.undo_remove_widget),
+                    color = textColor,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(start = 6.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/WidgetPickerSheet.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/WidgetPickerSheet.kt
@@ -60,6 +60,7 @@ import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalDesignStyle
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import kotlin.math.roundToInt
 
 /** Ein anbietbares Widget eines Providers (Label vorab geladen, Preview lazy pro Zeile). */
 internal data class WidgetPickerEntry(
@@ -307,7 +308,12 @@ private fun WidgetPickerWidgetRow(
             fontWeight = FontWeight.Normal
         )
         Text(
-            text = "${entry.info.minWidth} × ${entry.info.minHeight} dp",
+            // minWidth/minHeight sind in px – fuer die dp-Anzeige zurueckrechnen.
+            text = run {
+                val dens = context.resources.displayMetrics.density
+                "${(entry.info.minWidth / dens).roundToInt()} × " +
+                    "${(entry.info.minHeight / dens).roundToInt()} dp"
+            },
             color = mainTextColor.copy(alpha = 0.5f),
             fontSize = 13.sp
         )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -147,6 +147,10 @@
     <string name="widget_bind_failed">Widget konnte nicht hinzugefügt werden</string>
     <string name="cd_remove_widget">Widget entfernen</string>
     <string name="cd_resize_widget">Widget-Größe ändern</string>
+    <string name="cd_resize_widget_horizontal">Widget-Breite ändern</string>
+    <string name="cd_resize_widget_vertical">Widget-Höhe ändern</string>
+    <string name="widget_pending_removal">Wird beim Speichern entfernt</string>
+    <string name="undo_remove_widget">Rückgängig</string>
     <string name="icon_pack_section_title">Icon-Pack</string>
     <string name="icon_pack_system_default">System-Icons</string>
     <string name="icon_pack_system_default_sub">Standard-App-Icons ohne Pack</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -146,9 +146,6 @@
     <string name="widget_picker_empty">Keine Widgets gefunden</string>
     <string name="widget_bind_failed">Widget konnte nicht hinzugefügt werden</string>
     <string name="cd_remove_widget">Widget entfernen</string>
-    <string name="cd_resize_widget">Widget-Größe ändern</string>
-    <string name="cd_resize_widget_horizontal">Widget-Breite ändern</string>
-    <string name="cd_resize_widget_vertical">Widget-Höhe ändern</string>
     <string name="widget_pending_removal">Wird beim Speichern entfernt</string>
     <string name="undo_remove_widget">Rückgängig</string>
     <string name="icon_pack_section_title">Icon-Pack</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -132,6 +132,10 @@
     <string name="widget_bind_failed">No se pudo añadir el widget</string>
     <string name="cd_remove_widget">Quitar el widget</string>
     <string name="cd_resize_widget">Cambiar tamaño del widget</string>
+    <string name="cd_resize_widget_horizontal">Cambiar el ancho del widget</string>
+    <string name="cd_resize_widget_vertical">Cambiar la altura del widget</string>
+    <string name="widget_pending_removal">Se quitará al guardar</string>
+    <string name="undo_remove_widget">Deshacer</string>
     <string name="icon_pack_section_title">Paquete de iconos</string>
     <string name="icon_pack_system_default">Iconos del sistema</string>
     <string name="icon_pack_system_default_sub">Iconos de apps por defecto, sin paquete</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -131,9 +131,6 @@
     <string name="widget_picker_empty">No se encontraron widgets</string>
     <string name="widget_bind_failed">No se pudo añadir el widget</string>
     <string name="cd_remove_widget">Quitar el widget</string>
-    <string name="cd_resize_widget">Cambiar tamaño del widget</string>
-    <string name="cd_resize_widget_horizontal">Cambiar el ancho del widget</string>
-    <string name="cd_resize_widget_vertical">Cambiar la altura del widget</string>
     <string name="widget_pending_removal">Se quitará al guardar</string>
     <string name="undo_remove_widget">Deshacer</string>
     <string name="icon_pack_section_title">Paquete de iconos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -132,6 +132,10 @@
     <string name="widget_bind_failed">Impossible d\'ajouter le widget</string>
     <string name="cd_remove_widget">Retirer le widget</string>
     <string name="cd_resize_widget">Redimensionner le widget</string>
+    <string name="cd_resize_widget_horizontal">Modifier la largeur du widget</string>
+    <string name="cd_resize_widget_vertical">Modifier la hauteur du widget</string>
+    <string name="widget_pending_removal">Retiré à l\'enregistrement</string>
+    <string name="undo_remove_widget">Annuler</string>
     <string name="icon_pack_section_title">Pack d\'icônes</string>
     <string name="icon_pack_system_default">Icônes système</string>
     <string name="icon_pack_system_default_sub">Icônes d\'apps par défaut, sans pack</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -131,9 +131,6 @@
     <string name="widget_picker_empty">Aucun widget trouvé</string>
     <string name="widget_bind_failed">Impossible d\'ajouter le widget</string>
     <string name="cd_remove_widget">Retirer le widget</string>
-    <string name="cd_resize_widget">Redimensionner le widget</string>
-    <string name="cd_resize_widget_horizontal">Modifier la largeur du widget</string>
-    <string name="cd_resize_widget_vertical">Modifier la hauteur du widget</string>
     <string name="widget_pending_removal">Retiré à l\'enregistrement</string>
     <string name="undo_remove_widget">Annuler</string>
     <string name="icon_pack_section_title">Pack d\'icônes</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -131,9 +131,6 @@
     <string name="widget_picker_empty">Nessun widget trovato</string>
     <string name="widget_bind_failed">Impossibile aggiungere il widget</string>
     <string name="cd_remove_widget">Rimuovi widget</string>
-    <string name="cd_resize_widget">Ridimensiona widget</string>
-    <string name="cd_resize_widget_horizontal">Modifica larghezza del widget</string>
-    <string name="cd_resize_widget_vertical">Modifica altezza del widget</string>
     <string name="widget_pending_removal">Rimosso al salvataggio</string>
     <string name="undo_remove_widget">Annulla</string>
     <string name="icon_pack_section_title">Icon pack</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -132,6 +132,10 @@
     <string name="widget_bind_failed">Impossibile aggiungere il widget</string>
     <string name="cd_remove_widget">Rimuovi widget</string>
     <string name="cd_resize_widget">Ridimensiona widget</string>
+    <string name="cd_resize_widget_horizontal">Modifica larghezza del widget</string>
+    <string name="cd_resize_widget_vertical">Modifica altezza del widget</string>
+    <string name="widget_pending_removal">Rimosso al salvataggio</string>
+    <string name="undo_remove_widget">Annulla</string>
     <string name="icon_pack_section_title">Icon pack</string>
     <string name="icon_pack_system_default">Icone di sistema</string>
     <string name="icon_pack_system_default_sub">Icone predefinite delle app, senza pack</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -147,6 +147,11 @@
     <string name="widget_bind_failed">Widget could not be added</string>
     <string name="cd_remove_widget">Remove widget</string>
     <string name="cd_resize_widget">Resize widget</string>
+    <string name="cd_resize_widget_horizontal">Resize widget width</string>
+    <string name="cd_resize_widget_vertical">Resize widget height</string>
+    <string name="widget_size_label" translatable="false">%1$d × %2$d dp</string>
+    <string name="widget_pending_removal">Removed when you save</string>
+    <string name="undo_remove_widget">Undo</string>
     <string name="icon_pack_section_title">Icon pack</string>
     <string name="icon_pack_system_default">System icons</string>
     <string name="icon_pack_system_default_sub">Default app icons without a pack</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,9 +146,6 @@
     <string name="widget_picker_empty">No widgets found</string>
     <string name="widget_bind_failed">Widget could not be added</string>
     <string name="cd_remove_widget">Remove widget</string>
-    <string name="cd_resize_widget">Resize widget</string>
-    <string name="cd_resize_widget_horizontal">Resize widget width</string>
-    <string name="cd_resize_widget_vertical">Resize widget height</string>
     <string name="widget_size_label" translatable="false">%1$d × %2$d dp</string>
     <string name="widget_pending_removal">Removed when you save</string>
     <string name="undo_remove_widget">Undo</string>

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetHostManagerTest.kt
@@ -132,6 +132,52 @@ class WidgetHostManagerTest {
         assertEquals(widget(3), result.first { it.appWidgetId == 3 })
     }
 
+    // --- U3: vorgemerkte Loeschungen im Save-Commit ---
+
+    @Test
+    fun `updateWidgetPlacement commits placement and removals in one write`() = testScope.runTest {
+        every { host.deleteAppWidgetId(any()) } just Runs
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+
+        manager.updateWidgetPlacement(
+            offsets = mapOf(1 to Offset(15f, -25f)),
+            sizes = mapOf(1 to WidgetSizeDp(250, 140)),
+            removedIds = setOf(2),
+        )
+
+        val result = manager.widgets.first()
+        assertEquals(
+            listOf(widget(1).copy(offsetX = 15f, offsetY = -25f, widthDp = 250, heightDp = 140)),
+            result,
+        )
+        verify { host.deleteAppWidgetId(2) }
+        verify(exactly = 0) { host.deleteAppWidgetId(1) }
+    }
+
+    @Test
+    fun `updateWidgetPlacement with removals only still passes the early-return guard`() = testScope.runTest {
+        every { host.deleteAppWidgetId(any()) } just Runs
+        manager.addWidget(widget(1))
+        manager.addWidget(widget(2))
+
+        manager.updateWidgetPlacement(offsets = emptyMap(), sizes = emptyMap(), removedIds = setOf(1))
+
+        assertEquals(listOf(widget(2)), manager.widgets.first())
+        verify { host.deleteAppWidgetId(1) }
+    }
+
+    @Test
+    fun `updateWidgetPlacement removing an unknown id is harmless but frees the host id`() = testScope.runTest {
+        every { host.deleteAppWidgetId(any()) } just Runs
+        manager.addWidget(widget(1))
+
+        manager.updateWidgetPlacement(offsets = emptyMap(), sizes = emptyMap(), removedIds = setOf(99))
+
+        assertEquals(listOf(widget(1)), manager.widgets.first())
+        verify { host.deleteAppWidgetId(99) }
+    }
+
     @Test
     fun `cleanupOrphans deletes leaked ids and prunes uninstalled providers`() = testScope.runTest {
         every { host.deleteAppWidgetId(any()) } just Runs

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
@@ -129,4 +129,70 @@ class WidgetResizeTest {
 
         assertEquals(WidgetSizeDp(180, 210), applyResizeDrag(start, 999f, 100f, limits))
     }
+
+    // --- U3: Anschlag-Information fuer Haptik/Chip-Puls ---
+
+    @Test
+    fun `resolveResizeDrag within the range reports no clamping`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        val result = resolveResizeDrag(start, 20f, 20f, limits)
+
+        assertEquals(WidgetSizeDp(200, 130), result.size)
+        assertFalse(result.clampedWidth)
+        assertFalse(result.clampedHeight)
+    }
+
+    @Test
+    fun `resolveResizeDrag past max width reports width clamped`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        val result = resolveResizeDrag(start, 500f, 0f, limits)
+
+        assertEquals(WidgetSizeDp(320, 110), result.size)
+        assertTrue(result.clampedWidth)
+        assertFalse(result.clampedHeight)
+    }
+
+    @Test
+    fun `resolveResizeDrag below min height reports height clamped`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        val result = resolveResizeDrag(start, 0f, -500f, limits)
+
+        assertEquals(WidgetSizeDp(180, 60), result.size)
+        assertFalse(result.clampedWidth)
+        assertTrue(result.clampedHeight)
+    }
+
+    @Test
+    fun `locked axis never reports clamped even when pushed hard`() {
+        // Sonst wuerde jeder Diagonal-Drag an einem nur-vertikal skalierbaren
+        // Widget dauerhaft die Anschlag-Haptik ausloesen.
+        val limits = WidgetResizeLimits(180, 180, 60, 300)
+        val start = WidgetSizeDp(180, 110)
+
+        val result = resolveResizeDrag(start, 999f, 100f, limits)
+
+        assertEquals(WidgetSizeDp(180, 210), result.size)
+        assertFalse(result.clampedWidth)
+        assertFalse(result.clampedHeight)
+    }
+
+    @Test
+    fun `landing exactly on the limit does not count as clamped`() {
+        // Erst der Versuch, DARUEBER hinaus zu ziehen, meldet den Anschlag – die
+        // Haptik feuert damit genau auf der false-zu-true-Flanke an der Wand.
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        val result = resolveResizeDrag(start, 140f, 90f, limits)
+
+        assertEquals(WidgetSizeDp(320, 200), result.size)
+        assertFalse(result.clampedWidth)
+        assertFalse(result.clampedHeight)
+    }
 }

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
@@ -102,97 +102,100 @@ class WidgetResizeTest {
         assertEquals(900, result.maxWidthDp)
     }
 
-    @Test
-    fun `applyResizeDrag clamps to the limits`() {
-        val limits = WidgetResizeLimits(100, 320, 60, 200)
-        val start = WidgetSizeDp(180, 110)
+    // --- U3: Pinch-Resize (kumulierter Zoom-Faktor) + Anschlag-Info fuer Haptik/Chip ---
 
-        assertEquals(WidgetSizeDp(320, 60), applyResizeDrag(start, 500f, -500f, limits))
-        assertEquals(WidgetSizeDp(100, 200), applyResizeDrag(start, -500f, 500f, limits))
+    @Test
+    fun `resolveResizeZoom scales both axes from the start size`() {
+        val limits = WidgetResizeLimits(100, 400, 60, 300)
+        val start = WidgetSizeDp(200, 100)
+
+        val result = resolveResizeZoom(start, 1.5f, limits)
+
+        assertEquals(WidgetSizeDp(300, 150), result.size)
+        assertFalse(result.clampedWidth)
+        assertFalse(result.clampedHeight)
     }
 
     @Test
-    fun `applyResizeDrag accumulates from the start size without rounding drift`() {
+    fun `resolveResizeZoom with factor one keeps the size`() {
         val limits = WidgetResizeLimits(100, 400, 60, 300)
         val start = WidgetSizeDp(180, 110)
 
-        // Kumulierter Drag statt Delta-Summe: 0.4dp bewegt (noch) nichts …
-        assertEquals(start, applyResizeDrag(start, 0.4f, 0.4f, limits))
-        // … 30.6dp landet gerundet bei +31/+31.
-        assertEquals(WidgetSizeDp(211, 141), applyResizeDrag(start, 30.6f, 30.6f, limits))
+        assertEquals(start, resolveResizeZoom(start, 1f, limits).size)
     }
 
     @Test
-    fun `locked axis is a no-op even with drag input`() {
-        val limits = WidgetResizeLimits(180, 180, 60, 300)
+    fun `resolveResizeZoom accumulates from the start size without rounding drift`() {
+        val limits = WidgetResizeLimits(100, 400, 60, 300)
         val start = WidgetSizeDp(180, 110)
 
-        assertEquals(WidgetSizeDp(180, 210), applyResizeDrag(start, 999f, 100f, limits))
+        // Kumulierter Faktor statt Delta-Produkt: 1.001 bewegt (noch) fast nichts …
+        assertEquals(WidgetSizeDp(180, 110), resolveResizeZoom(start, 1.001f, limits).size)
+        // … 1.1 landet gerundet bei 198×121.
+        assertEquals(WidgetSizeDp(198, 121), resolveResizeZoom(start, 1.1f, limits).size)
     }
 
-    // --- U3: Anschlag-Information fuer Haptik/Chip-Puls ---
-
     @Test
-    fun `resolveResizeDrag within the range reports no clamping`() {
+    fun `zooming past the max reports the free axes as clamped`() {
         val limits = WidgetResizeLimits(100, 320, 60, 200)
         val start = WidgetSizeDp(180, 110)
 
-        val result = resolveResizeDrag(start, 20f, 20f, limits)
+        val result = resolveResizeZoom(start, 3f, limits)
 
-        assertEquals(WidgetSizeDp(200, 130), result.size)
-        assertFalse(result.clampedWidth)
-        assertFalse(result.clampedHeight)
-    }
-
-    @Test
-    fun `resolveResizeDrag past max width reports width clamped`() {
-        val limits = WidgetResizeLimits(100, 320, 60, 200)
-        val start = WidgetSizeDp(180, 110)
-
-        val result = resolveResizeDrag(start, 500f, 0f, limits)
-
-        assertEquals(WidgetSizeDp(320, 110), result.size)
+        assertEquals(WidgetSizeDp(320, 200), result.size)
         assertTrue(result.clampedWidth)
-        assertFalse(result.clampedHeight)
-    }
-
-    @Test
-    fun `resolveResizeDrag below min height reports height clamped`() {
-        val limits = WidgetResizeLimits(100, 320, 60, 200)
-        val start = WidgetSizeDp(180, 110)
-
-        val result = resolveResizeDrag(start, 0f, -500f, limits)
-
-        assertEquals(WidgetSizeDp(180, 60), result.size)
-        assertFalse(result.clampedWidth)
         assertTrue(result.clampedHeight)
     }
 
     @Test
-    fun `locked axis never reports clamped even when pushed hard`() {
-        // Sonst wuerde jeder Diagonal-Drag an einem nur-vertikal skalierbaren
+    fun `zooming below the min reports the free axes as clamped`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        val result = resolveResizeZoom(start, 0.3f, limits)
+
+        assertEquals(WidgetSizeDp(100, 60), result.size)
+        assertTrue(result.clampedWidth)
+        assertTrue(result.clampedHeight)
+    }
+
+    @Test
+    fun `locked axis stays fixed and never reports clamped`() {
+        // Sonst wuerde jede Pinch-Geste an einem nur-vertikal skalierbaren
         // Widget dauerhaft die Anschlag-Haptik ausloesen.
         val limits = WidgetResizeLimits(180, 180, 60, 300)
         val start = WidgetSizeDp(180, 110)
 
-        val result = resolveResizeDrag(start, 999f, 100f, limits)
+        val result = resolveResizeZoom(start, 2f, limits)
 
-        assertEquals(WidgetSizeDp(180, 210), result.size)
+        assertEquals(WidgetSizeDp(180, 220), result.size)
         assertFalse(result.clampedWidth)
         assertFalse(result.clampedHeight)
     }
 
     @Test
     fun `landing exactly on the limit does not count as clamped`() {
-        // Erst der Versuch, DARUEBER hinaus zu ziehen, meldet den Anschlag – die
+        // Erst der Versuch, DARUEBER hinaus zu zoomen, meldet den Anschlag – die
         // Haptik feuert damit genau auf der false-zu-true-Flanke an der Wand.
-        val limits = WidgetResizeLimits(100, 320, 60, 200)
-        val start = WidgetSizeDp(180, 110)
+        val limits = WidgetResizeLimits(100, 400, 60, 220)
+        val start = WidgetSizeDp(200, 110)
 
-        val result = resolveResizeDrag(start, 140f, 90f, limits)
+        val result = resolveResizeZoom(start, 2f, limits)
 
-        assertEquals(WidgetSizeDp(320, 200), result.size)
+        assertEquals(WidgetSizeDp(400, 220), result.size)
         assertFalse(result.clampedWidth)
         assertFalse(result.clampedHeight)
+    }
+
+    @Test
+    fun `degenerate zoom factors are floored instead of collapsing the widget`() {
+        val limits = WidgetResizeLimits(100, 400, 60, 300)
+        val start = WidgetSizeDp(180, 110)
+
+        val zero = resolveResizeZoom(start, 0f, limits)
+        val negative = resolveResizeZoom(start, -1f, limits)
+
+        assertEquals(WidgetSizeDp(100, 60), zero.size)
+        assertEquals(zero.size, negative.size)
     }
 }

--- a/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/data/WidgetResizeTest.kt
@@ -136,19 +136,22 @@ class WidgetResizeTest {
     }
 
     @Test
-    fun `zooming past the max reports the free axes as clamped`() {
+    fun `zooming past the max clamps the size and reports the tighter axis`() {
         val limits = WidgetResizeLimits(100, 320, 60, 200)
         val start = WidgetSizeDp(180, 110)
 
         val result = resolveResizeZoom(start, 3f, limits)
 
+        // Der Akkumulator wird an der groesseren freien Achse (Hoehe, Faktor
+        // 200/110) gekappt: die Hoehe landet exakt am Max (kein Anschlag), die
+        // engere Breiten-Achse meldet den Anschlag.
         assertEquals(WidgetSizeDp(320, 200), result.size)
         assertTrue(result.clampedWidth)
-        assertTrue(result.clampedHeight)
+        assertFalse(result.clampedHeight)
     }
 
     @Test
-    fun `zooming below the min reports the free axes as clamped`() {
+    fun `zooming below the min clamps the size and reports the tighter axis`() {
         val limits = WidgetResizeLimits(100, 320, 60, 200)
         val start = WidgetSizeDp(180, 110)
 
@@ -156,7 +159,37 @@ class WidgetResizeTest {
 
         assertEquals(WidgetSizeDp(100, 60), result.size)
         assertTrue(result.clampedWidth)
-        assertTrue(result.clampedHeight)
+        assertFalse(result.clampedHeight)
+    }
+
+    @Test
+    fun `applied zoom is capped so pinching back in works immediately`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        // Weit ueber das Max hinausgezogen: der Akkumulator bleibt am
+        // nuetzlichen Maximum stehen statt auf 10 davonzulaufen …
+        val maxed = resolveResizeZoom(start, 10f, limits)
+        assertEquals(200f / 110f, maxed.appliedZoom, 1e-4f)
+
+        // … dadurch schrumpft der naechste Reinzieh-Schritt sofort wieder
+        // (vorher: riesige tote Zone = "nicht mehr kleinziehbar").
+        val shrunk = resolveResizeZoom(start, maxed.appliedZoom * 0.9f, limits)
+        assertTrue(shrunk.size.widthDp < maxed.size.widthDp)
+        assertTrue(shrunk.size.heightDp < maxed.size.heightDp)
+    }
+
+    @Test
+    fun `applied zoom is floored so pinching back out works immediately`() {
+        val limits = WidgetResizeLimits(100, 320, 60, 200)
+        val start = WidgetSizeDp(180, 110)
+
+        val minned = resolveResizeZoom(start, 0.01f, limits)
+        assertEquals(60f / 110f, minned.appliedZoom, 1e-4f)
+
+        val grown = resolveResizeZoom(start, minned.appliedZoom * 1.1f, limits)
+        assertTrue(grown.size.widthDp > minned.size.widthDp)
+        assertTrue(grown.size.heightDp > minned.size.heightDp)
     }
 
     @Test

--- a/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/HomeDragStateHolderTest.kt
@@ -128,4 +128,77 @@ class HomeDragStateHolderTest {
         assertEquals(mapOf(1 to WidgetSizeDp(200, 100)), holder.toWidgetSizes())
         assertFalse(holder.widgetSizes.containsKey(2))
     }
+
+    // --- U3: zum Entfernen vorgemerkte Widgets ---
+
+    @Test
+    fun `marked widgets are excluded from offsets and sizes but others stay`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1), widget(2)))
+
+        holder.markWidgetForRemoval(2)
+
+        assertTrue(holder.isWidgetPendingRemoval(2))
+        assertFalse(holder.isWidgetPendingRemoval(1))
+        assertEquals(mapOf(1 to Offset.Zero), holder.toWidgetOffsets())
+        assertEquals(mapOf(1 to WidgetSizeDp(200, 100)), holder.toWidgetSizes())
+        assertEquals(setOf(2), holder.pendingRemovalsSnapshot())
+    }
+
+    @Test
+    fun `marking the selected widget clears selection and pin`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1)))
+        holder.selectedEditTarget = HomeEditTarget.Widget(1)
+        holder.isEditTargetUserPinned = true
+
+        holder.markWidgetForRemoval(1)
+
+        assertNull(holder.selectedEditTarget)
+        assertFalse(holder.isEditTargetUserPinned)
+    }
+
+    @Test
+    fun `marking another widget keeps the current selection`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1), widget(2)))
+        holder.selectedEditTarget = HomeEditTarget.Widget(1)
+        holder.isEditTargetUserPinned = true
+
+        holder.markWidgetForRemoval(2)
+
+        assertEquals(HomeEditTarget.Widget(1), holder.selectedEditTarget)
+        assertTrue(holder.isEditTargetUserPinned)
+    }
+
+    @Test
+    fun `undo restores the widget in offsets and sizes`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1)))
+
+        holder.markWidgetForRemoval(1)
+        holder.undoWidgetRemoval(1)
+
+        assertFalse(holder.isWidgetPendingRemoval(1))
+        assertEquals(mapOf(1 to Offset.Zero), holder.toWidgetOffsets())
+        assertEquals(mapOf(1 to WidgetSizeDp(200, 100)), holder.toWidgetSizes())
+    }
+
+    @Test
+    fun `seedFrom clears pending removals (cancel semantics)`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1)))
+
+        holder.markWidgetForRemoval(1)
+        holder.seedFrom(HomeLayout(), listOf(widget(1)))
+
+        assertFalse(holder.isWidgetPendingRemoval(1))
+        assertEquals(emptySet<Int>(), holder.pendingRemovalsSnapshot())
+    }
+
+    @Test
+    fun `marking twice does not duplicate the entry`() {
+        val holder = HomeDragStateHolder(HomeLayout(), listOf(widget(1)))
+
+        holder.markWidgetForRemoval(1)
+        holder.markWidgetForRemoval(1)
+        holder.undoWidgetRemoval(1)
+
+        assertFalse(holder.isWidgetPendingRemoval(1))
+    }
 }


### PR DESCRIPTION
## Was & Warum

Überarbeitung der Widget-Edit-UX auf dem Startbildschirm. Das bisherige Resize/Entfernen (B1-PR4) war schwer bedienbar; im Verlauf des User-Tests kam ein handfester Rendering-Bug dazu.

### Feature-Teil (U3)
- **Pinch-to-Resize** statt Eck-Handle: Widgets werden mit zwei Fingern direkt auf der Fläche skaliert (der „komische Punkt" ist weg). Der Pinch-Handler bricht einen laufenden Ein-Finger-Move sauber ab und konsumiert bis Gestenende, damit nichts nachspringt.
- **Live-Größen-Chip** „B × H dp" während der Geste, pulsiert am Min/Max-Anschlag; **Haptik** (Ticken je Änderung, deutlicher Impuls am Limit).
- **Rand-Korrektur**: wächst ein Widget über den Rand, zieht der Offset via `clampOffsetToBounds` mit → es bleibt komplett sichtbar/greifbar.
- **Entfernen ist Teil der Edit-Session**: das X merkt nur vor (Geister-Zustand + „Rückgängig"), **Speichern** löscht wirklich, **Abbrechen** stellt wieder her. Host-View bleibt komponiert → kein Zustandsverlust. Interner Bruch: `onRemoveWidget` entfällt, `onSaveWidgetLayout(offsets, sizes, removedIds)` + `updateWidgetPlacement(..., removedIds)` (ein atomarer DataStore-Write).
- 48dp-Trefffläche fürs X (A11y), geteilte Chrome-Composables in `WidgetEditChrome.kt`, Resize-Limits einmal pro Edit-Session gecacht statt providerInfo bei jeder Geste.

### Bugfix-Teil (aus dem User-Test)
- **Akkumulator-Kappung** beim Pinch: der Zoom-Faktor lief am Limit davon → „einmal groß, nicht mehr kleinziehbar". `resolveResizeZoom` kappt auf den nützlichen Bereich (`appliedZoom`).
- **px/dp-Einheiten-Fix (Kern):** `AppWidgetProviderInfo.minWidth/minResizeWidth/maxResizeWidth` etc. liefert Android in **Pixeln**, wurde aber roh als dp verarbeitet und über `Modifier.size(widthDp.dp)` ein zweites Mal mit der Dichte multipliziert → Widgets auf dichten Geräten ~3× zu groß und mit riesiger Resize-Untergrenze. Auf dem Emulator (Dichte 1.0) unsichtbar. Umrechnung durch die Gerätedichte an der Quelle (MainActivity Bind-Default + `widgetResizeLimits`-Lambda + `WidgetPickerSheet`-Label).

## Betroffene Dateien
- `data/WidgetResize.kt` – `resolveResizeZoom` + Anschlag-Flags (ersetzt `resolveResizeDrag`/`applyResizeDrag`)
- `ui/HomeDragStateHolder.kt` – `pendingWidgetRemovals`
- `data/WidgetHostManager.kt` – `updateWidgetPlacement(..., removedIds)`
- `ui/HomeScreen.kt` – Pinch-Geste, Chip, Ghost-Overlay
- `ui/WidgetEditChrome.kt` (neu), `ui/HostedWidgetView.kt`, `MainActivity.kt`, `ui/WidgetPickerSheet.kt`
- Strings in 5 Locales

## Tests / Gates
`detekt`, `testDebugUnitTest` (WidgetResize/HomeDragStateHolder/WidgetHostManager erweitert), `koverVerifyDebug`, `assembleDebug` – alle grün. Kein On-Device-Test durch mich.

## Für den Reviewer / manueller Test
- Neue Widgets erscheinen in vernünftiger Größe; Pinch größer/kleiner in alle Richtungen.
- Bereits zu groß gespeicherte Widgets rasten beim ersten Pinch in den korrekten Bereich ein.
- X → Ghost + Rückgängig; X → Speichern → wirklich weg (auch nach Neustart); X → Abbrechen → wieder da.
- Resize ist bewusst pinch-only (kein TalkBack-Pfad mehr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)