### PR TITLE
feat: Palette-Labels + Namen, die zum Ziel passen

### DIFF
--- a/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/EditConfigMenu.kt
@@ -68,7 +68,7 @@ fun EditConfigMenu() {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Text(
-                stringResource(R.string.edit_config_title),
+                stringResource(R.string.settings_title),
                 fontSize = 28.sp,
                 fontWeight = FontWeight.Light,
                 color = mainTextColor

--- a/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
+++ b/app/src/main/java/com/example/androidlauncher/ui/SettingsPaletteMenu.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.*
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,7 +23,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.composables.icons.lucide.ALargeSmall
 import com.composables.icons.lucide.Lucide
 import com.composables.icons.lucide.Palette
@@ -69,20 +73,24 @@ fun SettingsPaletteMenu(
     val mainTextColor = LocalHomeTextColor.current
     val haptics = com.example.androidlauncher.ui.theme.rememberAppHaptics()
 
+    // Labels benennen das ZIEL der Bubble (Farben-Menü, Schrift-&-Größe-Menü,
+    // Einstellungs-Hub) – nicht mehr die alten Sammelbegriffe „Themen"/"Größe"/"Bearbeiten".
     val settingsItems = listOf(
-        PaletteMenuItem("themes", Lucide.Palette, stringResource(R.string.label_themes), onOpenColorConfig),
-        PaletteMenuItem("size", Lucide.ALargeSmall, stringResource(R.string.label_size), onOpenSizeConfig),
+        PaletteMenuItem("themes", Lucide.Palette, stringResource(R.string.color_config_title), onOpenColorConfig),
+        PaletteMenuItem("size", Lucide.ALargeSmall, stringResource(R.string.size_config_title), onOpenSizeConfig),
         PaletteMenuItem(
             "favorites",
             Icons.Rounded.Star,
             stringResource(R.string.favorites_title),
             onOpenFavoritesConfig
         ),
-        PaletteMenuItem("edit", Lucide.Pencil, stringResource(R.string.edit_config_title), onOpenSystemSettings),
+        PaletteMenuItem("edit", Lucide.Pencil, stringResource(R.string.settings_title), onOpenSystemSettings),
         PaletteMenuItem("info", Icons.Rounded.Info, stringResource(R.string.label_info), onOpenInfo),
     )
 
-    val radius = 110f
+    // Radius groß genug, dass die Text-Labels benachbarter Bubbles nicht kollidieren
+    // (bei 110f liegen die Bubble-Zentren nur ~47dp auseinander).
+    val radius = 132f
     val startAngle = 85f
     val endAngle = 185f
     val density = LocalDensity.current
@@ -212,6 +220,23 @@ fun SettingsPaletteMenu(
                             modifier = Modifier.size(24.dp)
                         )
                     }
+
+                    // Text-Label unter der Bubble. requiredWidth hebelt die 56dp-Constraint
+                    // der Bubble-Box aus, ohne deren Geometrie (Offset/Clip an size/2) zu
+                    // verändern; das Label blendet erst am Ende des Auffächerns ein.
+                    Text(
+                        text = item.label,
+                        color = mainTextColor,
+                        fontSize = 10.sp,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                            .offset(y = 58.dp)
+                            .requiredWidthIn(max = 84.dp)
+                            .alpha(((progress - 0.6f) / 0.4f).coerceIn(0f, 1f))
+                    )
                 }
             }
         }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -108,6 +108,7 @@
     <string name="label_features">Funktionen</string>
     <string name="label_design_style">Design-Stil</string>
     <string name="edit_config_title">Bearbeiten</string>
+    <string name="settings_title">Einstellungen</string>
     <string name="section_appearance">Aussehen</string>
     <string name="category_sub_appearance">Themen, Farben, Schrift, Icons, Wallpaper, Animationen</string>
     <string name="section_homescreen">Startbildschirm</string>
@@ -280,7 +281,7 @@
     <string name="eyedropper_hint">Tippe oder ziehe, um eine Farbe vom Hintergrund zu wählen</string>
 
     <!-- Größen- / Schrift-Menü -->
-    <string name="size_config_title">Design &amp; Schriftart</string>
+    <string name="size_config_title">Schrift &amp; Größe</string>
     <string name="preview_favorite">Favorit</string>
     <string name="font_label">Schriftart</string>
     <string name="font_search_hint">Schriftart suchen…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -108,6 +108,7 @@
     <string name="label_features">Funciones</string>
     <string name="label_design_style">Estilo de diseño</string>
     <string name="edit_config_title">Editar</string>
+    <string name="settings_title">Ajustes</string>
     <string name="section_appearance">Apariencia</string>
     <string name="category_sub_appearance">Temas, colores, fuente, iconos, fondo de pantalla, animaciones</string>
     <string name="section_homescreen">Pantalla de inicio</string>
@@ -265,7 +266,7 @@
     <string name="eyedropper_hint">Toca o arrastra para elegir un color del fondo de pantalla</string>
 
     <!-- Menú Tamaño / fuente -->
