### PR TITLE
feat: Kategorie-Seite „Aussehen“ – Einstellungs-Hub Schritt 1

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -163,6 +163,7 @@ import com.example.androidlauncher.ui.home.HomeViewModel
 import com.example.androidlauncher.ui.home.rememberLaunchTransitionState
 import com.example.androidlauncher.ui.launchAppNoTransition
 import com.example.androidlauncher.ui.onboarding.OnboardingFlow
+import com.example.androidlauncher.ui.settings.AppearanceSettingsPage
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalAnimationSpeed
@@ -695,6 +696,7 @@ class MainActivity : ComponentActivity() {
                 var backPreviewActive by remember { mutableStateOf(false) }
                 val backPreviewTarget = if (backPreviewActive) homeUi.overlayBackStack.lastOrNull() else null
                 val isFavoritesConfigOpen = activeOverlay is ActiveOverlay.FavoritesConfig
+                val isAppearanceSettingsOpen = activeOverlay is ActiveOverlay.AppearanceSettings
                 val isColorConfigOpen = activeOverlay is ActiveOverlay.ColorConfig
                 val isAnimationsConfigOpen = activeOverlay is ActiveOverlay.AnimationsConfig
                 val isEdgeLightingConfigOpen = activeOverlay is ActiveOverlay.EdgeLightingConfig
@@ -1608,11 +1610,63 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    // ActivityResult-Effekte, die mehrere Einstellungs-Seiten teilen
+                    // (Hub, Aussehen, künftig System): Launcher/Prompts der Activity.
+                    val editConfigActions = remember {
+                        object : EditConfigActions {
+                            override fun openDefaultLauncherPrompt() = requestDefaultLauncher()
+
+                            override fun pickWallpaper() {
+                                wallpaperPickerLauncher.launch(
+                                    PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                                )
+                            }
+
+                            override fun exportBackup() {
+                                backupExportLauncher.launch(suggestedBackupFileName())
+                            }
+
+                            override fun importBackup() {
+                                backupImportLauncher.launch(
+                                    arrayOf("application/json", "application/octet-stream")
+                                )
+                            }
+                        }
+                    }
+
+                    // Einstellungs-Hub („Bearbeiten") – Eltern aller Kategorie-Seiten und
+                    // Untermenüs, deshalb VOR ihnen komponiert (der Predictive-Back-Backdrop
+                    // muss HINTER dem weggewischten Kind liegen).
                     MenuOverlay(
-                        visible = isColorConfigOpen || backPreviewTarget is ActiveOverlay.ColorConfig,
+                        visible = (isEditConfigOpen && !isWallpaperCropOpen) || backPreviewTarget is ActiveOverlay.EditConfig,
                         customWallpaperUri = customWallpaperUri,
                         onClose = { homeViewModel.closeOverlay() },
-                        isBackdrop = backPreviewTarget is ActiveOverlay.ColorConfig && activeOverlay !is ActiveOverlay.ColorConfig
+                        isBackdrop = backPreviewTarget is ActiveOverlay.EditConfig && activeOverlay !is ActiveOverlay.EditConfig
+                    ) {
+                        EditConfigMenu(actions = editConfigActions)
+                    }
+
+                    // Kategorie-Seite „Aussehen": Kind des Hubs UND Eltern der Darstellungs-
+                    // Untermenüs (Themen, Farben, Design, Schrift, Icons, Wallpaper, Animationen).
+                    MenuOverlay(
+                        visible = (isAppearanceSettingsOpen && !isWallpaperCropOpen) ||
+                            backPreviewTarget is ActiveOverlay.AppearanceSettings,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.AppearanceSettings &&
+                            activeOverlay !is ActiveOverlay.AppearanceSettings
+                    ) {
+                        AppearanceSettingsPage(actions = editConfigActions)
+                    }
+
+                    MenuOverlay(
+                        visible = isColorConfigOpen,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         ColorConfigMenu(
                             selectedTheme = currentTheme,
@@ -1621,9 +1675,6 @@ class MainActivity : ComponentActivity() {
                             onIconColorChange = { scope.launch { themeManager.setIconColor(it) } },
                             homeTextColor = homeTextColor,
                             onHomeTextColorChange = { scope.launch { themeManager.setHomeTextColor(it) } },
-                            designStyle = designStyle,
-                            onOpenDesignMenu = { homeViewModel.openOverlay(ActiveOverlay.DesignMenu) },
-                            onOpenThemeMenu = { homeViewModel.openOverlay(ActiveOverlay.ThemeMenu) },
                             customBackgroundColor = customBackgroundColor,
                             onCustomBackgroundChange = { scope.launch { themeManager.setCustomBackgroundColor(it) } },
                             customMenuColor = customMenuColor,
@@ -1677,6 +1728,8 @@ class MainActivity : ComponentActivity() {
                         visible = isSizeConfigOpen || backPreviewTarget is ActiveOverlay.SizeConfig,
                         customWallpaperUri = customWallpaperUri,
                         onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active },
                         isBackdrop = backPreviewTarget is ActiveOverlay.SizeConfig && activeOverlay !is ActiveOverlay.SizeConfig
                     ) {
                         SizeConfigMenu(
@@ -1713,39 +1766,6 @@ class MainActivity : ComponentActivity() {
                             onAppFontSelected = { scope.launch { themeManager.setAppFont(it) } },
                             onBack = { homeViewModel.closeOverlay() }
                         )
-                    }
-
-                    MenuOverlay(
-                        visible = (isEditConfigOpen && !isWallpaperCropOpen) || backPreviewTarget is ActiveOverlay.EditConfig,
-                        customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() },
-                        isBackdrop = backPreviewTarget is ActiveOverlay.EditConfig && activeOverlay !is ActiveOverlay.EditConfig
-                    ) {
-                        // A8-Split: Navigation + Einstellungen holt sich das Menü selbst
-                        // (HomeViewModel/EditConfigViewModel); hier bleiben nur die Effekte,
-                        // die die Activity braucht (ActivityResult-Launcher).
-                        val editConfigActions = remember {
-                            object : EditConfigActions {
-                                override fun openDefaultLauncherPrompt() = requestDefaultLauncher()
-
-                                override fun pickWallpaper() {
-                                    wallpaperPickerLauncher.launch(
-                                        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-                                    )
-                                }
-
-                                override fun exportBackup() {
-                                    backupExportLauncher.launch(suggestedBackupFileName())
-                                }
-
-                                override fun importBackup() {
-                                    backupImportLauncher.launch(
-                                        arrayOf("application/json", "application/octet-stream")
-                                    )
-                                }
-                            }
-                        }
-                        EditConfigMenu(actions = editConfigActions)
                     }
 
                     // B1: Widget-Auswahl – nach dem Edit-Menü komponiert, damit sie darüber

--- a/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/ColorConfigMenu.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
 import androidx.compose.material.icons.rounded.Check
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material3.*
@@ -49,9 +48,6 @@ fun ColorConfigMenu(
     onIconColorChange: (Color) -> Unit,
     homeTextColor: Color,
     onHomeTextColorChange: (Color) -> Unit,
-    designStyle: DesignStyle,
-    onOpenDesignMenu: () -> Unit,
-    onOpenThemeMenu: () -> Unit,
     customBackgroundColor: Color,
     onCustomBackgroundChange: (Color) -> Unit,
     customMenuColor: Color,
@@ -154,75 +150,6 @@ fun ColorConfigMenu(
                     mainTextColor = mainTextColor,
                     onClick = { activePicker = "menu" }
                 )
-            }
-
-            Spacer(modifier = Modifier.height(24.dp))
-
-            Text(
-                stringResource(R.string.color_section_appearance),
-                color = mainTextColor.copy(alpha = 0.5f),
-                fontSize = 14.sp
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-
-            // Antippbare Zeile → Theme-Untermenü.
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .clickable { onOpenThemeMenu() }
-                    .background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
-                    .testTag("theme_selection_row")
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(stringResource(R.string.label_themes), color = mainTextColor, fontSize = 16.sp)
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        selectedTheme.themeNameRes?.let { stringResource(it) } ?: selectedTheme.themeName,
-                        color = mainTextColor.copy(alpha = 0.6f),
-                        fontSize = 14.sp
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = null,
-                        tint = mainTextColor.copy(alpha = 0.5f),
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(10.dp))
-
-            // Antippbare Zeile, die das Design-Untermenü öffnet.
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(16.dp))
-                    .clickable { onOpenDesignMenu() }
-                    .background(mainTextColor.copy(alpha = 0.05f), RoundedCornerShape(16.dp))
-                    .testTag("design_style_row")
-                    .padding(horizontal = 16.dp, vertical = 12.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(stringResource(R.string.label_design), color = mainTextColor, fontSize = 16.sp)
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    Text(
-                        stringResource(designStyle.titleRes),
-                        color = mainTextColor.copy(alpha = 0.6f),
-                        fontSize = 14.sp
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                        contentDescription = null,
-                        tint = mainTextColor.copy(alpha = 0.5f),
-                        modifier = Modifier.size(20.dp)
-                    )
-                }
             }
 
             Spacer(modifier = Modifier.weight(1f))

--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -34,11 +34,10 @@ import com.composables.icons.lucide.CloudSun
 import com.composables.icons.lucide.Download
 import com.composables.icons.lucide.Hand
 import com.composables.icons.lucide.House
-import com.composables.icons.lucide.Image
 import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Palette
 import com.composables.icons.lucide.Pencil
-import com.composables.icons.lucide.Settings2
 import com.composables.icons.lucide.Shield
 import com.composables.icons.lucide.Smartphone
 import com.composables.icons.lucide.Sparkles
@@ -83,24 +82,15 @@ fun EditConfigMenu(
         homeViewModel.setHomeEditMode(true)
     }
     val onOpenWidgetPicker = { homeViewModel.openOverlay(ActiveOverlay.WidgetPicker) }
-    val onOpenIconConfig = { homeViewModel.openOverlay(ActiveOverlay.IconConfig) }
     val onOpenUninstallApps = { homeViewModel.openOverlay(ActiveOverlay.UninstallApps) }
     val onOpenHiddenApps = { homeViewModel.openOverlay(ActiveOverlay.HiddenApps) }
     val onOpenAppLock = { homeViewModel.openOverlay(ActiveOverlay.AppLock) }
-    val onOpenWallpaperAdjust = { homeViewModel.openOverlay(ActiveOverlay.WallpaperConfig) }
     val onOpenGesturesConfig = { homeViewModel.openOverlay(ActiveOverlay.GesturesConfig) }
-    val onOpenAnimationsConfig = { homeViewModel.openOverlay(ActiveOverlay.AnimationsConfig) }
     val onOpenEdgeLightingConfig = { homeViewModel.openOverlay(ActiveOverlay.EdgeLightingConfig) }
     val onOpenDefaultLauncher = { actions.openDefaultLauncherPrompt() }
-    val onChangeWallpaper = {
-        homeViewModel.closeOverlay()
-        actions.pickWallpaper()
-    }
 
     val isCustomHomeLayoutSet by editViewModel.isCustomHomeLayoutSet.collectAsState(initial = false)
-    val isCustomWallpaperSet by editViewModel.isCustomWallpaperSet.collectAsState(initial = false)
     val isSmartSuggestionsEnabled by editViewModel.isSmartSuggestionsEnabled.collectAsState(initial = true)
-    val isAnimationsEnabled by editViewModel.isAnimationsEnabled.collectAsState(initial = true)
     val isWeatherWidgetEnabled by editViewModel.isWeatherWidgetEnabled.collectAsState(initial = true)
     val isClockWidgetEnabled by editViewModel.isClockWidgetEnabled.collectAsState(initial = true)
     val isCalendarWidgetEnabled by editViewModel.isCalendarWidgetEnabled.collectAsState(initial = true)
@@ -122,10 +112,6 @@ fun EditConfigMenu(
     val onResetHomeLayout = {
         editViewModel.resetHomeLayout()
         Toast.makeText(context, context.getString(R.string.home_layout_reset), Toast.LENGTH_SHORT).show()
-    }
-    val onResetWallpaper = {
-        editViewModel.resetWallpaper()
-        Toast.makeText(context, context.getString(R.string.wallpaper_removed), Toast.LENGTH_SHORT).show()
     }
     val onClearSearchHistory = {
         editViewModel.clearSearchHistory()
@@ -205,6 +191,20 @@ fun EditConfigMenu(
             contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
         ) {
             item {
+                SettingsCategoryItem(
+                    icon = Lucide.Palette,
+                    title = stringResource(R.string.section_appearance),
+                    subtitle = stringResource(R.string.category_sub_appearance),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.AppearanceSettings) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "category_appearance_item"
+                )
+            }
+
+            item {
                 EditSectionHeader(
                     title = stringResource(R.string.section_general),
                     mainTextColor = mainTextColor
@@ -223,20 +223,6 @@ fun EditConfigMenu(
                     surfaceAccent = surfaceAccent,
                     isDarkTextEnabled = isDarkTextEnabled,
                     switchTestTag = "haptic_feedback_switch"
-                )
-            }
-
-            item {
-                EditMenuItem(
-                    icon = Lucide.Smartphone,
-                    label = stringResource(R.string.label_animations),
-                    onClick = onOpenAnimationsConfig,
-                    mainTextColor = mainTextColor,
-                    designStyle = designStyle,
-                    surfaceAccent = surfaceAccent,
-                    isDarkTextEnabled = isDarkTextEnabled,
-                    statusLabel = if (isAnimationsEnabled) null else stringResource(R.string.status_off),
-                    testTag = "animations_menu_item"
                 )
             }
 
@@ -387,62 +373,6 @@ fun EditConfigMenu(
                     isDarkTextEnabled = isDarkTextEnabled,
                     testTag = "add_widget_item"
                 )
-            }
-
-            item {
-                EditMenuItem(
-                    icon = Lucide.Settings2,
-                    label = stringResource(R.string.edit_app_icons),
-                    onClick = onOpenIconConfig,
-                    mainTextColor = mainTextColor,
-                    designStyle = designStyle,
-                    surfaceAccent = surfaceAccent,
-                    isDarkTextEnabled = isDarkTextEnabled
-                )
-            }
-
-            item {
-                EditMenuItem(
-                    icon = Lucide.Image,
-                    label = stringResource(R.string.change_wallpaper),
-                    onClick = onChangeWallpaper,
-                    mainTextColor = mainTextColor,
-                    designStyle = designStyle,
-                    surfaceAccent = surfaceAccent,
-                    isDarkTextEnabled = isDarkTextEnabled,
-                    trailingContent = {
-                        if (isCustomWallpaperSet) {
-                            IconButton(onClick = onResetWallpaper) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Close,
-                                    contentDescription = stringResource(R.string.cd_remove_wallpaper),
-                                    tint = mainTextColor.copy(alpha = 0.6f),
-                                    modifier = Modifier.size(24.dp)
-                                )
-                            }
-                        } else {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
-                                contentDescription = null,
-                                tint = mainTextColor.copy(alpha = 0.4f)
-                            )
-                        }
-                    }
-                )
-            }
-
-            if (isCustomWallpaperSet) {
-                item {
-                    EditMenuItem(
-                        icon = Lucide.Settings2,
-                        label = stringResource(R.string.adjust_wallpaper),
-                        onClick = onOpenWallpaperAdjust,
-                        mainTextColor = mainTextColor,
-                        designStyle = designStyle,
-                        surfaceAccent = surfaceAccent,
-                        isDarkTextEnabled = isDarkTextEnabled
-                    )
-                }
             }
 
             item {

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsMenuItems.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsMenuItems.kt
@@ -130,6 +130,73 @@ fun EditMenuItem(
     }
 }
 
