### PR TITLE
Untermenü-Zurück: eine Ebene hoch statt zur Startseite (+ M3-Predictive-Back-Vorschau)

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -2404,14 +2404,22 @@ private fun MenuOverlay(
         visible = visible,
         // Als Ziel-Vorschau (Backdrop) statisch einblenden – kein Slide-in, sonst würde das
         // Elternmenü während der Geste hereinfahren statt ruhig dahinterzuliegen.
-        enter = if (isBackdrop) EnterTransition.None else slideInHorizontally(
-            initialOffsetX = { it },
-            animationSpec = tween(actualEnterSlideDuration, easing = enterSlideEasing)
-        ) + fadeIn(animationSpec = tween(actualEnterFadeDuration)),
-        exit = if (isBackdrop) ExitTransition.None else slideOutHorizontally(
-            targetOffsetX = { it },
-            animationSpec = tween(actualExitSlideDuration, easing = exitSlideEasing)
-        ) + fadeOut(animationSpec = tween(actualExitFadeDuration))
+        enter = if (isBackdrop) {
+            EnterTransition.None
+        } else {
+            slideInHorizontally(
+                initialOffsetX = { it },
+                animationSpec = tween(actualEnterSlideDuration, easing = enterSlideEasing)
+            ) + fadeIn(animationSpec = tween(actualEnterFadeDuration))
+        },
+        exit = if (isBackdrop) {
+            ExitTransition.None
+        } else {
+            slideOutHorizontally(
+                targetOffsetX = { it },
+                animationSpec = tween(actualExitSlideDuration, easing = exitSlideEasing)
+            ) + fadeOut(animationSpec = tween(actualExitFadeDuration))
+        }
     ) {
         var totalDragX by remember { mutableStateOf(0f) }
 

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -30,6 +30,8 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInCubic
 import androidx.compose.animation.core.EaseOutCubic
@@ -687,6 +689,11 @@ class MainActivity : ComponentActivity() {
                 // der Zustand lebt im HomeViewModel. Die abgeleiteten Werte darunter halten
                 // die vielen Lese-Stellen stabil.
                 val activeOverlay = homeUi.activeOverlay
+                // Material-3 Predictive-Back: Während der Zurück-Geste auf einem Untermenü das
+                // Elternmenü (oberster Back-Stack-Eintrag) als statische Ziel-Vorschau dahinter
+                // einblenden. Nur das aktive, oberste Overlay meldet die Geste.
+                var backPreviewActive by remember { mutableStateOf(false) }
+                val backPreviewTarget = if (backPreviewActive) homeUi.overlayBackStack.lastOrNull() else null
                 val isFavoritesConfigOpen = activeOverlay is ActiveOverlay.FavoritesConfig
                 val isColorConfigOpen = activeOverlay is ActiveOverlay.ColorConfig
                 val isAnimationsConfigOpen = activeOverlay is ActiveOverlay.AnimationsConfig
@@ -1602,9 +1609,10 @@ class MainActivity : ComponentActivity() {
                     }
 
                     MenuOverlay(
-                        visible = isColorConfigOpen,
+                        visible = isColorConfigOpen || backPreviewTarget is ActiveOverlay.ColorConfig,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.ColorConfig && activeOverlay !is ActiveOverlay.ColorConfig
                     ) {
                         ColorConfigMenu(
                             selectedTheme = currentTheme,
@@ -1632,7 +1640,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isThemeMenuOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         ThemeSelectionMenu(
                             selectedTheme = currentTheme,
@@ -1647,7 +1657,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isDesignMenuOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         DesignStyleMenu(
                             currentStyle = designStyle,
@@ -1662,9 +1674,10 @@ class MainActivity : ComponentActivity() {
                     }
 
                     MenuOverlay(
-                        visible = isSizeConfigOpen,
+                        visible = isSizeConfigOpen || backPreviewTarget is ActiveOverlay.SizeConfig,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.SizeConfig && activeOverlay !is ActiveOverlay.SizeConfig
                     ) {
                         SizeConfigMenu(
                             currentFontSize = currentFontSize,
@@ -1691,7 +1704,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isFontSelectionOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         FontSelectionMenu(
                             currentAppFont = currentAppFont,
@@ -1701,9 +1716,10 @@ class MainActivity : ComponentActivity() {
                     }
 
                     MenuOverlay(
-                        visible = isEditConfigOpen && !isWallpaperCropOpen,
+                        visible = (isEditConfigOpen && !isWallpaperCropOpen) || backPreviewTarget is ActiveOverlay.EditConfig,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.EditConfig && activeOverlay !is ActiveOverlay.EditConfig
                     ) {
                         // A8-Split: Navigation + Einstellungen holt sich das Menü selbst
                         // (HomeViewModel/EditConfigViewModel); hier bleiben nur die Effekte,
@@ -1737,7 +1753,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isWidgetPickerOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         WidgetPickerSheet(
                             onWidgetChosen = { startWidgetBind(it) },
@@ -1750,7 +1768,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isAnimationsConfigOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         AnimationsConfigMenu(
                             isAnimationsEnabled = isAnimationsEnabled,
@@ -1790,7 +1810,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isEdgeLightingConfigOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         EdgeLightingConfigMenu(
                             isEnabled = isEdgeLightingEnabled,
@@ -1810,7 +1832,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isGesturesConfigOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         GesturesConfigMenu(
                             apps = allApps,
@@ -1864,7 +1888,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isWallpaperConfigOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         WallpaperConfigMenu(
                             blurLevel = wallpaperBlur,
@@ -1882,7 +1908,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isIconConfigOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         IconConfigMenu(
                             apps = allApps,
@@ -1922,7 +1950,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isUninstallAppsOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         UninstallAppsMenu(
                             apps = allApps,
@@ -1934,7 +1964,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isHiddenAppsOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         HiddenAppsMenu(
                             apps = allApps,
@@ -1950,7 +1982,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isAppLockOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         AppLockMenu(
                             apps = allApps,
@@ -2340,6 +2374,16 @@ private fun MenuOverlay(
     enterSlideEasing: Easing = EaseOutCubic,
     exitSlideEasing: Easing = EaseInCubic,
     onClose: () -> Unit,
+    // System-Zurück-Geste (Predictive Back). Untermenüs übergeben hier ein „eine Ebene
+    // zurück", während onClose (✕ / Runterwischen) weiterhin komplett zur Startseite schließt.
+    onBack: () -> Unit = onClose,
+    // Als statische Ziel-Vorschau HINTER dem gerade weggewischten Overlay rendern
+    // (Material-3 Predictive-Back): kein Ein-/Ausblenden, keine eigene Back-/Drag-Geste,
+    // keine Wegwisch-Transform – nur statischer Backdrop.
+    isBackdrop: Boolean = false,
+    // Meldet den Verlauf der Predictive-Back-Geste an den Container (true = Geste aktiv),
+    // damit dieser das Elternmenü als Backdrop einblenden kann.
+    onPredictiveBackActive: (Boolean) -> Unit = {},
     content: @Composable () -> Unit
 ) {
     val animationsEnabled = LocalMenuAnimationEnabled.current
@@ -2358,12 +2402,13 @@ private fun MenuOverlay(
 
     AnimatedVisibility(
         visible = visible,
-        // Seitliches Öffnen/Schließen (von rechts) – kohärent mit der Predictive-Back-Geste.
-        enter = slideInHorizontally(
+        // Als Ziel-Vorschau (Backdrop) statisch einblenden – kein Slide-in, sonst würde das
+        // Elternmenü während der Geste hereinfahren statt ruhig dahinterzuliegen.
+        enter = if (isBackdrop) EnterTransition.None else slideInHorizontally(
             initialOffsetX = { it },
             animationSpec = tween(actualEnterSlideDuration, easing = enterSlideEasing)
         ) + fadeIn(animationSpec = tween(actualEnterFadeDuration)),
-        exit = slideOutHorizontally(
+        exit = if (isBackdrop) ExitTransition.None else slideOutHorizontally(
             targetOffsetX = { it },
             animationSpec = tween(actualExitSlideDuration, easing = exitSlideEasing)
         ) + fadeOut(animationSpec = tween(actualExitFadeDuration))
@@ -2376,18 +2421,23 @@ private fun MenuOverlay(
         val dismiss = remember { Animatable(0f) }
         // +1 = nach rechts (Wisch von linker Kante), -1 = nach links (Wisch von rechter Kante).
         var backSign by remember { mutableStateOf(1f) }
-        PredictiveBackHandler(enabled = true) { backEvent ->
+        // Der Backdrop (Ziel-Vorschau) führt KEINE eigene Geste: Das obenliegende, weggewischte
+        // Overlay steuert die Predictive-Back-Geste; der Backdrop liegt nur ruhig dahinter.
+        PredictiveBackHandler(enabled = !isBackdrop) { backEvent ->
             try {
+                onPredictiveBackActive(true) // Container blendet das Elternmenü als Vorschau ein
                 backEvent.collect { ev ->
                     backSign = if (ev.swipeEdge == BackEventCompat.EDGE_LEFT) 1f else -1f
-                    dismiss.snapTo(ev.progress * 0.20f) // Live-„Peek" während der Geste
+                    dismiss.snapTo(ev.progress * 0.35f) // Live-„Peek" – gibt das Ziel dahinter frei
                 }
-                // Commit: von der aktuellen Position weiter ganz hinausgleiten, dann schließen.
+                // Commit: von der aktuellen Position weiter ganz hinausgleiten, dann zurück.
                 dismiss.animateTo(1f, animationSpec = tween((220 / speed).roundToInt(), easing = EaseInCubic))
-                onClose()
+                onBack()
+                onPredictiveBackActive(false)
             } catch (e: CancellationException) {
-                // Abbruch: zurückfedern.
+                // Abbruch: zurückfedern – Backdrop erst danach ausblenden (kein Flackern).
                 dismiss.animateTo(0f, animationSpec = RethroneSprings.effects(speed))
+                onPredictiveBackActive(false)
             }
         }
 
@@ -2395,14 +2445,15 @@ private fun MenuOverlay(
             modifier = Modifier
                 .fillMaxSize()
                 .graphicsLayer {
+                    if (isBackdrop) return@graphicsLayer // Ziel-Vorschau bleibt ruhig/unverzerrt
                     val p = dismiss.value
-                    scaleX = 1f - 0.10f * p
-                    scaleY = 1f - 0.10f * p
+                    // M3 Predictive-Back: das weggewischte Overlay schrumpft zur gerundeten Karte
+                    // und gleitet zur Wisch-Kante, sodass das Ziel dahinter sichtbar wird.
+                    scaleX = 1f - 0.14f * p
+                    scaleY = 1f - 0.14f * p
                     alpha = 1f - 0.15f * p
                     translationX = size.width * p * backSign
-                    // Ecken runden sich ab, sobald Predictive Back aktiv ist – schon beim Halten
-                    // voll gerundet (Peek liegt nur bei 0.20, daher 5x verstärkt), offen = eckig.
-                    val cornerFraction = (p * 5f).coerceAtMost(1f)
+                    val cornerFraction = (p * 3f).coerceAtMost(1f)
                     shape = RoundedCornerShape((cornerFraction * 44f).dp)
                     clip = true
                 }
@@ -2410,7 +2461,7 @@ private fun MenuOverlay(
                     detectTapGestures { } // Verhindert Klicks durch das Overlay hindurch
                 }
                 .then(
-                    if (enableDragToClose) {
+                    if (enableDragToClose && !isBackdrop) {
                         Modifier.pointerInput(Unit) {
                             detectHorizontalDragGestures(
                                 onDragEnd = {

--- a/app/src/main/java/com/example/androidlauncher/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/HomeViewModel.kt
@@ -16,6 +16,13 @@ import javax.inject.Inject
  */
 data class HomeUiState(
     val activeOverlay: ActiveOverlay = ActiveOverlay.None,
+    /**
+     * Eltern-Overlays des aktuell offenen Overlays (unterste = äußerstes Menü).
+     * Wird beim Öffnen eines Untermenüs gefüllt, damit die System-Zurück-Geste eine
+     * Ebene zum Elternmenü zurückgeht statt direkt zur Startseite.
+     * Invariante: [activeOverlay] == None ⇒ Stack leer.
+     */
+    val overlayBackStack: List<ActiveOverlay> = emptyList(),
     val isDrawerOpen: Boolean = false,
     val isSettingsOpen: Boolean = false,
     val isSearchOpen: Boolean = false,
@@ -43,11 +50,32 @@ class HomeViewModel @Inject constructor() : ViewModel() {
     private val _uiState = MutableStateFlow(HomeUiState())
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
+    /**
+     * Öffnet ein Overlay. Ist bereits ein anderes Overlay offen, wird es als
+     * Elternebene auf den Back-Stack geschoben (Untermenü-Verschachtelung) – so genügt
+     * ein einziger Reducer für beliebige Menü→Untermenü-Übergänge, ohne dass die
+     * Aufrufstellen zwischen „Top-Level" und „Kind" unterscheiden müssen.
+     */
     fun openOverlay(overlay: ActiveOverlay) {
-        _uiState.update { it.copy(activeOverlay = overlay) }
+        _uiState.update { state ->
+            when {
+                overlay == ActiveOverlay.None ->
+                    state.copy(activeOverlay = ActiveOverlay.None, overlayBackStack = emptyList())
+                state.activeOverlay != ActiveOverlay.None && state.activeOverlay != overlay ->
+                    state.copy(
+                        activeOverlay = overlay,
+                        overlayBackStack = state.overlayBackStack + state.activeOverlay,
+                    )
+                else ->
+                    state.copy(activeOverlay = overlay)
+            }
+        }
     }
 
-    fun closeOverlay() = openOverlay(ActiveOverlay.None)
+    /** Schließt die gesamte Overlay-Kette zur Startseite (✕-Button, Runterwischen, programmatisch). */
+    fun closeOverlay() {
+        _uiState.update { it.copy(activeOverlay = ActiveOverlay.None, overlayBackStack = emptyList()) }
+    }
 
     /**
      * Öffnet/schließt den App-Drawer. Beim Öffnen schließen sich Palette, Suche,
@@ -62,6 +90,7 @@ class HomeViewModel @Inject constructor() : ViewModel() {
                     isSearchOpen = false,
                     isHomeEditMode = false,
                     activeOverlay = ActiveOverlay.None,
+                    overlayBackStack = emptyList(),
                 )
             } else {
                 it.copy(isDrawerOpen = false)
@@ -98,16 +127,28 @@ class HomeViewModel @Inject constructor() : ViewModel() {
         _uiState.update { state ->
             val overlay = state.activeOverlay
             when {
-                overlay is ActiveOverlay.FolderConfig -> state.copy(activeOverlay = ActiveOverlay.None)
+                overlay is ActiveOverlay.FolderConfig -> state.poppedOverlay()
                 state.isHomeEditMode -> state.copy(isHomeEditMode = false)
                 state.isSearchOpen -> state.copy(isSearchOpen = false)
-                overlay in INNER_MENUS -> state.copy(activeOverlay = ActiveOverlay.None)
+                overlay in INNER_MENUS -> state.poppedOverlay()
                 state.isDrawerOpen -> state.copy(isDrawerOpen = false)
-                overlay != ActiveOverlay.None -> state.copy(activeOverlay = ActiveOverlay.None)
+                overlay != ActiveOverlay.None -> state.poppedOverlay()
                 else -> state
             }
         }
     }
+
+    /**
+     * Schließt genau eine Overlay-Ebene: liegt ein Elternmenü auf dem Back-Stack, wird
+     * dorthin zurückgekehrt, sonst zur Startseite (Overlay = None). Grundlage dafür, dass
+     * die Zurück-Geste in Untermenüs nicht direkt zur Startseite springt.
+     */
+    private fun HomeUiState.poppedOverlay(): HomeUiState =
+        if (overlayBackStack.isNotEmpty()) {
+            copy(activeOverlay = overlayBackStack.last(), overlayBackStack = overlayBackStack.dropLast(1))
+        } else {
+            copy(activeOverlay = ActiveOverlay.None)
+        }
 
     /** Zeigt den Nutzungszugriff-Hinweis genau einmal pro Prozess-Sitzung. */
     fun requestUsageAccessPromptOnce() {

--- a/app/src/test/java/com/example/androidlauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/home/HomeViewModelTest.kt
@@ -33,6 +33,42 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `opening a child while a parent overlay is open nests it`() {
+        // EditConfig (Eltern) → IconConfig (Kind)
+        vm.openOverlay(ActiveOverlay.EditConfig)
+        vm.openOverlay(ActiveOverlay.IconConfig)
+
+        assertEquals(ActiveOverlay.IconConfig, state.activeOverlay)
+        assertEquals(listOf(ActiveOverlay.EditConfig), state.overlayBackStack)
+    }
+
+    @Test
+    fun `back from a nested child returns to the parent then home`() {
+        vm.openOverlay(ActiveOverlay.EditConfig)
+        vm.openOverlay(ActiveOverlay.IconConfig)
+
+        // Erste Zurück-Geste: zurück zum Elternmenü, nicht zur Startseite.
+        vm.onBack()
+        assertEquals(ActiveOverlay.EditConfig, state.activeOverlay)
+        assertTrue(state.overlayBackStack.isEmpty())
+
+        // Zweite Zurück-Geste: jetzt zur Startseite.
+        vm.onBack()
+        assertEquals(ActiveOverlay.None, state.activeOverlay)
+    }
+
+    @Test
+    fun `close from a nested child goes straight home clearing the stack`() {
+        vm.openOverlay(ActiveOverlay.EditConfig)
+        vm.openOverlay(ActiveOverlay.IconConfig)
+
+        // ✕ / Runterwischen schließt die gesamte Kette.
+        vm.closeOverlay()
+        assertEquals(ActiveOverlay.None, state.activeOverlay)
+        assertTrue(state.overlayBackStack.isEmpty())
+    }
+
+    @Test
     fun `opening the drawer closes palette search edit mode and overlay`() {
         vm.setSettingsOpen(true)
         vm.openOverlay(ActiveOverlay.ColorConfig)


### PR DESCRIPTION
## Problem

Beim Zurückgehen (System-Zurück-Geste) aus einem Untermenü landete man **direkt auf der Startseite** statt im übergeordneten Menü. Ursache: Der Overlay-Zustand war flach (`activeOverlay` ohne Eltern-Info), und sowohl `HomeViewModel.onBack()` als auch der `MenuOverlay`-`PredictiveBackHandler` schalteten hart auf `None`.

Zusätzlich fehlte die Material-3-Predictive-Back-**Vorschau** – beim Wischen sah man den Startbildschirm statt des Zielmenüs.

## Lösung

**Back-Navigation (`HomeViewModel` / `HomeUiState`)**
- Neuer `overlayBackStack`. `openOverlay` schiebt bei bereits offenem Overlay das aktuelle als Elternebene auf den Stack (**Auto-Push**) → die vielen `openOverlay(child)`-Aufrufstellen bleiben unverändert.
- `onBack()` poppt **eine Ebene** (Untermenü → Elternmenü); `closeOverlay()` (✕-Button / Runterwischen / programmatisch) schließt weiterhin **komplett zur Startseite** und lässt damit die kritischen Programm-Closes (App-Start-Rückkehr-Animation, Widget-Bind) unangetastet.
- `setDrawerOpen(true)` leert den Stack.

**System-Zurück von ✕/Wisch getrennt (`MenuOverlay`)**
- Neuer `onBack`-Parameter (System-Zurück) neben `onClose` (✕/Drag). Die 12 Untermenü-Wrapper poppen per `onBack` eine Ebene; ✕/Wisch schließen weiter zur Startseite (auf Nutzerwunsch).

**Material-3 Predictive-Back-Vorschau**
- Während der Zurück-Geste eines Untermenüs wird das Elternmenü (oberster Back-Stack-Eintrag) als **statischer Backdrop** dahinter eingeblendet (`isBackdrop` + `onPredictiveBackActive`). Das weggewischte Menü schrumpft M3-typisch zur gerundeten Karte und gibt das Ziel frei. Nutzt aus, dass Overlays in Quell-Reihenfolge Eltern-vor-Kind komponiert werden (Eltern liegt bereits dahinter).
- Top-Level-Menüs → Startseite: liegt ohnehin schon hinter dem Overlay.

## Tests
- `HomeViewModelTest`: bestehende Reducer-Tests bleiben grün; neue Tests für Nesting, Back→Eltern→Home und Close→Home.
- `./gradlew :app:compileDebugKotlin` und `:app:testDebugUnitTest` grün.

## Reviewer-Hinweise
- Die Animation (Peek `0.35f`, Kartenskalierung/Ecken in der `graphicsLayer` von `MenuOverlay`) ist bewusst am Gerät nachjustierbar – reine Feel-Sache.
- Verhalten am besten am Gerät prüfen: EditConfig → IconConfig, ColorConfig → Design/Theme, SizeConfig → FontSelection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)