### PR TITLE
feat: Einstellungs-Hub komplett – 4 weitere Kategorie-Seiten

### DIFF
--- a/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
+++ b/app/src/androidTest/java/com/example/androidlauncher/LauncherComposableUiTest.kt
@@ -16,7 +16,7 @@ import com.example.androidlauncher.ui.AppDrawer
 import com.example.androidlauncher.ui.EditConfigMenu
 import com.example.androidlauncher.ui.HomeScreen
 import com.example.androidlauncher.ui.IconConfigMenu
-import com.example.androidlauncher.ui.home.EditConfigActions
+import com.example.androidlauncher.ui.settings.HomescreenSettingsPage
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
@@ -137,7 +137,7 @@ class LauncherComposableUiTest {
     // vor assertIsDisplayed()/performClick() nutzen. Reaktivieren nach Emulator-Check.
     @Ignore("LazyColumn-Scroll noetig (performScrollToNode) – mit Emulator verifizieren, dann reaktivieren")
     @Test
-    fun editConfigMenu_showsHomeLayoutResetWhenCustomLayoutIsSet() {
+    fun homescreenSettings_showsHomeLayoutResetWhenCustomLayoutIsSet() {
         // A8: Das Menue versorgt sich selbst aus den Settings-Stores -> Custom-Layout
         // direkt im injizierten Store setzen statt per Parameter.
         hiltRule.inject()
@@ -145,7 +145,7 @@ class LauncherComposableUiTest {
 
         composeRule.setContent {
             AndroidLauncherTheme {
-                EditConfigMenu(actions = NoopEditConfigActions)
+                HomescreenSettingsPage()
             }
         }
 
@@ -157,13 +157,13 @@ class LauncherComposableUiTest {
     }
 
     @Test
-    fun editConfigMenu_hidesHomeLayoutResetWhenLayoutIsDefault() {
+    fun homescreenSettings_hidesHomeLayoutResetWhenLayoutIsDefault() {
         hiltRule.inject()
         runBlocking { homeLayoutSettings.setHomeLayout(HomeLayout()) }
 
         composeRule.setContent {
             AndroidLauncherTheme {
-                EditConfigMenu(actions = NoopEditConfigActions)
+                HomescreenSettingsPage()
             }
         }
 
@@ -172,10 +172,19 @@ class LauncherComposableUiTest {
         }
     }
 
-    private object NoopEditConfigActions : EditConfigActions {
-        override fun openDefaultLauncherPrompt() = Unit
-        override fun pickWallpaper() = Unit
-        override fun exportBackup() = Unit
-        override fun importBackup() = Unit
+    @Test
+    fun settingsHub_showsAllCategoryRows() {
+        composeRule.setContent {
+            AndroidLauncherTheme {
+                EditConfigMenu()
+            }
+        }
+
+        composeRule.onNodeWithTag("category_appearance_item").assertIsDisplayed()
+        composeRule.onNodeWithTag("category_homescreen_item").assertIsDisplayed()
+        composeRule.onNodeWithTag("category_apps_item").assertIsDisplayed()
+        composeRule.onNodeWithTag("category_search_item").assertIsDisplayed()
+        composeRule.onNodeWithTag("category_gestures_item").assertIsDisplayed()
+        composeRule.onNodeWithTag("category_system_item").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/example/androidlauncher/MainActivity.kt
+++ b/app/src/main/java/com/example/androidlauncher/MainActivity.kt
@@ -164,6 +164,10 @@ import com.example.androidlauncher.ui.home.rememberLaunchTransitionState
 import com.example.androidlauncher.ui.launchAppNoTransition
 import com.example.androidlauncher.ui.onboarding.OnboardingFlow
 import com.example.androidlauncher.ui.settings.AppearanceSettingsPage
+import com.example.androidlauncher.ui.settings.AppsSettingsPage
+import com.example.androidlauncher.ui.settings.HomescreenSettingsPage
+import com.example.androidlauncher.ui.settings.SearchSettingsPage
+import com.example.androidlauncher.ui.settings.SystemSettingsPage
 import com.example.androidlauncher.ui.theme.AndroidLauncherTheme
 import com.example.androidlauncher.ui.theme.ColorTheme
 import com.example.androidlauncher.ui.theme.LocalAnimationSpeed
@@ -697,6 +701,10 @@ class MainActivity : ComponentActivity() {
                 val backPreviewTarget = if (backPreviewActive) homeUi.overlayBackStack.lastOrNull() else null
                 val isFavoritesConfigOpen = activeOverlay is ActiveOverlay.FavoritesConfig
                 val isAppearanceSettingsOpen = activeOverlay is ActiveOverlay.AppearanceSettings
+                val isHomescreenSettingsOpen = activeOverlay is ActiveOverlay.HomescreenSettings
+                val isAppsSettingsOpen = activeOverlay is ActiveOverlay.AppsSettings
+                val isSearchSettingsOpen = activeOverlay is ActiveOverlay.SearchSettings
+                val isSystemSettingsOpen = activeOverlay is ActiveOverlay.SystemSettings
                 val isColorConfigOpen = activeOverlay is ActiveOverlay.ColorConfig
                 val isAnimationsConfigOpen = activeOverlay is ActiveOverlay.AnimationsConfig
                 val isEdgeLightingConfigOpen = activeOverlay is ActiveOverlay.EdgeLightingConfig
@@ -1545,36 +1553,6 @@ class MainActivity : ComponentActivity() {
                     }
 
                     MenuOverlay(
-                        visible = isFavoritesConfigOpen,
-                        customWallpaperUri = customWallpaperUri,
-                        enableDragToClose = false,
-                        onClose = { homeViewModel.closeOverlay() }
-                    ) {
-                        @Suppress("DEPRECATION")
-                        FavoritesConfigMenu(
-                            apps = allApps,
-                            initialFavoritePackages = favoritePackages,
-                            showFavoriteLabels = showFavoriteLabels,
-                            onShowLabelsToggled = { show ->
-                                scope.launch { themeManager.setShowFavoriteLabels(show) }
-                            },
-                            notificationDotsEnabled = notificationDotsEnabled,
-                            onNotificationDotsToggled = { enabled ->
-                                scope.launch { themeManager.setNotificationDotsEnabled(enabled) }
-                            },
-                            favoritesBorderStyle = favoritesBorderStyle,
-                            onBorderStyleSelected = { style ->
-                                scope.launch { themeManager.setFavoritesBorderStyle(style) }
-                            },
-                            onConfirm = { newFavs ->
-                                scope.launch { favoritesManager.saveFavorites(newFavs) }
-                                homeViewModel.closeOverlay()
-                            },
-                            onClose = { homeViewModel.closeOverlay() }
-                        )
-                    }
-
-                    MenuOverlay(
                         visible = selectedFolderForConfig != null,
                         customWallpaperUri = customWallpaperUri,
                         enableDragToClose = false,
@@ -1611,7 +1589,7 @@ class MainActivity : ComponentActivity() {
                     }
 
                     // ActivityResult-Effekte, die mehrere Einstellungs-Seiten teilen
-                    // (Hub, Aussehen, künftig System): Launcher/Prompts der Activity.
+                    // (Aussehen, System): Launcher/Prompts der Activity.
                     val editConfigActions = remember {
                         object : EditConfigActions {
                             override fun openDefaultLauncherPrompt() = requestDefaultLauncher()
@@ -1643,7 +1621,7 @@ class MainActivity : ComponentActivity() {
                         onClose = { homeViewModel.closeOverlay() },
                         isBackdrop = backPreviewTarget is ActiveOverlay.EditConfig && activeOverlay !is ActiveOverlay.EditConfig
                     ) {
-                        EditConfigMenu(actions = editConfigActions)
+                        EditConfigMenu()
                     }
 
                     // Kategorie-Seite „Aussehen": Kind des Hubs UND Eltern der Darstellungs-
@@ -1659,6 +1637,91 @@ class MainActivity : ComponentActivity() {
                             activeOverlay !is ActiveOverlay.AppearanceSettings
                     ) {
                         AppearanceSettingsPage(actions = editConfigActions)
+                    }
+
+                    // Kategorie-Seite „Startbildschirm": Eltern von Favoriten, Widget-Picker
+                    // und Edge-Beleuchtung.
+                    MenuOverlay(
+                        visible = isHomescreenSettingsOpen || backPreviewTarget is ActiveOverlay.HomescreenSettings,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.HomescreenSettings &&
+                            activeOverlay !is ActiveOverlay.HomescreenSettings
+                    ) {
+                        HomescreenSettingsPage()
+                    }
+
+                    // Kategorie-Seite „Apps": Eltern von Ausblenden, App-Sperre, Deinstallieren.
+                    MenuOverlay(
+                        visible = isAppsSettingsOpen || backPreviewTarget is ActiveOverlay.AppsSettings,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.AppsSettings &&
+                            activeOverlay !is ActiveOverlay.AppsSettings
+                    ) {
+                        AppsSettingsPage()
+                    }
+
+                    // Kategorie-Seite „Suche": keine Unterseiten, reines Kind des Hubs.
+                    MenuOverlay(
+                        visible = isSearchSettingsOpen,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
+                    ) {
+                        SearchSettingsPage()
+                    }
+
+                    // Kategorie-Seite „System": Eltern des Info-Overlays.
+                    MenuOverlay(
+                        visible = isSystemSettingsOpen || backPreviewTarget is ActiveOverlay.SystemSettings,
+                        customWallpaperUri = customWallpaperUri,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active },
+                        isBackdrop = backPreviewTarget is ActiveOverlay.SystemSettings &&
+                            activeOverlay !is ActiveOverlay.SystemSettings
+                    ) {
+                        SystemSettingsPage(actions = editConfigActions)
+                    }
+
+                    // Favoriten: per Palette direkt ODER als Kind der Startbildschirm-Seite
+                    // erreichbar – deshalb NACH ihr komponiert.
+                    MenuOverlay(
+                        visible = isFavoritesConfigOpen,
+                        customWallpaperUri = customWallpaperUri,
+                        enableDragToClose = false,
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
+                    ) {
+                        @Suppress("DEPRECATION")
+                        FavoritesConfigMenu(
+                            apps = allApps,
+                            initialFavoritePackages = favoritePackages,
+                            showFavoriteLabels = showFavoriteLabels,
+                            onShowLabelsToggled = { show ->
+                                scope.launch { themeManager.setShowFavoriteLabels(show) }
+                            },
+                            notificationDotsEnabled = notificationDotsEnabled,
+                            onNotificationDotsToggled = { enabled ->
+                                scope.launch { themeManager.setNotificationDotsEnabled(enabled) }
+                            },
+                            favoritesBorderStyle = favoritesBorderStyle,
+                            onBorderStyleSelected = { style ->
+                                scope.launch { themeManager.setFavoritesBorderStyle(style) }
+                            },
+                            onConfirm = { newFavs ->
+                                scope.launch { favoritesManager.saveFavorites(newFavs) }
+                                homeViewModel.closeOverlay()
+                            },
+                            onClose = { homeViewModel.closeOverlay() }
+                        )
                     }
 
                     MenuOverlay(
@@ -2031,7 +2094,9 @@ class MainActivity : ComponentActivity() {
                     MenuOverlay(
                         visible = isInfoOpen,
                         customWallpaperUri = customWallpaperUri,
-                        onClose = { homeViewModel.closeOverlay() }
+                        onClose = { homeViewModel.closeOverlay() },
+                        onBack = { homeViewModel.onBack() },
+                        onPredictiveBackActive = { active -> backPreviewActive = active }
                     ) {
                         InfoDialog(
                             onClose = { homeViewModel.closeOverlay() }

--- a/app/src/main/java/com/example/androidlauncher/ui/home/ActiveOverlay.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/home/ActiveOverlay.kt
@@ -21,6 +21,18 @@ sealed interface ActiveOverlay {
     /** Kategorie-Seite „Aussehen" des Einstellungs-Hubs (Themen, Farben, Schrift, Icons, Wallpaper, Animationen). */
     data object AppearanceSettings : ActiveOverlay
 
+    /** Kategorie-Seite „Startbildschirm" (Favoriten, Layout, Widgets, Dynamic Island, Edge-Beleuchtung). */
+    data object HomescreenSettings : ActiveOverlay
+
+    /** Kategorie-Seite „Apps" (App-Zugriff, Ausblenden, Sperre, Deinstallieren). */
+    data object AppsSettings : ActiveOverlay
+
+    /** Kategorie-Seite „Suche" (Vorschläge, Verlauf). */
+    data object SearchSettings : ActiveOverlay
+
+    /** Kategorie-Seite „System" (Haptik, Backup, Berechtigungen, Info). */
+    data object SystemSettings : ActiveOverlay
+
     data object ColorConfig : ActiveOverlay
     data object AnimationsConfig : ActiveOverlay
     data object EdgeLightingConfig : ActiveOverlay

--- a/app/src/main/java/com/example/androidlauncher/ui/settings/AppsSettingsPage.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/settings/AppsSettingsPage.kt
@@ -1,4 +1,4 @@
-package com.example.androidlauncher.ui
+package com.example.androidlauncher.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -10,14 +10,16 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
-import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material.icons.rounded.Lock
+import androidx.compose.material.icons.rounded.VisibilityOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -25,35 +27,34 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.composables.icons.lucide.Hand
-import com.composables.icons.lucide.House
-import com.composables.icons.lucide.LayoutGrid
 import com.composables.icons.lucide.Lucide
-import com.composables.icons.lucide.Palette
-import com.composables.icons.lucide.Settings2
+import com.composables.icons.lucide.Trash2
 import com.example.androidlauncher.R
+import com.example.androidlauncher.data.AppAccessMode
+import com.example.androidlauncher.ui.EditAppAccessSelectorItem
+import com.example.androidlauncher.ui.EditMenuItem
 import com.example.androidlauncher.ui.home.ActiveOverlay
+import com.example.androidlauncher.ui.home.EditConfigViewModel
 import com.example.androidlauncher.ui.home.HomeViewModel
 import com.example.androidlauncher.ui.theme.LocalColorTheme
 import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
 import com.example.androidlauncher.ui.theme.LocalDesignStyle
 
 /**
- * Einstellungs-Hub: kurze Startseite mit einer Kategorie-Zeile pro Themenbereich
- * (Aussehen, Startbildschirm, Apps, Suche, Gesten, System). Jede Zeile nennt im
- * Untertitel die enthaltenen Einstellungen, damit auf einen Blick klar ist, wo
- * was liegt. Die eigentlichen Einstellungen leben auf den Kategorie-Seiten
- * unter ui/settings/.
+ * Kategorie-Seite „Apps" des Einstellungs-Hubs: Zugriffsart auf die App-Liste
+ * sowie Ausblenden, Sperren und Deinstallieren einzelner Apps.
  */
 @Composable
-fun EditConfigMenu() {
+fun AppsSettingsPage() {
     val homeViewModel: HomeViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+    val editViewModel: EditConfigViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+
+    val appAccessMode by editViewModel.appAccessMode.collectAsState(initial = AppAccessMode.DRAWER_LIST)
 
     val isDarkTextEnabled = LocalDarkTextEnabled.current
     val designStyle = LocalDesignStyle.current
     val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
     val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
-    val menuListState = rememberLazyListState()
 
     Column(
         modifier = Modifier
@@ -68,7 +69,7 @@ fun EditConfigMenu() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                stringResource(R.string.edit_config_title),
+                stringResource(R.string.section_apps),
                 fontSize = 28.sp,
                 fontWeight = FontWeight.Light,
                 color = mainTextColor
@@ -79,7 +80,6 @@ fun EditConfigMenu() {
         }
 
         LazyColumn(
-            state = menuListState,
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f),
@@ -87,86 +87,54 @@ fun EditConfigMenu() {
             contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
         ) {
             item {
-                SettingsCategoryItem(
-                    icon = Lucide.Palette,
-                    title = stringResource(R.string.section_appearance),
-                    subtitle = stringResource(R.string.category_sub_appearance),
-                    onClick = { homeViewModel.openOverlay(ActiveOverlay.AppearanceSettings) },
+                EditAppAccessSelectorItem(
+                    label = stringResource(R.string.app_access_label),
+                    selectedMode = appAccessMode,
+                    onModeSelected = { editViewModel.setAppAccessMode(it) },
                     mainTextColor = mainTextColor,
                     designStyle = designStyle,
                     surfaceAccent = surfaceAccent,
                     isDarkTextEnabled = isDarkTextEnabled,
-                    testTag = "category_appearance_item"
+                    testTag = "app_access_mode_selector"
                 )
             }
 
             item {
-                SettingsCategoryItem(
-                    icon = Lucide.House,
-                    title = stringResource(R.string.section_homescreen),
-                    subtitle = stringResource(R.string.category_sub_homescreen),
-                    onClick = { homeViewModel.openOverlay(ActiveOverlay.HomescreenSettings) },
+                EditMenuItem(
+                    icon = Icons.Rounded.VisibilityOff,
+                    label = stringResource(R.string.hide_apps),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.HiddenApps) },
                     mainTextColor = mainTextColor,
                     designStyle = designStyle,
                     surfaceAccent = surfaceAccent,
                     isDarkTextEnabled = isDarkTextEnabled,
-                    testTag = "category_homescreen_item"
+                    testTag = "hidden_apps_item"
                 )
             }
 
             item {
-                SettingsCategoryItem(
-                    icon = Lucide.LayoutGrid,
-                    title = stringResource(R.string.section_apps),
-                    subtitle = stringResource(R.string.category_sub_apps),
-                    onClick = { homeViewModel.openOverlay(ActiveOverlay.AppsSettings) },
+                EditMenuItem(
+                    icon = Icons.Rounded.Lock,
+                    label = stringResource(R.string.app_lock),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.AppLock) },
                     mainTextColor = mainTextColor,
                     designStyle = designStyle,
                     surfaceAccent = surfaceAccent,
                     isDarkTextEnabled = isDarkTextEnabled,
-                    testTag = "category_apps_item"
+                    testTag = "app_lock_item"
                 )
             }
 
             item {
-                SettingsCategoryItem(
-                    icon = Icons.Rounded.Search,
-                    title = stringResource(R.string.section_search),
-                    subtitle = stringResource(R.string.category_sub_search),
-                    onClick = { homeViewModel.openOverlay(ActiveOverlay.SearchSettings) },
+                EditMenuItem(
+                    icon = Lucide.Trash2,
+                    label = stringResource(R.string.uninstall_apps),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.UninstallApps) },
                     mainTextColor = mainTextColor,
                     designStyle = designStyle,
                     surfaceAccent = surfaceAccent,
                     isDarkTextEnabled = isDarkTextEnabled,
-                    testTag = "category_search_item"
-                )
-            }
-
-            item {
-                SettingsCategoryItem(
-                    icon = Lucide.Hand,
-                    title = stringResource(R.string.label_gestures),
-                    subtitle = stringResource(R.string.category_sub_gestures),
-                    onClick = { homeViewModel.openOverlay(ActiveOverlay.GesturesConfig) },
-                    mainTextColor = mainTextColor,
-                    designStyle = designStyle,
-                    surfaceAccent = surfaceAccent,
-                    isDarkTextEnabled = isDarkTextEnabled,
-                    testTag = "category_gestures_item"
-                )
-            }
-
-            item {
-                SettingsCategoryItem(
-                    icon = Lucide.Settings2,
-                    title = stringResource(R.string.section_system),
-                    subtitle = stringResource(R.string.category_sub_system),
-                    onClick = { homeViewModel.openOverlay(ActiveOverlay.SystemSettings) },
-                    mainTextColor = mainTextColor,
-                    designStyle = designStyle,
-                    surfaceAccent = surfaceAccent,
-                    isDarkTextEnabled = isDarkTextEnabled,
-                    testTag = "category_system_item"
+                    testTag = "uninstall_apps_item"
                 )
             }
         }

--- a/app/src/main/java/com/example/androidlauncher/ui/settings/HomescreenSettingsPage.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/settings/HomescreenSettingsPage.kt
@@ -1,0 +1,268 @@
+package com.example.androidlauncher.ui.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.composables.icons.lucide.Bell
+import com.composables.icons.lucide.Calendar
+import com.composables.icons.lucide.Clock
+import com.composables.icons.lucide.CloudSun
+import com.composables.icons.lucide.LayoutGrid
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Pencil
+import com.composables.icons.lucide.Sparkles
+import com.example.androidlauncher.R
+import com.example.androidlauncher.data.IslandAnimationStyle
+import com.example.androidlauncher.ui.EditIslandAnimationSelectorItem
+import com.example.androidlauncher.ui.EditMenuItem
+import com.example.androidlauncher.ui.EditToggleItem
+import com.example.androidlauncher.ui.home.ActiveOverlay
+import com.example.androidlauncher.ui.home.EditConfigViewModel
+import com.example.androidlauncher.ui.home.HomeViewModel
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalDesignStyle
+
+/**
+ * Kategorie-Seite „Startbildschirm" des Einstellungs-Hubs: alles, was direkt auf
+ * der Startseite sichtbar ist (Favoriten, Layout, Widgets, Dynamic Island,
+ * Edge-Beleuchtung).
+ */
+@Composable
+fun HomescreenSettingsPage() {
+    val context = LocalContext.current
+    val homeViewModel: HomeViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+    val editViewModel: EditConfigViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+
+    val isCustomHomeLayoutSet by editViewModel.isCustomHomeLayoutSet.collectAsState(initial = false)
+    val isClockWidgetEnabled by editViewModel.isClockWidgetEnabled.collectAsState(initial = true)
+    val isCalendarWidgetEnabled by editViewModel.isCalendarWidgetEnabled.collectAsState(initial = true)
+    val isWeatherWidgetEnabled by editViewModel.isWeatherWidgetEnabled.collectAsState(initial = true)
+    val isDynamicIslandEnabled by editViewModel.isDynamicIslandEnabled.collectAsState(initial = true)
+    val islandAnimationStyle by editViewModel.islandAnimationStyle
+        .collectAsState(initial = IslandAnimationStyle.FROM_NOTCH)
+    val isEdgeLightingEnabled by editViewModel.isEdgeLightingEnabled.collectAsState(initial = false)
+
+    val onOpenHomeLayoutEdit = {
+        homeViewModel.closeOverlay()
+        homeViewModel.setHomeEditMode(true)
+    }
+    val onResetHomeLayout = {
+        editViewModel.resetHomeLayout()
+        Toast.makeText(context, context.getString(R.string.home_layout_reset), Toast.LENGTH_SHORT).show()
+    }
+
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val designStyle = LocalDesignStyle.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.section_homescreen),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = { homeViewModel.closeOverlay() }) {
+                Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.cd_close), tint = mainTextColor)
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
+        ) {
+            item {
+                EditMenuItem(
+                    icon = Icons.Rounded.Star,
+                    label = stringResource(R.string.favorites_title),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.FavoritesConfig) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "homescreen_favorites_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Pencil,
+                    label = stringResource(R.string.edit_home_layout),
+                    onClick = onOpenHomeLayoutEdit,
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "edit_home_layout_item",
+                    trailingContent = {
+                        if (isCustomHomeLayoutSet) {
+                            IconButton(
+                                onClick = onResetHomeLayout,
+                                modifier = Modifier.testTag("edit_home_layout_reset")
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Close,
+                                    contentDescription = stringResource(R.string.cd_reset_home_layout),
+                                    tint = mainTextColor.copy(alpha = 0.6f),
+                                    modifier = Modifier.size(24.dp)
+                                )
+                            }
+                        } else {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Rounded.KeyboardArrowRight,
+                                contentDescription = null,
+                                tint = mainTextColor.copy(alpha = 0.4f)
+                            )
+                        }
+                    }
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.LayoutGrid,
+                    label = stringResource(R.string.add_widget),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.WidgetPicker) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "add_widget_item"
+                )
+            }
+
+            item {
+                EditToggleItem(
+                    icon = Lucide.Clock,
+                    label = stringResource(R.string.clock_widget),
+                    description = stringResource(R.string.clock_widget_desc),
+                    checked = isClockWidgetEnabled,
+                    onCheckedChange = { editViewModel.setClockWidgetEnabled(it) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    switchTestTag = "clock_widget_switch"
+                )
+            }
+
+            item {
+                EditToggleItem(
+                    icon = Lucide.Calendar,
+                    label = stringResource(R.string.calendar_widget),
+                    description = stringResource(R.string.calendar_widget_desc),
+                    checked = isCalendarWidgetEnabled,
+                    onCheckedChange = { editViewModel.setCalendarWidgetEnabled(it) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    switchTestTag = "calendar_widget_switch"
+                )
+            }
+
+            item {
+                EditToggleItem(
+                    icon = Lucide.CloudSun,
+                    label = stringResource(R.string.weather_widget),
+                    description = stringResource(R.string.weather_widget_desc),
+                    checked = isWeatherWidgetEnabled,
+                    onCheckedChange = { editViewModel.setWeatherWidgetEnabled(it) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    switchTestTag = "weather_widget_switch"
+                )
+            }
+
+            item {
+                EditToggleItem(
+                    icon = Lucide.Bell,
+                    label = stringResource(R.string.dynamic_island),
+                    description = stringResource(R.string.dynamic_island_desc),
+                    checked = isDynamicIslandEnabled,
+                    onCheckedChange = { editViewModel.setDynamicIslandEnabled(it) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    switchTestTag = "dynamic_island_switch"
+                )
+            }
+
+            if (isDynamicIslandEnabled) {
+                item {
+                    EditIslandAnimationSelectorItem(
+                        label = stringResource(R.string.island_anim_style),
+                        selectedStyle = islandAnimationStyle,
+                        onStyleSelected = { editViewModel.setIslandAnimationStyle(it) },
+                        mainTextColor = mainTextColor,
+                        designStyle = designStyle,
+                        surfaceAccent = surfaceAccent,
+                        isDarkTextEnabled = isDarkTextEnabled,
+                        testTag = "island_animation_selector"
+                    )
+                }
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Sparkles,
+                    label = stringResource(R.string.edge_lighting),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.EdgeLightingConfig) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    statusLabel = if (isEdgeLightingEnabled) null else stringResource(R.string.status_off),
+                    testTag = "edge_lighting_menu_item"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/settings/SearchSettingsPage.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/settings/SearchSettingsPage.kt
@@ -1,0 +1,122 @@
+package com.example.androidlauncher.ui.settings
+
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Trash2
+import com.example.androidlauncher.R
+import com.example.androidlauncher.ui.EditMenuItem
+import com.example.androidlauncher.ui.EditToggleItem
+import com.example.androidlauncher.ui.home.EditConfigViewModel
+import com.example.androidlauncher.ui.home.HomeViewModel
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalDesignStyle
+
+/**
+ * Kategorie-Seite „Suche" des Einstellungs-Hubs: intelligente Vorschläge und
+ * das Löschen des Suchverlaufs.
+ */
+@Composable
+fun SearchSettingsPage() {
+    val context = LocalContext.current
+    val homeViewModel: HomeViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+    val editViewModel: EditConfigViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+
+    val isSmartSuggestionsEnabled by editViewModel.isSmartSuggestionsEnabled.collectAsState(initial = true)
+
+    val onClearSearchHistory = {
+        editViewModel.clearSearchHistory()
+        Toast.makeText(context, context.getString(R.string.search_history_cleared), Toast.LENGTH_SHORT).show()
+    }
+
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val designStyle = LocalDesignStyle.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.section_search),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = { homeViewModel.closeOverlay() }) {
+                Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.cd_close), tint = mainTextColor)
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
+        ) {
+            item {
+                EditToggleItem(
+                    icon = Icons.Rounded.Search,
+                    label = stringResource(R.string.smart_suggestions),
+                    description = stringResource(R.string.smart_suggestions_desc),
+                    checked = isSmartSuggestionsEnabled,
+                    onCheckedChange = { editViewModel.setSmartSuggestionsEnabled(it) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    switchTestTag = "smart_search_switch"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Trash2,
+                    label = stringResource(R.string.clear_search_history),
+                    onClick = onClearSearchHistory,
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/androidlauncher/ui/settings/SystemSettingsPage.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/settings/SystemSettingsPage.kt
@@ -1,0 +1,298 @@
+package com.example.androidlauncher.ui.settings
+
+import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Close
+import androidx.compose.material.icons.rounded.Info
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.net.toUri
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
+import com.composables.icons.lucide.Bell
+import com.composables.icons.lucide.Download
+import com.composables.icons.lucide.Hand
+import com.composables.icons.lucide.House
+import com.composables.icons.lucide.Lucide
+import com.composables.icons.lucide.Shield
+import com.composables.icons.lucide.Smartphone
+import com.composables.icons.lucide.Upload
+import com.example.androidlauncher.ForegroundAppResolver
+import com.example.androidlauncher.LauncherAccessibilityService
+import com.example.androidlauncher.R
+import com.example.androidlauncher.isDefaultLauncher
+import com.example.androidlauncher.isNotificationServiceEnabled
+import com.example.androidlauncher.openAccessibilitySettings
+import com.example.androidlauncher.openNotificationSettings
+import com.example.androidlauncher.ui.EditMenuItem
+import com.example.androidlauncher.ui.EditSectionHeader
+import com.example.androidlauncher.ui.EditToggleItem
+import com.example.androidlauncher.ui.home.ActiveOverlay
+import com.example.androidlauncher.ui.home.EditConfigActions
+import com.example.androidlauncher.ui.home.EditConfigViewModel
+import com.example.androidlauncher.ui.home.HomeViewModel
+import com.example.androidlauncher.ui.theme.LocalColorTheme
+import com.example.androidlauncher.ui.theme.LocalDarkTextEnabled
+import com.example.androidlauncher.ui.theme.LocalDesignStyle
+
+/**
+ * Kategorie-Seite „System" des Einstellungs-Hubs: Haptik, Backup (Export/Import),
+ * System-Berechtigungen und App-Info.
+ */
+@Composable
+fun SystemSettingsPage(
+    actions: EditConfigActions
+) {
+    val context = LocalContext.current
+    val homeViewModel: HomeViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+    val editViewModel: EditConfigViewModel = androidx.hilt.navigation.compose.hiltViewModel()
+
+    val isHapticFeedbackEnabled by editViewModel.isHapticFeedbackEnabled.collectAsState(initial = true)
+
+    // Haptik schreibt zusätzlich das System-Setting → ohne WRITE_SETTINGS-Berechtigung
+    // stattdessen den System-Dialog öffnen (Verhalten wie zuvor im Bearbeiten-Menü).
+    val onHapticFeedbackToggled: (Boolean) -> Unit = { enabled ->
+        if (Settings.System.canWrite(context)) {
+            editViewModel.setHapticFeedbackEnabled(enabled)
+        } else {
+            val writeSettingsIntent = Intent(Settings.ACTION_MANAGE_WRITE_SETTINGS).apply {
+                data = ("package:" + context.packageName).toUri()
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            context.startActivity(writeSettingsIntent)
+            Toast.makeText(
+                context,
+                context.getString(R.string.write_settings_permission_required),
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
+    val isDarkTextEnabled = LocalDarkTextEnabled.current
+    val designStyle = LocalDesignStyle.current
+    val surfaceAccent = LocalColorTheme.current.menuSurfaceColor(isDarkTextEnabled)
+    val mainTextColor = if (isDarkTextEnabled) Color(0xFF010101) else Color.White
+
+    var isDefaultLauncherSet by remember { mutableStateOf(isDefaultLauncher(context)) }
+    var isNotificationEnabled by remember { mutableStateOf(isNotificationServiceEnabled(context)) }
+    var isAccessibilityEnabled by remember {
+        mutableStateOf(
+            LauncherAccessibilityService.isAccessibilityServiceEnabled(context)
+        )
+    }
+    var isUsageAccessEnabled by remember { mutableStateOf(ForegroundAppResolver.hasUsageAccess(context)) }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        isDefaultLauncherSet = isDefaultLauncher(context)
+        isNotificationEnabled = isNotificationServiceEnabled(context)
+        isAccessibilityEnabled = LauncherAccessibilityService.isAccessibilityServiceEnabled(context)
+        isUsageAccessEnabled = ForegroundAppResolver.hasUsageAccess(context)
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .statusBarsPadding()
+            .navigationBarsPadding()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                stringResource(R.string.section_system),
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Light,
+                color = mainTextColor
+            )
+            IconButton(onClick = { homeViewModel.closeOverlay() }) {
+                Icon(Icons.Rounded.Close, contentDescription = stringResource(R.string.cd_close), tint = mainTextColor)
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            contentPadding = PaddingValues(top = 32.dp, bottom = 8.dp)
+        ) {
+            item {
+                EditToggleItem(
+                    icon = Lucide.Smartphone,
+                    label = stringResource(R.string.haptic_feedback),
+                    description = stringResource(R.string.haptic_feedback_desc),
+                    checked = isHapticFeedbackEnabled,
+                    onCheckedChange = { onHapticFeedbackToggled(it) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    switchTestTag = "haptic_feedback_switch"
+                )
+            }
+
+            item {
+                EditSectionHeader(
+                    title = stringResource(R.string.section_backup),
+                    mainTextColor = mainTextColor
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Download,
+                    label = stringResource(R.string.backup_export),
+                    onClick = { actions.exportBackup() },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "backup_export_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Upload,
+                    label = stringResource(R.string.backup_import),
+                    onClick = { actions.importBackup() },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "backup_import_item"
+                )
+            }
+
+            // Klartext-Hinweis: Exporte enthalten u. a. die Liste der ausgeblendeten
+            // Apps unverschlüsselt (gerätegebundener Ciphertext wäre im Backup nutzlos).
+            item {
+                Text(
+                    text = stringResource(R.string.backup_plaintext_hint),
+                    fontSize = 12.sp,
+                    color = mainTextColor.copy(alpha = 0.6f),
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+            }
+
+            item {
+                EditSectionHeader(
+                    title = stringResource(R.string.section_permissions),
+                    mainTextColor = mainTextColor
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.House,
+                    label = stringResource(R.string.default_launcher),
+                    onClick = { actions.openDefaultLauncherPrompt() },
+                    statusLabel = if (isDefaultLauncherSet) {
+                        stringResource(R.string.status_on)
+                    } else {
+                        stringResource(R.string.status_off)
+                    },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "default_launcher_item"
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Bell,
+                    label = stringResource(R.string.notifications_label),
+                    onClick = { openNotificationSettings(context) },
+                    statusLabel = if (isNotificationEnabled) {
+                        stringResource(R.string.status_on)
+                    } else {
+                        stringResource(R.string.status_off)
+                    },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Hand,
+                    label = stringResource(R.string.accessibility_label),
+                    onClick = { openAccessibilitySettings(context) },
+                    statusLabel = if (isAccessibilityEnabled) {
+                        stringResource(R.string.status_on)
+                    } else {
+                        stringResource(R.string.status_off)
+                    },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Lucide.Shield,
+                    label = stringResource(R.string.usage_access_label),
+                    onClick = { ForegroundAppResolver.openUsageAccessSettings(context) },
+                    statusLabel = if (isUsageAccessEnabled) {
+                        stringResource(R.string.status_on)
+                    } else {
+                        stringResource(R.string.status_off)
+                    },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled
+                )
+            }
+
+            item {
+                EditMenuItem(
+                    icon = Icons.Rounded.Info,
+                    label = stringResource(R.string.label_info),
+                    onClick = { homeViewModel.openOverlay(ActiveOverlay.Info) },
+                    mainTextColor = mainTextColor,
+                    designStyle = designStyle,
+                    surfaceAccent = surfaceAccent,
+                    isDarkTextEnabled = isDarkTextEnabled,
+                    testTag = "system_info_item"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,9 +108,15 @@
     <string name="label_features">Funktionen</string>
     <string name="label_design_style">Design-Stil</string>
     <string name="edit_config_title">Bearbeiten</string>
-    <string name="section_general">Allgemein</string>
     <string name="section_appearance">Aussehen</string>
     <string name="category_sub_appearance">Themen, Farben, Schrift, Icons, Wallpaper, Animationen</string>
+    <string name="section_homescreen">Startbildschirm</string>
+    <string name="category_sub_homescreen">Favoriten, Layout, Widgets, Dynamic Island, Edge Lighting</string>
+    <string name="category_sub_apps">App-Zugriff, Ausblenden, Sperre, Deinstallieren</string>
+    <string name="category_sub_search">Intelligente Vorschläge, Suchverlauf</string>
+    <string name="category_sub_gestures">Wischen, Doppeltippen, Schütteln</string>
+    <string name="section_system">System</string>
+    <string name="category_sub_system">Haptik, Backup, Berechtigungen, Info</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Suche</string>
     <string name="section_permissions">Zugriffe</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -108,9 +108,15 @@
     <string name="label_features">Funciones</string>
     <string name="label_design_style">Estilo de diseño</string>
     <string name="edit_config_title">Editar</string>
-    <string name="section_general">General</string>
     <string name="section_appearance">Apariencia</string>
     <string name="category_sub_appearance">Temas, colores, fuente, iconos, fondo de pantalla, animaciones</string>
+    <string name="section_homescreen">Pantalla de inicio</string>
+    <string name="category_sub_homescreen">Favoritos, diseño, widgets, Dynamic Island, iluminación de bordes</string>
+    <string name="category_sub_apps">Acceso a apps, ocultar, bloquear, desinstalar</string>
+    <string name="category_sub_search">Sugerencias inteligentes, historial</string>
+    <string name="category_sub_gestures">Deslizar, doble toque, agitar</string>
+    <string name="section_system">Sistema</string>
+    <string name="category_sub_system">Háptica, copia de seguridad, permisos, info</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Búsqueda</string>
     <string name="section_permissions">Permisos</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,9 +108,15 @@
     <string name="label_features">Fonctionnalités</string>
     <string name="label_design_style">Style du design</string>
     <string name="edit_config_title">Modifier</string>
-    <string name="section_general">Général</string>
     <string name="section_appearance">Apparence</string>
     <string name="category_sub_appearance">Thèmes, couleurs, police, icônes, fond d\'écran, animations</string>
+    <string name="section_homescreen">Écran d\'accueil</string>
+    <string name="category_sub_homescreen">Favoris, disposition, widgets, Dynamic Island, éclairage des bords</string>
+    <string name="category_sub_apps">Accès aux apps, masquer, verrouiller, désinstaller</string>
+    <string name="category_sub_search">Suggestions intelligentes, historique</string>
+    <string name="category_sub_gestures">Balayage, double tap, secousse</string>
+    <string name="section_system">Système</string>
+    <string name="category_sub_system">Haptique, sauvegarde, autorisations, infos</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Recherche</string>
     <string name="section_permissions">Autorisations</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -108,9 +108,15 @@
     <string name="label_features">Funzioni</string>
     <string name="label_design_style">Stile di design</string>
     <string name="edit_config_title">Modifica</string>
-    <string name="section_general">Generale</string>
     <string name="section_appearance">Aspetto</string>
     <string name="category_sub_appearance">Temi, colori, carattere, icone, sfondo, animazioni</string>
+    <string name="section_homescreen">Schermata Home</string>
+    <string name="category_sub_homescreen">Preferiti, layout, widget, Dynamic Island, illuminazione bordi</string>
+    <string name="category_sub_apps">Accesso alle app, nascondi, blocco, disinstalla</string>
+    <string name="category_sub_search">Suggerimenti intelligenti, cronologia</string>
+    <string name="category_sub_gestures">Scorrimento, doppio tocco, scuotimento</string>
+    <string name="section_system">Sistema</string>
+    <string name="category_sub_system">Feedback aptico, backup, autorizzazioni, info</string>
     <string name="section_apps">App</string>
     <string name="section_search">Ricerca</string>
     <string name="section_permissions">Autorizzazioni</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,9 +108,15 @@
     <string name="label_features">Features</string>
     <string name="label_design_style">Design style</string>
     <string name="edit_config_title">Edit</string>
-    <string name="section_general">General</string>
     <string name="section_appearance">Appearance</string>
     <string name="category_sub_appearance">Themes, colors, font, icons, wallpaper, animations</string>
+    <string name="section_homescreen">Home screen</string>
+    <string name="category_sub_homescreen">Favorites, layout, widgets, Dynamic Island, edge lighting</string>
+    <string name="category_sub_apps">App access, hide, lock, uninstall</string>
+    <string name="category_sub_search">Smart suggestions, search history</string>
+    <string name="category_sub_gestures">Swipe, double tap, shake</string>
+    <string name="section_system">System</string>
+    <string name="category_sub_system">Haptics, backup, permissions, info</string>
     <string name="section_apps">Apps</string>
     <string name="section_search">Search</string>
     <string name="section_permissions">Permissions</string>

--- a/app/src/test/java/com/example/androidlauncher/ui/home/HomeViewModelTest.kt
+++ b/app/src/test/java/com/example/androidlauncher/ui/home/HomeViewModelTest.kt
@@ -58,6 +58,51 @@ class HomeViewModelTest {
     }
 
     @Test
+    fun `back walks a three level hub chain one page at a time`() {
+        // Hub → Kategorie-Seite → Untermenü (z. B. Bearbeiten → Aussehen → Farben).
+        vm.openOverlay(ActiveOverlay.EditConfig)
+        vm.openOverlay(ActiveOverlay.AppearanceSettings)
+        vm.openOverlay(ActiveOverlay.ColorConfig)
+
+        assertEquals(ActiveOverlay.ColorConfig, state.activeOverlay)
+        assertEquals(
+            listOf(ActiveOverlay.EditConfig, ActiveOverlay.AppearanceSettings),
+            state.overlayBackStack
+        )
+
+        vm.onBack()
+        assertEquals(ActiveOverlay.AppearanceSettings, state.activeOverlay)
+
+        vm.onBack()
+        assertEquals(ActiveOverlay.EditConfig, state.activeOverlay)
+        assertTrue(state.overlayBackStack.isEmpty())
+
+        vm.onBack()
+        assertEquals(ActiveOverlay.None, state.activeOverlay)
+    }
+
+    @Test
+    fun `close from a three level hub chain goes straight home`() {
+        vm.openOverlay(ActiveOverlay.EditConfig)
+        vm.openOverlay(ActiveOverlay.HomescreenSettings)
+        vm.openOverlay(ActiveOverlay.FavoritesConfig)
+
+        vm.closeOverlay()
+        assertEquals(ActiveOverlay.None, state.activeOverlay)
+        assertTrue(state.overlayBackStack.isEmpty())
+    }
+
+    @Test
+    fun `palette deep link into a category child keeps back stack shallow`() {
+        // Palette-Shortcut öffnet ColorConfig direkt (leerer Stack): Back geht zur
+        // Startseite, nicht zum Hub – der gewohnte Shortcut-Vertrag bleibt erhalten.
+        vm.openOverlay(ActiveOverlay.ColorConfig)
+
+        vm.onBack()
+        assertEquals(ActiveOverlay.None, state.activeOverlay)
+    }
+
+    @Test
     fun `close from a nested child goes straight home clearing the stack`() {
         vm.openOverlay(ActiveOverlay.EditConfig)
         vm.openOverlay(ActiveOverlay.IconConfig)


### PR DESCRIPTION
## Kontext

Schritt 3 der Menü-Restrukturierung: Der Hub „Bearbeiten“ wird zur reinen Kategorie-Liste — sechs Zeilen mit Untertiteln, die die enthaltenen Einstellungen aufzählen. Die 14-Einträge-Grabbelkiste „Allgemein“ ist damit Geschichte.

**Stacked auf #131** (`feature/settings-hub-appearance`) — Merge-Reihenfolge: #130 → #131 → dieser PR.

## Neue Struktur des Hubs

1. **Aussehen** — Themen, Farben, Schrift, Icons, Wallpaper, Animationen (aus #131)
2. **Startbildschirm** — Favoriten, Layout, Widgets, Dynamic Island, Edge Lighting
3. **Apps** — App-Zugriff, Ausblenden, Sperre, Deinstallieren
4. **Suche** — Intelligente Vorschläge, Suchverlauf
5. **Gesten** — öffnet direkt das bestehende Gesten-Menü
6. **System** — Haptik, Backup, Berechtigungen, Info

## Änderungen

- **4 neue Seiten** unter `ui/settings/`: `HomescreenSettingsPage`, `AppsSettingsPage`, `SearchSettingsPage`, `SystemSettingsPage` — Zeilen 1:1 aus dem alten Bearbeiten-Menü übernommen (gleiche testTags, gleiches Verhalten inkl. Layout-Reset, WRITE_SETTINGS-Fallback, Berechtigungs-Status via ON_RESUME)
- **`ActiveOverlay`**: 4 neue Cases; `HomeViewModel` unverändert (der generische Back-Stack trägt 3 Ebenen von selbst)
- **MainActivity**: Call-Sites in Parent-vor-Kind-Reihenfolge (Predictive-Back-Backdrop); **FavoritesConfig** hinter die Startbildschirm-Seite verschoben + `onBack` eine Ebene hoch (Palette-Deep-Link bleibt: Back → Home); **Info** als Kind der System-Seite
- **`EditConfigMenu`**: nur noch Kategorie-Liste (~700 → ~190 Zeilen), `actions`-Parameter entfernt
- **Strings**: `section_general` raus, neue Sektions-/Untertitel in allen 5 Locales
- **Tests**: 3-Ebenen-Ketten (Back schrittweise, ✕ direkt Home, Palette-Deep-Link) im `HomeViewModelTest`; UI-Tests auf `HomescreenSettingsPage` umgezogen; neuer Hub-Smoke-Test prüft alle 6 Kategorie-Zeilen

## Verifikation

- `./gradlew :app:assembleDebug :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin detekt` grün
- Manuell: jede Kategorie → jedes Untermenü → Back-Kette Ebene für Ebene; Predictive-Back-Peek zeigt jeweils die Elternseite; ✕/Drag springt direkt zur Startseite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