+/**
+ * Kategorie-Zeile des Einstellungs-Hubs: Icon, Titel und ein Untertitel, der die
+ * enthaltenen Einstellungen aufzählt – damit auf einen Blick klar ist, wo was liegt.
+ */
+@Composable
+internal fun SettingsCategoryItem(
+    icon: ImageVector,
+    title: String,
+    subtitle: String,
+    onClick: () -> Unit,
+    mainTextColor: Color,
+    designStyle: DesignStyle,
+    surfaceAccent: Color,
+    isDarkTextEnabled: Boolean,
+    testTag: String? = null
+) {
+    val backgroundModifier = Modifier.designSurface(
+        designStyle, RoundedCornerShape(20.dp), isDarkTextEnabled, surfaceAccent,
+        fillAlpha = 0.05f, glassStartAlpha = 0.10f, glassEndAlpha = 0.03f,
+        borderWidth = 1.dp, borderStartAlpha = if (isDarkTextEnabled) 0.2f else 0.25f, borderEndAlpha = 0.05f
+    )
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(20.dp))
+            .then(backgroundModifier)
+            .then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+            .clickable { onClick() },
+        color = Color.Transparent
+    ) {
+        Row(
+            modifier = Modifier.padding(vertical = 18.dp, horizontal = 16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = mainTextColor,
+                modifier = Modifier.size(24.dp)
+            )
+            Spacer(modifier = Modifier.width(16.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    color = mainTextColor,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Normal
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = subtitle,
+                    color = mainTextColor.copy(alpha = 0.6f),
+                    fontSize = 13.sp,
+                    lineHeight = 18.sp
+                )
+            }
+            Spacer(modifier = Modifier.width(12.dp))
+            Icon(
+                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                contentDescription = null,
+                tint = mainTextColor.copy(alpha = 0.4f)
+            )
+        }
+    }
+}
+
 @Composable
 fun EditToggleItem(
     icon: ImageVector,

--- a/app/src/main/java/com/example/androidlauncher/ui/home/ActiveOverlay.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/ActiveOverlay.kt
@@ -17,6 +17,10 @@ sealed interface ActiveOverlay {
     data object None : ActiveOverlay
 
     data object FavoritesConfig : ActiveOverlay
+
+    /** Kategorie-Seite „Aussehen" des Einstellungs-Hubs (Themen, Farben, Schrift, Icons, Wallpaper, Animationen). */
+    data object AppearanceSettings : ActiveOverlay
+
     data object ColorConfig : ActiveOverlay
     data object AnimationsConfig : ActiveOverlay
     data object EdgeLightingConfig : ActiveOverlay

--- a/app/src/main/java/com/example/androidlauncher/ui/settings/AppearanceSettingsPage.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/settings/AppearanceSettingsPage.kt
@@ -1,0 +1,240 @@
+package com.example.androidlauncher.ui.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.composables.icons.lucide.ALargeSmall
+import com.composables.icons.lucide.Droplet
+import com.composables.icons.lucide.Image
+import com.composables.icons.lucide.Layers
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Palette
+import com.composables.icons.lucide.Settings2
+import com.composables.icons.lucide.Smartphone
+import com.example.androidlauncher.R
+import com.example.androidlauncher.ui.EditMenuItem
+import com.example.androidlauncher.ui.home.ActiveOverlay
+import com.example.androidlauncher.ui.home.EditConfigActions
+import com.example.androidlauncher.ui.home.EditConfigViewModel
+import com.example.androidlauncher.ui.home.HomeViewModel
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalDesignStyle
+
+/**
+ * Kategorie-Seite „Aussehen" des Einstellungs-Hubs: bündelt alle visuellen
+ * Einstellungen (Themen, Farben, Design-Stil, Schrift, Icons, Wallpaper,
+ * Animationen), die vorher über Farben-Menü und „Allgemein" verstreut waren.
+ */
+@Composable
+fun AppearanceSettingsPage(
+    actions: EditConfigActions
+) {
+    val context = LocalContext.current
+    val homeViewModel: HomeViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+    val editViewModel: EditConfigViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+
+    val isCustomWallpaperSet by editViewModel.isCustomWallpaperSet.collectAsState(initial = false)
+    val isAnimationsEnabled by editViewModel.isAnimationsEnabled.collectAsState(initial = true)
+
+    val onResetWallpaper = {
+        editViewModel.resetWallpaper()
+        Toast.makeText(context, context.getString(R.string.wallpaper_removed), Toast.LENGTH_SHORT).show()
+    }
+    val onChangeWallpaper = {
+        homeViewModel.closeOverlay()
+        actions.pickWallpaper()
+    }
+
+    val selectedTheme = LocalColorTheme.current
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val designStyle = LocalDesignStyle.current
+    val surfaceAccent = selectedTheme.menuSurfaceColor(isDarkTextEnabled)
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.section_appearance),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = { homeViewModel.closeOverlay() }) {
+                Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.cd_close), tint = mainTextColor)
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
+        ) {
+            item {
+                EditMenuItem(
+                    icon = Lucide.Palette,
+                    label = stringResource(R.string.label_themes),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.ThemeMenu) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    statusLabel = selectedTheme.themeNameRes?.let { stringResource(it) } ?: selectedTheme.themeName,
+                    testTag = "appearance_themes_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Droplet,
+                    label = stringResource(R.string.color_config_title),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.ColorConfig) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "appearance_colors_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Layers,
+                    label = stringResource(R.string.label_design_style),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.DesignMenu) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    statusLabel = stringResource(designStyle.titleRes),
+                    testTag = "appearance_design_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.ALargeSmall,
+                    label = stringResource(R.string.size_config_title),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.SizeConfig) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "appearance_font_size_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Settings2,
+                    label = stringResource(R.string.edit_app_icons),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.IconConfig) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "appearance_app_icons_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Image,
+                    label = stringResource(R.string.change_wallpaper),
+                    onClick = onChangeWallpaper,
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "appearance_wallpaper_item",
+                    trailingContent = {
+                        if (isCustomWallpaperSet) {
+                            IconButton(onClick = onResetWallpaper) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Close,
+                                    contentDescription = stringResource(R.string.cd_remove_wallpaper),
+                                    tint = mainTextColor.copy(alpha = 0.6f),
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                                contentDescription = null,
+                                tint = mainTextColor.copy(alpha = 0.4f)
+                            )
+                        }
+                    }
+                )
+            }
+
+            if (isCustomWallpaperSet) {
+                item {
+                    EditMenuItem(
+                        icon = Lucide.Settings2,
+                        label = stringResource(R.string.adjust_wallpaper),
+                        onClick = { homeViewModel.openOverlay(ActiveOverlay.WallpaperConfig) },
+                        mainTextColor = mainTextColor,
+                        designStyle = designStyle,
+                        surfaceAccent = surfaceAccent,
+                        isDarkTextEnabled = isDarkTextEnabled,
+                        testTag = "appearance_adjust_wallpaper_item"
+                    )
+                }
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Smartphone,
+                    label = stringResource(R.string.label_animations),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.AnimationsConfig) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    statusLabel = if (isAnimationsEnabled) null else stringResource(R.string.status_off),
+                    testTag = "appearance_animations_item"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -106,8 +106,11 @@
     <string name="label_animations">Animationen</string>
     <string name="label_info">Info</string>
     <string name="label_features">Funktionen</string>