-    <string name="size_config_title">Diseño y fuente</string>
+    <string name="size_config_title">Fuente y tamaño</string>
     <string name="preview_favorite">Favorito</string>
     <string name="font_label">Fuente</string>
     <string name="font_search_hint">Buscar fuente…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -108,6 +108,7 @@
     <string name="label_features">Fonctionnalités</string>
     <string name="label_design_style">Style du design</string>
     <string name="edit_config_title">Modifier</string>
+    <string name="settings_title">Réglages</string>
     <string name="section_appearance">Apparence</string>
     <string name="category_sub_appearance">Thèmes, couleurs, police, icônes, fond d\'écran, animations</string>
     <string name="section_homescreen">Écran d\'accueil</string>
@@ -265,7 +266,7 @@
     <string name="eyedropper_hint">Touchez ou glissez pour choisir une couleur du fond d\'écran</string>
 
     <!-- Menu Taille / police -->
-    <string name="size_config_title">Apparence &amp; police</string>
+    <string name="size_config_title">Police et taille</string>
     <string name="preview_favorite">Favori</string>
     <string name="font_label">Police</string>
     <string name="font_search_hint">Rechercher une police…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -108,6 +108,7 @@
     <string name="label_features">Funzioni</string>
     <string name="label_design_style">Stile di design</string>
     <string name="edit_config_title">Modifica</string>
+    <string name="settings_title">Impostazioni</string>
     <string name="section_appearance">Aspetto</string>
     <string name="category_sub_appearance">Temi, colori, carattere, icone, sfondo, animazioni</string>
     <string name="section_homescreen">Schermata Home</string>
@@ -265,7 +266,7 @@
     <string name="eyedropper_hint">Tocca o trascina per scegliere un colore dallo sfondo</string>
 
     <!-- Menu Dimensione / font -->
-    <string name="size_config_title">Aspetto e font</string>
+    <string name="size_config_title">Font e dimensioni</string>
     <string name="preview_favorite">Preferito</string>
     <string name="font_label">Font</string>
     <string name="font_search_hint">Cerca font…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,7 @@
     <string name="label_features">Features</string>
     <string name="label_design_style">Design style</string>
     <string name="edit_config_title">Edit</string>
+    <string name="settings_title">Settings</string>
     <string name="section_appearance">Appearance</string>
     <string name="category_sub_appearance">Themes, colors, font, icons, wallpaper, animations</string>
     <string name="section_homescreen">Home screen</string>
@@ -281,7 +282,7 @@
     <string name="eyedropper_hint">Tap or drag to pick a color from the wallpaper</string>
 
     <!-- Size / font menu -->
-    <string name="size_config_title">Design &amp; font</string>
+    <string name="size_config_title">Font &amp; size</string>
     <string name="preview_favorite">Favorite</string>
     <string name="font_label">Font</string>
     <string name="font_search_hint">Search fonts…</string>


### PR DESCRIPTION
## Kontext

Schritt 4 der Menü-Restrukturierung: Die radiale Palette zeigte fünf Icons ohne Text — man musste raten, was sich hinter welchem Icon verbirgt. Zudem passten die Namen nicht zu den Zielen („Themen“ öffnete „Farben“, „Größe“ öffnete „Design & Schriftart“, „Bearbeiten“ sagte nichts).

**Stacked auf #132** — Merge-Reihenfolge: #130 → #131 → #132 → dieser PR.

## Änderungen

- **Text-Labels unter den Palette-Bubbles** (10sp, einzeilig, Ellipsis): als Geschwister-Text unter der unveränderten 56dp-Bubble; `requiredWidthIn(max = 84dp)` hebelt die Eltern-Constraint aus, ohne die Offset-/Overlap-Clip-Geometrie (beide an `size/2` gekoppelt) anzufassen. Label blendet erst am Ende des Auffächerns ein (`alpha = (progress − 0.6) / 0.4`), damit beim Einklappen nichts flackert.
- **Arc-Radius 110 → 132**, damit benachbarte Labels bei 25°-Schritten nicht kollidieren.
- **Konsistente Namen** (Bubble = Seitentitel = Hub-Zeile):
  - „Themen“ → **Farben** (`color_config_title`)
  - „Größe“ → **Schrift & Größe** (`size_config_title` in allen 5 Locales umbenannt)
  - „Bearbeiten“ → **Einstellungen** (neuer String `settings_title`, auch als Hub-Titel)

## Verifikation

- `./gradlew :app:assembleDebug :app:testDebugUnitTest :app:compileDebugAndroidTestKotlin detekt` grün
- ⚠️ **Bitte auf dem Gerät prüfen**: Label-Position der linken Bubble (185°, nahe Nav-Bar) und Kollisionsfreiheit auf kleinen Screens — Radius/Offset sind dafür die Stellschrauben (`SettingsPaletteMenu.kt`, `radius` und `offset(y = 58.dp)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