+    <string name="label_design_style">Design-Stil</string>
     <string name="edit_config_title">Bearbeiten</string>
     <string name="section_general">Allgemein</string>
+    <string name="section_appearance">Aussehen</string>
+    <string name="category_sub_appearance">Themen, Farben, Schrift, Icons, Wallpaper, Animationen</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Suche</string>
     <string name="section_permissions">Zugriffe</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -106,8 +106,11 @@
     <string name="label_animations">Animaciones</string>
     <string name="label_info">Info</string>
     <string name="label_features">Funciones</string>
+    <string name="label_design_style">Estilo de diseño</string>
     <string name="edit_config_title">Editar</string>
     <string name="section_general">General</string>
+    <string name="section_appearance">Apariencia</string>
+    <string name="category_sub_appearance">Temas, colores, fuente, iconos, fondo de pantalla, animaciones</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Búsqueda</string>
     <string name="section_permissions">Permisos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -106,8 +106,11 @@
     <string name="label_animations">Animations</string>
     <string name="label_info">Info</string>
     <string name="label_features">Fonctionnalités</string>
+    <string name="label_design_style">Style du design</string>
     <string name="edit_config_title">Modifier</string>
     <string name="section_general">Général</string>
+    <string name="section_appearance">Apparence</string>
+    <string name="category_sub_appearance">Thèmes, couleurs, police, icônes, fond d\'écran, animations</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Recherche</string>
     <string name="section_permissions">Autorisations</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -106,8 +106,11 @@
     <string name="label_animations">Animazioni</string>
     <string name="label_info">Info</string>
     <string name="label_features">Funzioni</string>
+    <string name="label_design_style">Stile di design</string>
     <string name="edit_config_title">Modifica</string>
     <string name="section_general">Generale</string>
+    <string name="section_appearance">Aspetto</string>
+    <string name="category_sub_appearance">Temi, colori, carattere, icone, sfondo, animazioni</string>
     <string name="section_apps">App</string>
     <string name="section_search">Ricerca</string>
     <string name="section_permissions">Autorizzazioni</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,8 +106,11 @@
     <string name="label_animations">Animations</string>
     <string name="label_info">Info</string>
     <string name="label_features">Features</string>
+    <string name="label_design_style">Design style</string>
     <string name="edit_config_title">Edit</string>
     <string name="section_general">General</string>
+    <string name="section_appearance">Appearance</string>
+    <string name="category_sub_appearance">Themes, colors, font, icons, wallpaper, animations</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Search</string>
     <string name="section_permissions">Permissions</string>


### PR DESCRIPTION
## Kontext

Schritt 2 der Menü-Restrukturierung (Hub-and-Spoke): Die visuellen Einstellungen waren über fünf Orte verstreut (Farben-Menü mit versteckter „Darstellung“-Sektion, „Allgemein“-Grabbelkiste, Palette). Jetzt bündelt eine Kategorie-Seite **Aussehen** alles Visuelle.

**Stacked auf #130** (`refactor/settings-menu-items`) — bitte zuerst #130 mergen.

## Änderungen

- **Neu `ui/settings/AppearanceSettingsPage.kt`**: Themen · Farben · Design-Stil · Schrift & Größe · App-Icons · Wallpaper ändern (+ Reset) · Hintergrund anpassen (konditional) · Animationen — mit Status-Labels (aktuelles Theme, aktueller Design-Stil)
- **Neu `SettingsCategoryItem`**: Hub-Zeile mit Untertitel, der die enthaltenen Einstellungen aufzählt („Themen, Farben, Schrift, Icons, Wallpaper, Animationen“)
- **`ActiveOverlay.AppearanceSettings`** + MainActivity-Wiring:
  - Reihenfolge-Invariante: Hub → Kategorie-Seite → Leaves (jeder Parent VOR seinen Kindern komponiert, damit der Predictive-Back-Backdrop dahinter rendert)
  - ColorConfig & SizeConfig sind jetzt Kinder: `onBack` geht eine Ebene hoch statt den Stack zu leeren; ✕/Drag-to-close springt weiter direkt zur Startseite
  - `editConfigActions` gehoisted (Hub + Aussehen teilen die ActivityResult-Launcher)
- **`ColorConfigMenu`**: „Darstellung“-Sektion + 2 Callback-Params entfernt → reine Farben-Seite
- **`EditConfigMenu`** (Hub): Aussehen-Kategoriezeile oben; Animationen/App-Icons/Wallpaper/Hintergrund-Zeilen raus aus „Allgemein“
- Strings in allen 5 Locales (`section_appearance`, `category_sub_appearance`, `label_design_style`)

Palette-Shortcuts (Farben/Größe) deep-linken weiterhin direkt; Back geht dort zur Startseite (bewusst, unverändert).

## Verifikation

- `./gradlew :app:assembleDebug :app:testDebugUnitTest detekt` grün, androidTest kompiliert
- Manuell zu prüfen: Hub → Aussehen → Farben → Back → Back → Back (Predictive-Back-Peek zeigt jeweils die Elternebene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
